### PR TITLE
Matrixordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ pyat/prefix
 pyat/integrator-src
 *.egg-info
 
+# dynamic integrator list
+atintegrators/passmethodlist.m
+
 # cmake
 CMakeCache.txt
 CMakeFiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
       env: PYTHON=3
 
 install: |
+  python -c "import numpy; print(numpy.__version__)"
   if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     if [[ $PYTHON == '3' ]]; then
       brew update

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -206,7 +206,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
         PyErr_SetString(PyExc_ValueError, "Failed to parse arguments to atpass");
         return NULL;
     }
-    if (PyArray_DIM(rin,PyArray_NDIM(rin)-1) != 6) {
+    if (PyArray_DIM(rin,0) != 6) {
         PyErr_SetString(PyExc_ValueError, "Numpy array is not 6D");
         return NULL;
     }
@@ -214,8 +214,8 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
         PyErr_SetString(PyExc_ValueError, "rin is not a double array");
         return NULL;
     }
-    if ((PyArray_FLAGS(rin) & NPY_ARRAY_CARRAY_RO) != NPY_ARRAY_CARRAY_RO) {
-        PyErr_SetString(PyExc_ValueError, "rin is not C aligned");
+    if ((PyArray_FLAGS(rin) & NPY_ARRAY_FARRAY_RO) != NPY_ARRAY_FARRAY_RO) {
+        PyErr_SetString(PyExc_ValueError, "rin is not Fortran-aligned");
         return NULL;
     }
 
@@ -237,18 +237,18 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
         /* empty array for refpts means only get tracking at the last turn */
         num_refpts = PyArray_SIZE(refs);
         if (num_refpts == 0)
-            outdims[0] = num_particles;
+            outdims[1] = num_particles;
         else
-            outdims[0] = num_turns*num_refpts*num_particles;
+            outdims[1] = num_turns*num_refpts*num_particles;
     }
     else {
         /* no argument provided for refpts means get tracking at the end of each turn */
         refpts = &num_elements;
         num_refpts = 1;
-        outdims[0] = num_turns*num_particles;
+        outdims[1] = num_turns*num_particles;
     }
-    outdims[1] = 6;
-    rout = PyArray_SimpleNew(2, outdims, NPY_DOUBLE);
+    outdims[0] = 6;
+    rout = PyArray_EMPTY(2, outdims, NPY_DOUBLE, 1);
     drout = PyArray_DATA((PyArrayObject *)rout);
 
     if (!reuse) new_lattice = 1;

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,6 +1,11 @@
 """Python port of the Accelerator Toolbox"""
-from at.atpass import atpass
-from at.patpass import patpass
+
+# Make all functions visible in the at nammspace:
+# noinspection PyUnresolvedReferences
+from .atpass import atpass
+from .patpass import patpass
+from .track import *
+from .physics import *
 
 from . import elements
 from . import lattice

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,6 +1,6 @@
 """Python port of the Accelerator Toolbox"""
 
-# Make all functions visible in the at nammspace:
+# Make all functions visible in the at namespace:
 # noinspection PyUnresolvedReferences
 from .atpass import atpass
 from .patpass import patpass

--- a/pyat/at/elements.py
+++ b/pyat/at/elements.py
@@ -15,7 +15,7 @@ class Element(object):
 
     def __init__(self, family_name, length=0.0, **kwargs):
         self.FamName = family_name
-        self.Length = length
+        self.Length = float(length)
         self.PassMethod = kwargs.pop('PassMethod', 'IdentityPass')
         for field in Element.FLOAT_ARRAYS:
             if field in kwargs:
@@ -45,14 +45,14 @@ class Marker(Element):
     """pyAT marker element"""
 
     def __init__(self, family_name, **kwargs):
-        super(Marker, self).__init__(family_name, 0.0, **kwargs)
+        super(Marker, self).__init__(family_name, kwargs.pop('Length', 0.0), **kwargs)
 
 
 class Monitor(Element):
     """pyAT monitor element"""
 
     def __init__(self, family_name, **kwargs):
-        super(Monitor, self).__init__(family_name, 0.0, **kwargs)
+        super(Monitor, self).__init__(family_name, kwargs.pop('Length', 0.0), **kwargs)
 
 
 class Aperture(Element):
@@ -63,7 +63,7 @@ class Aperture(Element):
         assert len(limits) == 4
         kwargs['Limits'] = numpy.array(limits, dtype=numpy.float64)
         kwargs.setdefault('PassMethod', 'AperturePass')
-        super(Aperture, self).__init__(family_name, 0.0, **kwargs)
+        super(Aperture, self).__init__(family_name, kwargs.pop('Length', 0.0), **kwargs)
 
 
 class Drift(Element):
@@ -95,8 +95,7 @@ class ThinMultipole(Element):
         kwargs['PolynomB'] = numpy.concatenate((poly_b, numpy.zeros(poly_size - len(poly_b))))
         kwargs['MaxOrder'] = int(kwargs.pop('MaxOrder', poly_size - 1))
         kwargs.setdefault('PassMethod', 'ThinMPolePass')
-        length = kwargs.pop('Length', 0.0)
-        super(ThinMultipole, self).__init__(family_name, length, **kwargs)
+        super(ThinMultipole, self).__init__(family_name, kwargs.pop('Length', 0.0), **kwargs)
 
 
 class Multipole(ThinMultipole):
@@ -134,11 +133,12 @@ class Dipole(Multipole):
         'MaxOrder'      Number of desired multipoles
         'NumIntSteps'   Number of integration steps (default: 10)
         """
-        poly_b = kwargs.pop('PolynomB', [0, k])
-        kwargs.setdefault('EntranceAngle', 0.0)
-        kwargs.setdefault('ExitAngle', 0.0)
+        poly_b = kwargs.pop('PolynomB', numpy.array([0, k]))
+        kwargs['BendingAngle'] = float(bending_angle)
+        kwargs['EntranceAngle'] = float(kwargs.pop('EntranceAngle', 0.0))
+        kwargs['ExitAngle'] = float(kwargs.pop('ExitAngle', 0.0))
         kwargs.setdefault('PassMethod', 'BendLinearPass')
-        super(Dipole, self).__init__(family_name, length, [], poly_b, BendingAngle=bending_angle, **kwargs)
+        super(Dipole, self).__init__(family_name, length, [], poly_b, **kwargs)
 
 
 # Bend is a synonym of Dipole.
@@ -158,7 +158,7 @@ class Quadrupole(Multipole):
         'MaxOrder'      Number of desired multipoles
         'NumIntSteps'   Number of integration steps (default: 10)
         """
-        poly_b = kwargs.pop('PolynomB', [0, k])
+        poly_b = kwargs.pop('PolynomB', numpy.array([0, k]))
         kwargs.setdefault('PassMethod', 'QuadLinearPass')
         super(Quadrupole, self).__init__(family_name, length, [], poly_b, **kwargs)
 
@@ -199,10 +199,10 @@ class RFCavity(Element):
         Available keywords:
         'TimeLag'   time lag with respect to the reference particle
         """
-        kwargs.setdefault('Voltage', voltage)
-        kwargs.setdefault('Frequency', frequency)
-        kwargs.setdefault('HarmNumber', harmonic_number)
-        kwargs.setdefault('Energy', energy)
+        kwargs.setdefault('Voltage', float(voltage))
+        kwargs.setdefault('Frequency', float(frequency))
+        kwargs.setdefault('HarmNumber', int(harmonic_number))
+        kwargs.setdefault('Energy', float(energy))
         kwargs.setdefault('TimeLag', 0.0)
         kwargs.setdefault('PassMethod', 'CavityPass')
         super(RFCavity, self).__init__(family_name, length, **kwargs)
@@ -214,7 +214,7 @@ class RingParam(Element):
                                                          'Periodicity']
 
     def __init__(self, family_name, energy, nb_periods, **kwargs):
-        kwargs.setdefault('Energy', energy)
-        kwargs.setdefault('Periodicity', nb_periods)
+        kwargs.setdefault('Energy', float(energy))
+        kwargs.setdefault('Periodicity', int(nb_periods))
         kwargs.setdefault('PassMethod', 'IdentityPass')
-        super(RingParam, self).__init__(family_name, 0.0, **kwargs)
+        super(RingParam, self).__init__(family_name, kwargs.pop('Length', 0.0), **kwargs)

--- a/pyat/at/lattice.py
+++ b/pyat/at/lattice.py
@@ -3,6 +3,10 @@ Helper functions for working with AT lattices.
 
 A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
+
+The refpts functions allow selecting a number of points in a lattice.
+Indexing runs from zero (the start of the first element) to n_elements + 1
+(the end of the last element).
 """
 import numpy
 import collections
@@ -11,14 +15,16 @@ import collections
 def uint32_refpts(refpts, n_elements):
     """
     Return a uint32 numpy array with contents as the indices of the selected
-    elements.
+    elements.  This is used for indexing a lattice using explicit indices.
     """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         urefpts = numpy.array(numpy.flatnonzero(refpts), dtype=numpy.uint32)
     else:
         if not isinstance(refpts, (collections.Sequence, numpy.ndarray)):
             refpts = [refpts]
-        if numpy.any(numpy.diff(numpy.array(refpts)) < 0) or (refpts[-1] > n_elements):
+        if (numpy.any(numpy.diff(numpy.array(refpts)) < 0)
+                or (refpts[-1] > n_elements)
+                or numpy.any(numpy.array(refpts) < 0)):
             raise ValueError('refpts must be ascending and less or equal to {}'.format(n_elements))
         urefpts = numpy.asarray(refpts, dtype=numpy.uint32)
     return urefpts
@@ -26,13 +32,13 @@ def uint32_refpts(refpts, n_elements):
 
 def bool_refpts(refpts, n_elements):
     """
-    Return a boolean numpy array of length n_elements where True elements are
-    selected.
+    Return a boolean numpy array of length n_elements + 1 where True elements are
+    selected. This is used for indexing a lattice using True or False values.
     """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         return refpts
     else:
-        brefpts = numpy.zeros(n_elements+1, dtype=bool)
+        brefpts = numpy.zeros(n_elements + 1, dtype=bool)
         brefpts[refpts] = True
         return brefpts
 

--- a/pyat/at/lattice.py
+++ b/pyat/at/lattice.py
@@ -5,37 +5,34 @@ A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
 """
 import numpy
+import collections
 
 
-def get_refpts(refpts, n_elements, append_last=False):
-    """
-    If using refpts in a call to at.atpass(), it must be a numpy array of type
-    uint32.  This function creates such an array.
-    """
-    if refpts is None:
-        refpts = [n_elements]
-    int_array = numpy.array(refpts, dtype=numpy.uint32)
-    if numpy.any(numpy.diff(int_array) < 0) or numpy.any(int_array > n_elements):
-        raise ValueError('refpts must be an ascending array: {} {}'.
-                         format(int_array, n_elements))
-    if append_last and refpts[-1] != n_elements:
-        int_array = numpy.append(int_array, [n_elements])
-    return numpy.array(int_array, dtype=numpy.uint32)
+def uint32_refpts(refpts, n_elements):
+    if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
+        urefpts = numpy.array(numpy.flatnonzero(refpts), dtype=numpy.uint32)
+    else:
+        if not isinstance(refpts, (collections.Sequence, numpy.ndarray)):
+            refpts = [refpts]
+        if numpy.any(numpy.diff(numpy.array(refpts)) < 0) or (refpts[-1] > n_elements):
+            raise ValueError('refpts must be ascending and less or equal to {}'.format(n_elements))
+        urefpts = numpy.asarray(refpts, dtype=numpy.uint32)
+    return urefpts
 
 
-def get_s_pos(ring, refpts=None):
+def bool_refpts(refpts, n_elements):
+    if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
+        return refpts
+    else:
+        brefpts = numpy.zeros(n_elements+1, dtype=bool)
+        brefpts[refpts] = True
+        return brefpts
+
+
+def get_s_pos(ring, refpts):
     """
     Return a numpy array corresponding to the s position of the specified
     elements.
     """
-    refpts = get_refpts(refpts, len(ring), append_last=True)
-    total = 0
-    s_pos = numpy.zeros(len(refpts))
-    j = 1
-    for i, element in enumerate(ring):
-        total += element.Length
-        if i in refpts:
-            s_pos[j] = total
-            j += 1
-    s_pos[-1] = total
-    return s_pos
+    s_pos = numpy.concatenate(([0.0], numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])))
+    return s_pos[refpts]

--- a/pyat/at/lattice.py
+++ b/pyat/at/lattice.py
@@ -9,6 +9,10 @@ import collections
 
 
 def uint32_refpts(refpts, n_elements):
+    """
+    Return a uint32 numpy array with contents as the indices of the selected
+    elements.
+    """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         urefpts = numpy.array(numpy.flatnonzero(refpts), dtype=numpy.uint32)
     else:
@@ -21,6 +25,10 @@ def uint32_refpts(refpts, n_elements):
 
 
 def bool_refpts(refpts, n_elements):
+    """
+    Return a boolean numpy array of length n_elements where True elements are
+    selected.
+    """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         return refpts
     else:
@@ -29,10 +37,13 @@ def bool_refpts(refpts, n_elements):
         return brefpts
 
 
-def get_s_pos(ring, refpts):
+def get_s_pos(ring, refpts=None):
     """
     Return a numpy array corresponding to the s position of the specified
     elements.
     """
-    s_pos = numpy.concatenate(([0.0], numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])))
-    return s_pos[refpts]
+    # Positions at the end of each element.
+    s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
+    # Prepend position at the start of the first element.
+    s_pos = numpy.concatenate(([0.0], s_pos))
+    return numpy.squeeze(s_pos[refpts])

--- a/pyat/at/patpass.py
+++ b/pyat/at/patpass.py
@@ -4,7 +4,6 @@ Simple parallelisation of atpass() using multiprocessing.
 import multiprocessing
 from at import atpass
 import numpy
-import time
 
 
 def _atpass_one(args):
@@ -14,13 +13,13 @@ def _atpass_one(args):
 
 
 def _patpass(ring, rin, nturns, pool_size):
-    rout = numpy.zeros((rin.shape[0] * nturns, rin.shape[1]))
+    rout = numpy.zeros((rin.shape[0], rin.shape[1] * nturns))
     pool = multiprocessing.Pool(pool_size)
-    args = [(ring, rin[i, :], nturns) for i in range(rin.shape[0])]
+    args = [(ring, rin[:, i], nturns) for i in range(rin.shape[1])]
     results = pool.map(_atpass_one, args)
     for i, res in enumerate(results):
         # Fold the results back into the same shape as atpass.
-        rout[i::rin.shape[0], :] = res
+        rout[:, i::rin.shape[1]] = res
     return rout
 
 

--- a/pyat/at/physics.py
+++ b/pyat/at/physics.py
@@ -20,11 +20,10 @@ TWISS_DTYPE = [('idx', numpy.uint32),
                ('m44', numpy.float64, (4, 4))]
 
 
-# noinspection PyPep8Naming
 def find_orbit4(ring, dp=0.0, refpts=None):
     """findorbit4 finds the closed orbit in the 4-d transverse phase
     space by numerically solving for a fixed point of the one turn
-    map M calculated with LINEPASS
+    map M calculated with linepass
 
         (X, PX, Y, PY, dP2, CT2 ) = M (X, PX, Y, PY, dP1, CT1)
 
@@ -40,24 +39,20 @@ def find_orbit4(ring, dp=0.0, refpts=None):
                 HarmNumber*Frev = Frf
 
     To impose this artificial constraint in findorbit4, PassMethod
-    used for any elemen SHOULD NOT
+    used for any element SHOULD NOT
     1. change the longitudinal momentum dP (cavities , magnets with radiation)
     2. have any time dependence (localized impedance, fast kickers etc)
 
     findorbit4(RING, dP) is 4x1 vector - fixed point at the
     entrance of the 1-st element of the RING (x,px,y,py)
 
-    findorbit4(RING, dP, REFPTS) is 4-by-Length(REFPTS)
+    findorbit4(RING, dP, refpts) is 4-by-Length(refpts)
     array of column vectors - fixed points (x,px,y,py)
-    at the entrance of each element indexed REFPTS array.
-    REFPTS is an array of increasing indexes that select elements
+    at the entrance of each element indexed refpts array.
+    refpts is an array of increasing indexes that select elements
     from the range 0 to length(RING).
-    See further explanation of REFPTS in the 'help' for FINDSPOS
+    See further explanation of refpts in the 'help' for FINDSPOS
 
-    findorbit4(RING ,dP, REFPTS, GUESS) - same as above but the search
-    for the fixed point starts at the initial condition GUESS
-    Otherwise the search starts from [0,0,0,0,0,0].
-    GUESS must be a 6-by-1 vector;
     """
     # We seek
     #  - f(x) = x
@@ -84,7 +79,7 @@ def find_orbit4(ring, dp=0.0, refpts=None):
     keeplattice = False
     while (change > CONVERGENCE) and itercount < MAX_ITERATIONS:
         in_mat = r_in.reshape((6, 1)) + delta_matrix
-        out_mat = at.linepass(ring, in_mat, KeepLattice=keeplattice)
+        out_mat = at.linepass(ring, in_mat, keep_lattice=keeplattice)
         # the reference particle after one turn
         ref_out = out_mat[:4, 4]
         # 4x4 jacobian matrix from numerical differentiation:
@@ -100,11 +95,10 @@ def find_orbit4(ring, dp=0.0, refpts=None):
         r_in = r_next
         keeplattice = True
 
-    all_points = at.linepass(ring, r_in, refpts, KeepLattice=keeplattice)
+    all_points = at.linepass(ring, r_in, refpts, keep_lattice=keeplattice)
     return r_in[:4], all_points[:4, :]
 
 
-# noinspection PyPep8Naming
 def find_m44(ring, dp=0.0, refpts=None, orbit4=None, XYStep=XYDEFSTEP):
     """
     Determine the transfer matrix for ring, by first finding the closed orbit.
@@ -127,7 +121,7 @@ def find_m44(ring, dp=0.0, refpts=None, orbit4=None, XYStep=XYDEFSTEP):
     # Add the deltas to multiple copies of the closed orbit
     in_mat = orbit6 + dmat
 
-    out_mat = at.linepass(ring, in_mat, refpts, KeepLattice=keeplattice)
+    out_mat = at.linepass(ring, in_mat, refpts, keep_lattice=keeplattice)
     tmat3 = numpy.reshape(out_mat[:4, :], (4, 8, -1), order='F')
     # (x + d) - (x - d) / d
     mstack = (tmat3[:, :4, :] - tmat3[:, 4:8, :]) / XYStep

--- a/pyat/at/physics.py
+++ b/pyat/at/physics.py
@@ -8,10 +8,16 @@ EPS = 1e-10
 XYDEFSTEP = 6.055454452393343e-006  # Optimal delta?
 DDP = 1e-8
 
-_dtype = [('idx', numpy.uint32), ('s_pos', numpy.float64),
-          ('closed_orbit', numpy.float64, (4,)), ('dispersion', numpy.float64, (4,)),
-          ('alpha', numpy.float64, (2,)), ('beta', numpy.float64, (2,)), ('mu', numpy.float64, (2,)),
-          ('m44', numpy.float64, (4, 4))]
+
+# dtype for structured array containing Twiss parameters
+TWISS_DTYPE = [('idx', numpy.uint32),
+               ('s_pos', numpy.float64),
+               ('closed_orbit', numpy.float64, (4,)),
+               ('dispersion', numpy.float64, (4,)),
+               ('alpha', numpy.float64, (2,)),
+               ('beta', numpy.float64, (2,)),
+               ('mu', numpy.float64, (2,)),
+               ('m44', numpy.float64, (4, 4))]
 
 
 # noinspection PyPep8Naming
@@ -176,7 +182,7 @@ def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, ddp=DDP):
     ay, by, my = twiss22(m44[2:, 2:], mstack[2:, 2:, :])
 
     tune = numpy.array((mx[-1], my[-1])) / (2 * numpy.pi)
-    twiss = numpy.zeros(nrefs, dtype=_dtype)
+    twiss = numpy.zeros(nrefs, dtype=TWISS_DTYPE)
     twiss['idx'] = refpts[:nrefs]
     twiss['s_pos'] = lattice.get_s_pos(ring, refpts[:nrefs])
     twiss['closed_orbit'] = numpy.rollaxis(orbit, -1)[:nrefs]

--- a/pyat/at/track.py
+++ b/pyat/at/track.py
@@ -5,80 +5,78 @@ from .atpass import atpass
 from .lattice import uint32_refpts
 
 
-# noinspection PyPep8Naming
-def linepass(line, r_in, refpts=None, KeepLattice=False):
-    """LINEPASS tracks particles through each element of the cell array LINE
+def linepass(line, r_in, refpts=None, keep_lattice=False):
+    """linepass tracks particles through each element of the sequence line
     calling the element-specific tracking function specified in the
-    LINE[i].PassMethod field.
+    line[i].PassMethod field.
 
-    R_OUT=linepass(LINE, R_IN) tracks particle(s) with initial
+    r_out = linepass(line, r_in) tracks particle(s) with initial
     condition(s) r_in to the end of the line
 
-    LINE        AT lattice
-    R_IN        6xN matrix: input coordinates of N particles
+    line        AT lattice
+    r_in        6xN matrix: input coordinates of N particles
 
-    R_OUT       6xN matrix: output coordinates of N particles at
+    r_out       6xN matrix: output coordinates of N particles at
 
-    R_OUT=linepass(LINE, R_IN, REFPTS) returns intermediate results
+    r_out=linepass(line, r_in, REFPTS) returns intermediate results
     at the entrance of each element specified in refpts
 
     REFPTS is an array of increasing indexes that selects elements
-    between 0 and length(LINE).
+    between 0 and length(line).
     See further explanation of REFPTS in the 'help' for FINDSPOS
-    R_OUT       6x(N*length(REFPTS)) matrix: output coordinates of N particles at
+    r_out       6x(N*length(REFPTS)) matrix: output coordinates of N particles at
                 each reference point
 
-    KeepLattice:If set to True, LINEPASS is more efficient because it reuses
-                some of the data and functions stored in the persistent
-                memory in previous calls to LINEPASS.
+    keep_lattice:If set to True, linepass is more efficient because it reuses
+                 some of the data and functions stored in the persistent
+                 memory in previous calls to linepass.
 
-    !!! In order to use this option, LINEPASS must first be called without
-    the KeepLattice flag. This will create persistent data structures and keep
+    !!! In order to use this option, linepass must first be called without
+    the keep_lattice flag. This will create persistent data structures and keep
     pointers to pass-method functions.
 
-    !!! LINEPASS(..., KeepLattice=True) assumes that the RING is unchanged
-    since the last call. Otherwise, RINGPASS with KeepLattice=False must be
+    !!! linepass(..., keep_lattice=True) assumes that the RING is unchanged
+    since the last call. Otherwise, ringpass with keep_lattice=False must be
     called again.
 
     NOTE:
-    linepass(LINE,R_IN,length(LINE)) is the same as LINEPASS(LINE,R_IN)
-    since the reference point length(LINE) is the exit of the last element
-    linepass(LINE,R_IN, 0) is a copy of R_IN since the
+    linepass(line,r_in,length(line)) is the same as linepass(line,r_in)
+    since the reference point length(line) is the exit of the last element
+    linepass(line,r_in, 0) is a copy of r_in since the
     reference point 0 is the entrance of the first element
     """
     if refpts is None:
         refpts = len(line)
     refs = uint32_refpts(refpts, len(line))
     r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
-    return atpass(line, r_in, 1, refs, int(KeepLattice))
+    return atpass(line, r_in, 1, refs, int(keep_lattice))
 
 
-# noinspection PyPep8Naming
-def ringpass(ring, r_in, nturns=1, KeepLattice=False):
-    """RINGPASS tracks particles through each element of the cell array RING
+def ringpass(ring, r_in, nturns=1, keep_lattice=False):
+    """ringpass tracks particles through each element of the cell array ring
     calling the element-specific tracking function specified in the
-    RING[i].PassMethod field.
+    ring[i].PassMethod field.
 
-    R_OUT=ringpass(RING,R_IN,NTURNS) tracks particle(s) with initial
-    condition(s) RIN for NTURNS turns
+    r_out=ringpass(ring,r_in,nturns) tracks particle(s) with initial
+    condition(s) RIN for nturns turns
 
-    RING:       AT lattice
-    R_IN:       6xN matrix: input coordinates of N particles
-    NTURNS:     Number of turns to perform (default: 1)
+    ring:       AT lattice
+    r_in:       6xN matrix: input coordinates of N particles
+    nturns:     Number of turns to perform (default: 1)
 
-    R_OUT:      6x(N*NTURNS) matrix: output coordinates of N particles at
+    r_out:      6x(N*nturns) matrix: output coordinates of N particles at
 
-    KeepLattice:If set to True, RINGPASS is more efficient because it reuses
-                some of the data and functions stored in the persistent
-                memory in previous calls to RINGPASS.
+    keep_lattice:If set to True, ringpass is more efficient because it reuses
+                 some of the data and functions stored in the persistent
+                 memory in previous calls to ringpass.
 
-    !!! In order to use this option, RINGPASS must first be called without
-    the KeepLattice flag. This will create persistent data structures and keep
+    !!! In order to use this option, ringpass must first be called without
+    the keep_lattice flag. This will create persistent data structures and keep
     pointers to pass-method functions.
 
-    !!! RINGPASS(..., KeepLattice=True) assumes that the RING is unchanged
-    since the last call. Otherwise, RINGPASS with KeepLattice=False must be
+    !!! ringpass(..., keep_lattice=True) assumes that the ring is unchanged
+    since the last call. Otherwise, ringpass with keep_lattice=False must be
     called again.
-"""
+    """
     r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
-    return atpass(ring, r_in, nturns, reuse=int(KeepLattice))
+    return atpass(ring, r_in, nturns, reuse=int(keep_lattice))

--- a/pyat/at/track.py
+++ b/pyat/at/track.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+import numpy
+# noinspection PyUnresolvedReferences
+from .atpass import atpass
+from .lattice import uint32_refpts
+
+
+# noinspection PyPep8Naming
+def linepass(line, r_in, refpts=None, KeepLattice=False):
+    """LINEPASS tracks particles through each element of the cell array LINE
+    calling the element-specific tracking function specified in the
+    LINE[i].PassMethod field.
+
+    R_OUT=linepass(LINE, R_IN) tracks particle(s) with initial
+    condition(s) r_in to the end of the line
+
+    LINE        AT lattice
+    R_IN        6xN matrix: input coordinates of N particles
+
+    R_OUT       6xN matrix: output coordinates of N particles at
+
+    R_OUT=linepass(LINE, R_IN, REFPTS) returns intermediate results
+    at the entrance of each element specified in refpts
+
+    REFPTS is an array of increasing indexes that selects elements
+    between 0 and length(LINE).
+    See further explanation of REFPTS in the 'help' for FINDSPOS
+    R_OUT       6x(N*length(REFPTS)) matrix: output coordinates of N particles at
+                each reference point
+
+    KeepLattice:If set to True, LINEPASS is more efficient because it reuses
+                some of the data and functions stored in the persistent
+                memory in previous calls to LINEPASS.
+
+    !!! In order to use this option, LINEPASS must first be called without
+    the KeepLattice flag. This will create persistent data structures and keep
+    pointers to pass-method functions.
+
+    !!! LINEPASS(..., KeepLattice=True) assumes that the RING is unchanged
+    since the last call. Otherwise, RINGPASS with KeepLattice=False must be
+    called again.
+
+    NOTE:
+    linepass(LINE,R_IN,length(LINE)) is the same as LINEPASS(LINE,R_IN)
+    since the reference point length(LINE) is the exit of the last element
+    linepass(LINE,R_IN, 0) is a copy of R_IN since the
+    reference point 0 is the entrance of the first element
+    """
+    if refpts is None:
+        refpts = len(line)
+    refs = uint32_refpts(refpts, len(line))
+    r_in = numpy.asfortranarray(r_in).reshape((6, -1))
+    return atpass(line, r_in, 1, refs, int(KeepLattice))
+
+
+# noinspection PyPep8Naming
+def ringpass(ring, r_in, nturns=1, KeepLattice=False):
+    """RINGPASS tracks particles through each element of the cell array RING
+    calling the element-specific tracking function specified in the
+    RING[i].PassMethod field.
+
+    R_OUT=ringpass(RING,R_IN,NTURNS) tracks particle(s) with initial
+    condition(s) RIN for NTURNS turns
+
+    RING:       AT lattice
+    R_IN:       6xN matrix: input coordinates of N particles
+    NTURNS:     Number of turns to perform (default: 1)
+
+    R_OUT:      6x(N*NTURNS) matrix: output coordinates of N particles at
+
+    KeepLattice:If set to True, RINGPASS is more efficient because it reuses
+                some of the data and functions stored in the persistent
+                memory in previous calls to RINGPASS.
+
+    !!! In order to use this option, RINGPASS must first be called without
+    the KeepLattice flag. This will create persistent data structures and keep
+    pointers to pass-method functions.
+
+    !!! RINGPASS(..., KeepLattice=True) assumes that the RING is unchanged
+    since the last call. Otherwise, RINGPASS with KeepLattice=False must be
+    called again.
+"""
+    r_in = numpy.asfortranarray(r_in).reshape((6, -1))
+    return atpass(ring, r_in, nturns, reuse=int(KeepLattice))

--- a/pyat/at/track.py
+++ b/pyat/at/track.py
@@ -49,7 +49,7 @@ def linepass(line, r_in, refpts=None, KeepLattice=False):
     if refpts is None:
         refpts = len(line)
     refs = uint32_refpts(refpts, len(line))
-    r_in = numpy.asfortranarray(r_in).reshape((6, -1))
+    r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
     return atpass(line, r_in, 1, refs, int(KeepLattice))
 
 
@@ -80,5 +80,5 @@ def ringpass(ring, r_in, nturns=1, KeepLattice=False):
     since the last call. Otherwise, RINGPASS with KeepLattice=False must be
     called again.
 """
-    r_in = numpy.asfortranarray(r_in).reshape((6, -1))
+    r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
     return atpass(ring, r_in, nturns, reuse=int(KeepLattice))

--- a/pyat/test/conftest.py
+++ b/pyat/test/conftest.py
@@ -7,5 +7,5 @@ import pytest
 
 @pytest.fixture
 def rin():
-    rin = numpy.array(numpy.zeros((1, 6)))
+    rin = numpy.array(numpy.zeros((6, 1)), order='F')
     return rin

--- a/pyat/test/test_atpass.py
+++ b/pyat/test/test_atpass.py
@@ -15,52 +15,53 @@ def test_incorrect_types_raises_value_error(rin):
 
 def test_incorrect_dimensions_raises_value_error():
     l = []
-    rin = numpy.array(numpy.zeros((1,7)))
+    rin = numpy.array(numpy.zeros((7, 1)))
     with pytest.raises(ValueError):
         atpass(l, rin, 1)
-    rin = numpy.array(numpy.zeros((6, 1)))
+    rin = numpy.array(numpy.zeros((1, 6)))
     with pytest.raises(ValueError):
         atpass(l, rin, 1)
 
 
-def test_fortran_aligned_array_raises_value_error():
-    rin = numpy.asfortranarray(numpy.zeros((2, 6)))
+def test_c_aligned_array_raises_value_error():
+    rin = numpy.zeros((2, 6))
     l = []
     with pytest.raises(ValueError):
         atpass(l, rin, 1)
 
 
 def test_transposed_array_raises_value_error():
-    rin_transposed = numpy.zeros((6, 2))
+    rin_transposed = numpy.asfortranarray(numpy.zeros((2, 6)))
     with pytest.raises(ValueError):
         atpass([], rin_transposed.T, 1)
 
 
-def test_transposed_fortran_array_does_not_raise_value_error():
-    rin_fortran = numpy.asfortranarray(numpy.zeros((6, 2)))
-    atpass([], rin_fortran.T, 1)
+def test_transposed_c_array_does_not_raise_value_error():
+    rin_c = numpy.zeros((2, 6))
+    atpass([], rin_c.T, 1)
 
 
-def test_transposed_fortran_array_gives_same_result_as_c_array():
+def test_transposed_c_array_gives_same_result_as_fortran_array():
     """
     This test explores the behaviour of C- and Fortran- aligned arrays.
     Since we use the data from the numpy array directly, some of the
-    behaviour we see does not honour what we do in numpy.
+    behaviour we see is not what we'd expect if we used numpy as intended.
     """
-    # Standard numpy array (2, 6) as used in pyAT.
-    rin_c = numpy.arange(12).reshape(2, 6) * 1e-5
-    # Taking an actual copy of the transpose and making sure it is
-    # Fortran-aligned should give us the same layout in memory.
-    rin_fortran = numpy.copy(rin_c.T, order='F')
+    # Standard numpy array (6, 2) as used in pyAT.
+    rin_fortran = numpy.array(numpy.arange(12).reshape(6, 2), order='F') * 1e-5
+    # Taking an copy of the transpose and making sure it is C-aligned should
+    # give us the same layout of data in memory, but with a (2, 6) array.
+    rin_c = numpy.copy(rin_fortran.T, order='C')
     e = elements.Drift('drift', 1.0)
     l = [e]
-    rout_c = atpass(l, rin_c, 1)
-    # at.c does not currently accept (6, x) arrays.  This transpose
-    # passes the dimension check, but does NOT change the layout in memory
-    # since it returns a 'view' on the array.  The AT C code would give the
-    # same result without the transpose.
-    rin_fortran_transposed = rin_fortran.T
-    rout_fortran = atpass(l, rin_fortran_transposed, 1)
+    rout_fortran = atpass(l, rin_fortran, 1)
+    # at.c does not accept (x, 6) arrays.  This transpose allows rin_c
+    # to pass the dimension check, but does NOT change the layout in memory
+    # since in Python it returns a 'view' on the array.
+    # The AT C code would give the same result for rin_c without the
+    # transpose if the dimension check were not there.
+    rin_c_transposed = rin_c.T
+    rout_c = atpass(l, rin_c_transposed, 1)
     numpy.testing.assert_equal(rout_c, rout_fortran)
 
 
@@ -85,7 +86,7 @@ def test_reuse_attributes(rin, reuse):
     m = elements.Drift('drift', 1.0)
     l = [m]
     rin[0,0] = 1e-6
-    rin[0,1] = 1e-6
+    rin[1,0] = 1e-6
     rin_copy = numpy.copy(rin)
     # two turns with original lattice
     atpass(l, rin, 2)
@@ -103,34 +104,34 @@ def test_reuse_attributes(rin, reuse):
 
 
 def test_two_particles_for_two_turns():
-    rin = numpy.zeros((2, 6))
+    rin = numpy.asfortranarray(numpy.zeros((6, 2)))
     d = elements.Drift('drift', 1.0)
     lattice = [d]
-    rin[0][1] = 1e-6
-    rin[0][3] = -2e-6
+    rin[1][0] = 1e-6
+    rin[3][0] = -2e-6
     rout = atpass(lattice, rin, 2)
     # results from Matlab
     rout1_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6)
     rout2_expected = numpy.array([2e-6, 1e-6, -4e-6, -2e-6, 0, 5e-12]).reshape(6)
     # the second particle doesn't change
     rout3_expected = numpy.zeros((6,))
-    # the first two 1x6 rows are the two particles after the first turn
-    numpy.testing.assert_equal(rout[0,:], rout1_expected)
-    numpy.testing.assert_equal(rout[1,:], rout3_expected)
-    # the second two 1x6 rows are the two particles after the second turn
-    numpy.testing.assert_equal(rout[2,:], rout2_expected)
-    numpy.testing.assert_equal(rout[3,:], rout3_expected)
+    # the first two 6x1 columns are the two particles after the first turn
+    numpy.testing.assert_equal(rout[:,0], rout1_expected)
+    numpy.testing.assert_equal(rout[:,1], rout3_expected)
+    # the second two 6x1 columns are the two particles after the second turn
+    numpy.testing.assert_equal(rout[:,2], rout2_expected)
+    numpy.testing.assert_equal(rout[:,3], rout3_expected)
 
 
 def test_one_particle_for_two_turns_with_empty_refpts(rin):
     d = elements.Drift('drift', 1.0)
     lattice = [d]
-    rin[0][1] = 1e-6
-    rin[0][3] = -2e-6
+    rin[1][0] = 1e-6
+    rin[3][0] = -2e-6
     # an empty refpts returns only the value at the end of the last turn
     rout = atpass(lattice, rin, 2, refpts=numpy.zeros((0,), dtype=numpy.uint32))
-    assert rout.shape == (1, 6)
-    rout_expected = numpy.array([2e-6, 1e-6, -4e-6, -2e-6, 0, 5e-12]).reshape(1, 6)
+    assert rout.shape == (6, 1)
+    rout_expected = numpy.array([2e-6, 1e-6, -4e-6, -2e-6, 0, 5e-12]).reshape(6, 1)
     # rin is changed in place
     numpy.testing.assert_equal(rin, rout_expected)
     numpy.testing.assert_equal(rout, rout_expected)
@@ -146,9 +147,9 @@ def test_1d_particle():
     # an empty refpts returns only the value at the end of the last turn
     rout = atpass(lattice, rin, 1)
     # the input may be 1d but the output is 2d
-    assert rout.shape == (1, 6)
+    assert rout.shape == (6, 1)
     rout_expected = numpy.array([1e-6, 1e-6, 0, 0, 0, 5e-13])
     # rin is changed in place
     numpy.testing.assert_equal(rin, rout_expected)
-    numpy.testing.assert_equal(rout, rout_expected.reshape(1, 6))
+    numpy.testing.assert_equal(rout, rout_expected.reshape(6, 1))
 

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -9,17 +9,18 @@ def test_correct_dimensions_does_not_raise_error(rin):
     atpass(l, rin, 1)
     rin = numpy.zeros((6,))
     atpass(l, rin, 1)
-    rin = numpy.zeros((2,6))
+    rin = numpy.array(numpy.zeros((6, 2), order='F'))
+    atpass(l, rin, 1)
 
 
 @pytest.mark.parametrize("dipole_class", (elements.Dipole, elements.Bend))
 def test_dipole(rin, dipole_class):
     b = dipole_class('dipole', 1.0, 0.1, EntranceAngle=0.05, ExitAngle=0.05)
     l = [b]
-    rin[0,0] = 1e-6
+    rin[0, 0] = 1e-6
     rin_orig = numpy.copy(rin)
     atpass(l, rin, 1)
-    rin_expected = numpy.array([1e-6, 0, 0, 0, 0, 1e-7]).reshape((1,6))
+    rin_expected = numpy.array([1e-6, 0, 0, 0, 0, 1e-7]).reshape((6, 1))
     numpy.testing.assert_almost_equal(rin_orig, rin_expected)
 
 
@@ -37,8 +38,8 @@ def test_aperture_inside_limits(rin):
     a = elements.Aperture('aperture', [-1e-3, 1e-3, -1e-4, 1e-4])
     assert a.Length == 0
     lattice = [a]
-    rin[0][0] = 1e-5
-    rin[0][2] = -1e-5
+    rin[0, 0] = 1e-5
+    rin[2, 0] = -1e-5
     rin_orig = numpy.array(rin, copy=True)
     atpass(lattice, rin, 1)
     numpy.testing.assert_equal(rin, rin_orig)
@@ -48,18 +49,18 @@ def test_aperture_outside_limits(rin):
     a = elements.Aperture('aperture', [-1e-3, 1e-3, -1e-4, 1e-4])
     assert a.Length == 0
     lattice = [a]
-    rin[0][0] = 1e-2
-    rin[0][2] = -1e-2
+    rin[0, 0] = 1e-2
+    rin[2, 0] = -1e-2
     atpass(lattice, rin, 1)
-    assert numpy.isinf(rin[0][5])
-    assert rin[0][2] == -1e-2  # Only the 6th coordinate is marked as infinity
+    assert numpy.isinf(rin[5, 0])
+    assert rin[2, 0] == -1e-2  # Only the 6th coordinate is marked as infinity
 
 
 def test_drift_offset(rin):
     d = elements.Drift('drift', 1)
     lattice = [d]
-    rin[0][0] = 1e-6
-    rin[0][2] = 2e-6
+    rin[0, 0] = 1e-6
+    rin[2, 0] = 2e-6
     rin_orig = numpy.array(rin, copy=True)
     atpass(lattice, rin, 1)
     numpy.testing.assert_equal(rin, rin_orig)
@@ -69,11 +70,11 @@ def test_drift_divergence(rin):
     d = elements.Drift('drift', 1.0)
     assert d.Length == 1
     lattice = [d]
-    rin[0][1] = 1e-6
-    rin[0][3] = -2e-6
+    rin[1, 0] = 1e-6
+    rin[3, 0] = -2e-6
     atpass(lattice, rin, 1)
     # results from Matlab
-    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(1,6)
+    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
     numpy.testing.assert_equal(rin, rin_expected)
 
 
@@ -81,19 +82,19 @@ def test_drift_two_particles(rin):
     d = elements.Drift('drift', 1.0)
     assert d.Length == 1
     lattice = [d]
-    two_rin = numpy.concatenate((rin, rin), axis=0)
+    two_rin = numpy.array(numpy.concatenate((rin, rin), axis=1), order='F')
     # particle one is offset
-    two_rin[0][0] = 1e-6
-    two_rin[0][2] = 2e-6
+    two_rin[0, 0] = 1e-6
+    two_rin[2, 0] = 2e-6
     # particle two has divergence
-    two_rin[1][1] = 1e-6
-    two_rin[1][3] = -2e-6
+    two_rin[1, 1] = 1e-6
+    two_rin[3, 1] = -2e-6
     two_rin_orig = numpy.array(two_rin, copy=True)
     atpass(lattice, two_rin, 1)
     # results from Matlab
-    p1_expected = numpy.array(two_rin_orig[0,:]).reshape(1,6)
-    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(1,6)
-    two_rin_expected = numpy.concatenate((p1_expected, p2_expected), axis=0)
+    p1_expected = numpy.array(two_rin_orig[:, 0]).reshape(6, 1)
+    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
+    two_rin_expected = numpy.concatenate((p1_expected, p2_expected), axis=1)
     numpy.testing.assert_equal(two_rin, two_rin_expected)
 
 
@@ -107,7 +108,7 @@ def test_quad(rin):
                             0,
                             0,
                             0,
-                            0.000000010330489]).reshape(1, 6) * 1e-6
+                            0.000000010330489]).reshape(6, 1) * 1e-6
     numpy.testing.assert_allclose(rin, expected)
 
 

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -28,8 +28,8 @@ def test_marker(rin):
     m = elements.Marker('marker')
     assert m.Length == 0
     lattice = [m]
-    rin = numpy.random.rand(*rin.shape)
-    rin_orig = numpy.array(rin, copy=True)
+    rin = numpy.array(numpy.random.rand(*rin.shape), order='F')
+    rin_orig = numpy.array(rin, copy=True, order='F')
     atpass(lattice, rin, 1)
     numpy.testing.assert_equal(rin, rin_orig)
 

--- a/pyat/test/test_lattice.py
+++ b/pyat/test/test_lattice.py
@@ -3,40 +3,20 @@ from at import lattice, elements
 import pytest
 
 
-def test_get_refpts_returns_num_elements_if_argument_is_none():
-    expected = numpy.array([0], dtype=numpy.uint32)
-    numpy.testing.assert_equal(lattice.get_refpts(None, 0), expected)
-    expected[0] = 1
-    numpy.testing.assert_equal(lattice.get_refpts(None, 1), expected)
-
-
-def test_get_refpts_does_not_append_num_elements_if_not_requested():
-    expected = numpy.array([1, 2, 3], dtype=numpy.uint32)
-    numpy.testing.assert_equal(lattice.get_refpts([1, 2, 3], 5),
-                               expected)
-
-
-def test_get_refpts_does_not_append_num_elements_if_requested():
-    expected = numpy.array([1, 2, 3, 5], dtype=numpy.uint32)
-    numpy.testing.assert_equal(lattice.get_refpts([1, 2, 3], 5, True),
-                               expected)
-
-
-
-def test_get_refpts_handles_array_as_input():
+def test_uint32_refpts_handles_array_as_input():
     expected = numpy.array([1, 2, 3], dtype=numpy.uint32)
     requested = numpy.array([1, 2, 3], dtype=numpy.uint32)
-    numpy.testing.assert_equal(lattice.get_refpts(requested, 5),
+    numpy.testing.assert_equal(lattice.uint32_refpts(requested, 5),
                                expected)
     requested = numpy.array([1, 2, 3], dtype=numpy.float64)
-    numpy.testing.assert_equal(lattice.get_refpts(requested, 5),
+    numpy.testing.assert_equal(lattice.uint32_refpts(requested, 5),
                                expected)
 
 
 @pytest.mark.parametrize('input', ([-1], [3], [3, 2, 1]))
-def test_get_refpts_throws_ValueError_if_input_invalid(input):
+def test_uint32_refpts_throws_ValueError_if_input_invalid(input):
     with pytest.raises(ValueError):
-        lattice.get_refpts(input, 2)
+        r = lattice.uint32_refpts(input, 2)
 
 
 def test_get_s_pos_returns_zero_for_empty_lattice():

--- a/pyat/test/test_lattice.py
+++ b/pyat/test/test_lattice.py
@@ -45,19 +45,27 @@ def test_get_s_pos_returns_zero_for_empty_lattice():
 
 def test_get_s_pos_returns_length_for_lattice_with_one_element():
     e = elements.Element('e', 0.1)
-    assert lattice.get_s_pos([e], None) == numpy.array([0.1])
+    assert lattice.get_s_pos([e], [1]) == numpy.array([0.1])
 
 
-def test_get_s_pos_returns_length_for_lattice_with_two_elements():
+def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_and_refpts_None():
     e = elements.Element('e', 0.1)
     f = elements.Element('e', 2.1)
-    numpy.testing.assert_equal(lattice.get_s_pos([e, f]),
-                               numpy.array([2.2]))
+    print(lattice.get_s_pos([e, f], None))
+    numpy.testing.assert_equal(lattice.get_s_pos([e, f], None),
+                               numpy.array([0, 0.1, 2.2]))
 
 
-def test_get_s_pos_returns_all_points_for_lattice_with_two_elements():
+def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_using_int_refpts():
     e = elements.Element('e', 0.1)
     f = elements.Element('e', 2.1)
     lat = [e, f]
     numpy.testing.assert_equal(lattice.get_s_pos(lat, range(len(lat) + 1)),
+                               numpy.array([0, 0.1, 2.2]))
+
+def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_using_bool_refpts():
+    e = elements.Element('e', 0.1)
+    f = elements.Element('e', 2.1)
+    lat = [e, f]
+    numpy.testing.assert_equal(lattice.get_s_pos(lat, numpy.array((True, True, True))),
                                numpy.array([0, 0.1, 2.2]))

--- a/pyat/test/test_patpass.py
+++ b/pyat/test/test_patpass.py
@@ -17,21 +17,21 @@ def test_patpass_raises_ValueError_if_reuse_False(rin):
 def test_patpass_multiple_particles_and_turns():
     nturns = 10
     nparticles = 10
-    rin = numpy.zeros((nparticles, 6))
+    rin = numpy.zeros((6, nparticles))
     d = elements.Drift('drift', 1.0)
     assert d.Length == 1
     lattice = [d]
-    rin[0][1] = 1e-6
-    rin[0][3] = -2e-6
+    rin[1, 0] = 1e-6
+    rin[3, 0] = -2e-6
     rout = patpass(lattice, rin, nturns)
     # results from Matlab
-    assert rout.shape == (nparticles*nturns, 6)
+    assert rout.shape == (6, nparticles*nturns)
     rout_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6,)
     zeros = numpy.zeros((6,))
-    numpy.testing.assert_equal(rout[0,:], rout_expected)
+    numpy.testing.assert_equal(rout[:, 0], rout_expected)
     # only the first particle is not all zeros
     for i in range(nturns):
         with pytest.raises(AssertionError):
-            numpy.testing.assert_equal(rout[i * nturns,:], zeros)
+            numpy.testing.assert_equal(rout[:, i * nturns], zeros)
         for j in range(1, nparticles):
-            numpy.testing.assert_equal(rout[i * nturns + j,:], zeros)
+            numpy.testing.assert_equal(rout[:, i * nturns + j], zeros)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -22,52 +22,57 @@ def ring():
 
 
 def test_find_orbit4(ring):
-    orbit4 = physics.find_orbit4(ring, DP)
-    expected = numpy.array([1.091636e-7, 1.276747e-15, 0, 0]).reshape(1, 4)
+    orbit4, _ = physics.find_orbit4(ring, DP)
+    expected = numpy.array([1.091636e-7, 1.276747e-15, 0, 0])
     numpy.testing.assert_allclose(orbit4, expected, atol=1e-12)
 
 
 def test_find_orbit4_finds_zeros_if_dp_zero(ring):
-    orbit4 = physics.find_orbit4(ring, 0)
-    expected = numpy.zeros((1, 4))
+    orbit4, _ = physics.find_orbit4(ring, 0)
+    expected = numpy.zeros((4,))
     numpy.testing.assert_allclose(orbit4, expected)
 
 
 def test_find_orbit4_result_unchanged_by_atpass(ring):
-    orbit4 = physics.find_orbit4(ring, DP)
+    orbit4, _ = physics.find_orbit4(ring, DP)
     orbit6 = numpy.append(orbit4, numpy.zeros((1, 2)))
     orbit6[4] = DP
-    orbit6_pass = atpass(ring, orbit6, 1)
-    numpy.testing.assert_allclose(orbit4, orbit6_pass[:, :4], atol=1e-12)
+    orbit6_pass = atpass(ring, orbit6, 1)[:, 0]
+    numpy.testing.assert_allclose(orbit4, orbit6_pass[:4], atol=1e-12)
 
 
 def test_find_orbit4_with_two_refpts(ring):
-    orbit4 = physics.find_orbit4(ring, DP, [49, 99])
+    _, all_points = physics.find_orbit4(ring, DP, [49, 99])
     expected = numpy.array([[8.148212e-6, 1.0993354e-5, 0, 0],
-                            [3.0422808e-8, 9.1635269e-8, 0, 0]]).reshape(2, 4)
-    numpy.testing.assert_allclose(orbit4, expected, atol=1e-12)
+                            [3.0422808e-8, 9.1635269e-8, 0, 0]]).T
+    numpy.testing.assert_allclose(all_points, expected, atol=1e-12)
 
 
-@pytest.mark.parametrize('refpts', (None, [20], [1, 2, 3]))
+@pytest.mark.parametrize('refpts', ([145], [20], [1, 2, 3]))
 def test_find_m44_returns_same_answer_as_matlab(ring, refpts):
     m44, mstack = physics.find_m44(ring, dp=DP, refpts=refpts)
 
-    numpy.testing.assert_allclose(m44[:4], M44_MATLAB.T[:4], rtol=1e-5, atol=1e-7)
+    numpy.testing.assert_allclose(m44[:4], M44_MATLAB[:4], rtol=1e-5, atol=1e-7)
     stack_size = 0 if refpts is None else len(refpts)
-    assert mstack.shape == (stack_size, 4, 4)
+    assert mstack.shape == (4, 4, stack_size)
 
 
-@pytest.mark.parametrize('refpts', (None, [1, 2, 3, 145]))
+@pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
 def test_get_twiss(ring, refpts):
-    twiss = physics.get_twiss(ring, DP, refpts, get_chrom=True)
-    numpy.testing.assert_allclose(twiss.s_pos[-1], 56.209377216)
-    numpy.testing.assert_allclose(twiss.closed_orbit[-1], [1.0916359e-7, 0, 0, 0], atol=1e-12)
-    numpy.testing.assert_allclose(twiss.m44, M44_MATLAB.T, rtol=1e-5, atol=1e-7)
-    numpy.testing.assert_almost_equal(twiss.beta[:, -1], (2.9872, 6.6381), decimal=4)
+    twiss, tune, chrom = physics.get_twiss(ring, DP, refpts, get_chrom=True)
+    numpy.testing.assert_allclose(twiss['s_pos'][-1], 56.209377216)
+    numpy.testing.assert_allclose(twiss['closed_orbit'][-1],
+                                  [1.0916359e-7, 0, 0, 0], atol=1e-12)
+    numpy.testing.assert_allclose(twiss['m44'][-1, :, :],
+                                  M44_MATLAB, rtol=1e-5, atol=1e-7)
+    numpy.testing.assert_almost_equal(twiss['beta'][-1, :],
+                                      (2.9872, 6.6381), decimal=4)
     # Why is the tune different for these two cases?
-    if refpts is None:
+    if refpts == [145]:
         # These are not especially accurate at present.
-        numpy.testing.assert_allclose(twiss.tune, (-0.1344708, -0.00628742), rtol=1e-5, atol=1e-12)
-        numpy.testing.assert_allclose(twiss.chrom, (-0.3090409, -0.44186077), rtol=1e-4)
+        numpy.testing.assert_allclose(tune, (-0.1344708, -0.00628742),
+                                      rtol=1e-5, atol=1e-12)
+        numpy.testing.assert_allclose(chrom, (-0.3090409, -0.44186077),
+                                      rtol=1e-4)
     else:
-        numpy.testing.assert_almost_equal(twiss.tune, (0.36553, 0.49371), decimal=5)
+        numpy.testing.assert_almost_equal(tune, (0.36553, 0.49371), decimal=5)


### PR DESCRIPTION
When looking at the matrix ordering question, I went through the `physics` module and found a few issues:

1. Function names: in matlab, all recent function names start with at, old ones don't. For python, I propose to remove the "at" initials if present and keep the matlab name. Ex.:
    `atlinopt` -> `at.linopt`
I also think that all public functions should be directly visible in the `at` package, since users will never remember if they belong to "physics" or "lattice" etc. module.

2. Output arguments: AT uses a lot the possibility in Matlab to check in a function the number of expected output arguments, and act accordingly. This does not exist in python, so there are several alternatives :
	- always consider the maximum number of arguments, and let the user put dummy variables if he is not interested in the result. This is what I tried in `find_orbit4`. Not very elegant, and may lead to unnecessary computations,
	- Add input keywords to let the user tell the function what he is interested in. Possibly more efficient, but not so elegant also.

	What is the most pythonic way ?

3. Matrix ordering:  we can respect the classical orientation of vectors and matrices:

	X=T.X0, where the transfer matrix T  is square and X, X0 are column vectors of coordinates

	Fortran-ordering is only needed in `atpass`. This condition is ensured by the intermediate functions `linepass` and `ringpass`. Outside, any ordering may be used, numpy takes care of it.  For performance reason, functions calling `linepass`/`ringpass` can build directly the input coordinate arrays directly in Fortran-order.