### PR TITLE
Pyat tweaks

### DIFF
--- a/pyat/at/lattice.py
+++ b/pyat/at/lattice.py
@@ -22,18 +22,20 @@ def uint32_refpts(refpts, n_elements):
     else:
         if not isinstance(refpts, (collections.Sequence, numpy.ndarray)):
             refpts = [refpts]
-        if (numpy.any(numpy.diff(numpy.array(refpts)) < 0)
-                or (refpts[-1] > n_elements)
-                or numpy.any(numpy.array(refpts) < 0)):
-            raise ValueError('refpts must be ascending and less or equal to {}'.format(n_elements))
+        if (numpy.any(numpy.diff(numpy.array(refpts)) < 0) or
+                (refpts[-1] > n_elements) or
+                numpy.any(numpy.array(refpts) < 0)):
+            error_msg = 'refpts must be ascending and less than or equal to {}'
+            raise ValueError(error_msg.format(n_elements))
         urefpts = numpy.asarray(refpts, dtype=numpy.uint32)
     return urefpts
 
 
 def bool_refpts(refpts, n_elements):
     """
-    Return a boolean numpy array of length n_elements + 1 where True elements are
-    selected. This is used for indexing a lattice using True or False values.
+    Return a boolean numpy array of length n_elements + 1 where True elements
+    are selected. This is used for indexing a lattice using True or False
+    values.
     """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         return refpts

--- a/pyat/at/physics.py
+++ b/pyat/at/physics.py
@@ -23,7 +23,7 @@ TWISS_DTYPE = [('idx', numpy.uint32),
 def find_orbit4(ring, dp=0.0, refpts=None):
     """findorbit4 finds the closed orbit in the 4-d transverse phase
     space by numerically solving for a fixed point of the one turn
-    map M calculated with linepass
+    map M calculated with lattice_pass.
 
         (X, PX, Y, PY, dP2, CT2 ) = M (X, PX, Y, PY, dP1, CT1)
 
@@ -79,7 +79,7 @@ def find_orbit4(ring, dp=0.0, refpts=None):
     keeplattice = False
     while (change > CONVERGENCE) and itercount < MAX_ITERATIONS:
         in_mat = r_in.reshape((6, 1)) + delta_matrix
-        out_mat = at.linepass(ring, in_mat, keep_lattice=keeplattice)
+        out_mat = at.lattice_pass(ring, in_mat, keep_lattice=keeplattice)
         # the reference particle after one turn
         ref_out = out_mat[:4, 4]
         # 4x4 jacobian matrix from numerical differentiation:
@@ -95,7 +95,8 @@ def find_orbit4(ring, dp=0.0, refpts=None):
         r_in = r_next
         keeplattice = True
 
-    all_points = at.linepass(ring, r_in, refpts, keep_lattice=keeplattice)
+    all_points = at.lattice_pass(ring, r_in, refpts=refpts,
+                                 keep_lattice=keeplattice)
     return r_in[:4], all_points[:4, :]
 
 
@@ -121,7 +122,8 @@ def find_m44(ring, dp=0.0, refpts=None, orbit4=None, XYStep=XYDEFSTEP):
     # Add the deltas to multiple copies of the closed orbit
     in_mat = orbit6 + dmat
 
-    out_mat = at.linepass(ring, in_mat, refpts, keep_lattice=keeplattice)
+    out_mat = at.lattice_pass(ring, in_mat, refpts=refpts,
+                              keep_lattice=keeplattice)
     tmat3 = numpy.reshape(out_mat[:4, :], (4, 8, -1), order='F')
     # (x + d) - (x - d) / d
     mstack = (tmat3[:, :4, :] - tmat3[:, 4:8, :]) / XYStep

--- a/pyat/at/physics.py
+++ b/pyat/at/physics.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy
 import at
 from at import lattice
@@ -80,6 +79,8 @@ def find_orbit4(ring, dp=0.0, refpts=None):
     while (change > CONVERGENCE) and itercount < MAX_ITERATIONS:
         in_mat = r_in.reshape((6, 1)) + delta_matrix
         out_mat = at.lattice_pass(ring, in_mat, keep_lattice=keeplattice)
+        # out_mat: 5 particles at one refpt and one turn
+        out_mat = out_mat[:, :, 0, 0]
         # the reference particle after one turn
         ref_out = out_mat[:4, 4]
         # 4x4 jacobian matrix from numerical differentiation:
@@ -97,7 +98,8 @@ def find_orbit4(ring, dp=0.0, refpts=None):
 
     all_points = at.lattice_pass(ring, r_in, refpts=refpts,
                                  keep_lattice=keeplattice)
-    return r_in[:4], all_points[:4, :]
+    # all_points: one particle at n refpts for one turn
+    return r_in[:4], all_points[:4, 0, :, 0]
 
 
 def find_m44(ring, dp=0.0, refpts=None, orbit4=None, XYStep=XYDEFSTEP):
@@ -124,7 +126,8 @@ def find_m44(ring, dp=0.0, refpts=None, orbit4=None, XYStep=XYDEFSTEP):
 
     out_mat = at.lattice_pass(ring, in_mat, refpts=refpts,
                               keep_lattice=keeplattice)
-    tmat3 = numpy.reshape(out_mat[:4, :], (4, 8, -1), order='F')
+    # out_mat: 8 particles at n refpts for one turn
+    tmat3 = out_mat[:4, :, :, 0]
     # (x + d) - (x - d) / d
     mstack = (tmat3[:, :4, :] - tmat3[:, 4:8, :]) / XYStep
     m44 = mstack[:, :, -1]

--- a/pyat/at/track.py
+++ b/pyat/at/track.py
@@ -5,8 +5,11 @@ from .atpass import atpass
 from .lattice import uint32_refpts
 
 
+DIMENSION_ERROR = 'Input to lattice_pass() must be a 6xN array.'
+
+
 def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
-    """pass tracks particles through each element of the sequence lattice
+    """lattice_pass tracks particles through each element of the sequence lattice
     calling the element-specific tracking function specified in the
     lattice[i].PassMethod field.
 
@@ -15,7 +18,7 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
      * lattice_pass(lattice, r_in, refpts=len(line)) is the same as
        lattice_pass(lattice, r_in) since the reference point len(line) is the
        exit of the last element
-     * linepass(lattice, r_in, refpts=0]) is a copy of r_in since the
+     * linepass(lattice, r_in, refpts=0) is a copy of r_in since the
        reference point 0 is the entrance of the first element
 
     Args:
@@ -29,16 +32,25 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
                       that previous call.
 
     Returns:
-        6xN array containing output coordinates of x particles at y selected
-        indices for z turns; N = x * y * z. The sequence of output is
-        coordinates for each particle for each refpt for each turn - that is,
-        the first x columns are the x particles at the first refpt on the first
-        turn, and the first x * y columns are the x particles at all refpts on
-        the first turn.
+        6xAxBxC array containing output coordinates of A particles at B
+        selected indices for C turns.
     """
-    assert r_in.shape[0] == 6
+    assert r_in.shape[0] == 6 and r_in.ndim in (1, 2), DIMENSION_ERROR
+    nparticles = 1 if r_in.ndim == 1 else r_in.shape[1]
     r_in = numpy.asfortranarray(r_in)
     if refpts is None:
         refpts = len(lattice)
     refs = uint32_refpts(refpts, len(lattice))
-    return atpass(lattice, r_in, nturns, refs, int(keep_lattice))
+    result = atpass(lattice, r_in, nturns, refs, int(keep_lattice))
+    # atpass returns 6xN array where n = x*y*z;
+    # * x is number of particles;
+    # * y is number of refpts
+    # * z is the number of turns
+    # The sequence of output is coordinates for each particle for each refpt
+    # for each turn - that is, the first x columns are the x particles at the
+    # first refpt on the first # turn, and the first x * y columns are the x
+    # particles at all refpts on the first turn.
+    # Fortran-order reshaping gathers the elements in this order - from first
+    # index of the 4D array to last.
+    result = result.reshape((6, nparticles, len(refs), nturns), order='F')
+    return result

--- a/pyat/at/track.py
+++ b/pyat/at/track.py
@@ -5,78 +5,40 @@ from .atpass import atpass
 from .lattice import uint32_refpts
 
 
-def linepass(line, r_in, refpts=None, keep_lattice=False):
-    """linepass tracks particles through each element of the sequence line
+def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
+    """pass tracks particles through each element of the sequence lattice
     calling the element-specific tracking function specified in the
-    line[i].PassMethod field.
+    lattice[i].PassMethod field.
 
-    r_out = linepass(line, r_in) tracks particle(s) with initial
-    condition(s) r_in to the end of the line
+    Note:
 
-    line        AT lattice
-    r_in        6xN matrix: input coordinates of N particles
+     * lattice_pass(lattice, r_in, refpts=len(line)) is the same as
+       lattice_pass(lattice, r_in) since the reference point len(line) is the
+       exit of the last element
+     * linepass(lattice, r_in, refpts=0]) is a copy of r_in since the
+       reference point 0 is the entrance of the first element
 
-    r_out       6xN matrix: output coordinates of N particles at
+    Args:
+        lattice: sequence of AT elements
+        r_in: 6xN array: input coordinates of N particles
+        nturns: number of passes through the lattice line
+        refpts: indices of elements at which to return coordinates (see
+                lattice.py)
+        keep_lattice: use elements persisted from a previous call to at.atpass.
+                      If True, assume that the lattice has not changed since
+                      that previous call.
 
-    r_out=linepass(line, r_in, REFPTS) returns intermediate results
-    at the entrance of each element specified in refpts
-
-    REFPTS is an array of increasing indexes that selects elements
-    between 0 and length(line).
-    See further explanation of REFPTS in the 'help' for FINDSPOS
-    r_out       6x(N*length(REFPTS)) matrix: output coordinates of N particles at
-                each reference point
-
-    keep_lattice:If set to True, linepass is more efficient because it reuses
-                 some of the data and functions stored in the persistent
-                 memory in previous calls to linepass.
-
-    !!! In order to use this option, linepass must first be called without
-    the keep_lattice flag. This will create persistent data structures and keep
-    pointers to pass-method functions.
-
-    !!! linepass(..., keep_lattice=True) assumes that the RING is unchanged
-    since the last call. Otherwise, ringpass with keep_lattice=False must be
-    called again.
-
-    NOTE:
-    linepass(line,r_in,length(line)) is the same as linepass(line,r_in)
-    since the reference point length(line) is the exit of the last element
-    linepass(line,r_in, 0) is a copy of r_in since the
-    reference point 0 is the entrance of the first element
+    Returns:
+        6xN array containing output coordinates of x particles at y selected
+        indices for z turns; N = x * y * z. The sequence of output is
+        coordinates for each particle for each refpt for each turn - that is,
+        the first x columns are the x particles at the first refpt on the first
+        turn, and the first x * y columns are the x particles at all refpts on
+        the first turn.
     """
+    assert r_in.shape[0] == 6
+    r_in = numpy.asfortranarray(r_in)
     if refpts is None:
-        refpts = len(line)
-    refs = uint32_refpts(refpts, len(line))
-    r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
-    return atpass(line, r_in, 1, refs, int(keep_lattice))
-
-
-def ringpass(ring, r_in, nturns=1, keep_lattice=False):
-    """ringpass tracks particles through each element of the cell array ring
-    calling the element-specific tracking function specified in the
-    ring[i].PassMethod field.
-
-    r_out=ringpass(ring,r_in,nturns) tracks particle(s) with initial
-    condition(s) RIN for nturns turns
-
-    ring:       AT lattice
-    r_in:       6xN matrix: input coordinates of N particles
-    nturns:     Number of turns to perform (default: 1)
-
-    r_out:      6x(N*nturns) matrix: output coordinates of N particles at
-
-    keep_lattice:If set to True, ringpass is more efficient because it reuses
-                 some of the data and functions stored in the persistent
-                 memory in previous calls to ringpass.
-
-    !!! In order to use this option, ringpass must first be called without
-    the keep_lattice flag. This will create persistent data structures and keep
-    pointers to pass-method functions.
-
-    !!! ringpass(..., keep_lattice=True) assumes that the ring is unchanged
-    since the last call. Otherwise, ringpass with keep_lattice=False must be
-    called again.
-    """
-    r_in = numpy.asfortranarray(r_in.reshape((6, -1)))
-    return atpass(ring, r_in, nturns, reuse=int(keep_lattice))
+        refpts = len(lattice)
+    refs = uint32_refpts(refpts, len(lattice))
+    return atpass(lattice, r_in, nturns, refs, int(keep_lattice))

--- a/pyat/test/test_track.py
+++ b/pyat/test/test_track.py
@@ -1,11 +1,25 @@
-from at import track
+from at import elements, track
 import numpy
 import pytest
 
 
-@pytest.mark.parametrize('input_dim', [(0,), (5,), (7,), (1,1), (6,1,1)])
+@pytest.mark.parametrize('input_dim', [(0,), (5,), (7,), (1, 1), (6, 1, 1)])
 def test_lattice_pass_raises_AssertionError_if_rin_incorrect_shape(input_dim):
-    r_in = numpy.zeros(input_dim)
+    rin = numpy.zeros(input_dim)
     lattice = []
     with pytest.raises(AssertionError):
-        track.lattice_pass(lattice, r_in)
+        track.lattice_pass(lattice, rin)
+
+
+def test_multiple_particles_lattice_pass():
+    lattice = [elements.Drift('Drift', 1.0)]
+    rin = numpy.zeros((6, 2))
+    rin[0, 0] = 1e-6  # particle one offset in x
+    rin[2, 1] = 1e-6  # particle two offset in y
+    r_original = numpy.copy(rin)
+    r_out = track.lattice_pass(lattice, rin, nturns=2)
+    # particle position is not changed passing through the drift
+    numpy.testing.assert_equal(r_original[:, 0], r_out[:, 0, 0, 0])
+    numpy.testing.assert_equal(r_original[:, 0], r_out[:, 0, 0, 1])
+    numpy.testing.assert_equal(r_original[:, 1], r_out[:, 1, 0, 0])
+    numpy.testing.assert_equal(r_original[:, 1], r_out[:, 1, 0, 1])

--- a/pyat/test/test_track.py
+++ b/pyat/test/test_track.py
@@ -1,0 +1,11 @@
+from at import track
+import numpy
+import pytest
+
+
+@pytest.mark.parametrize('input_dim', [(0,), (5,), (7,), (1,1), (6,1,1)])
+def test_lattice_pass_raises_AssertionError_if_rin_incorrect_shape(input_dim):
+    r_in = numpy.zeros(input_dim)
+    lattice = []
+    with pytest.raises(AssertionError):
+        track.lattice_pass(lattice, r_in)


### PR DESCRIPTION
@lfarv this branch merges `linepass()` and `ringpass()`.  Questions:

* I called the new function `lattice_pass()`. Would you like a different name?
* Should we reshape the array that is returned? 

It is currently 6xABC, where A is number of particles, B is number of refpts and C is number of turns, but we could make it 6xAxBxC, i.e. a 4D array. I think that should make it easier to use:

* `r_out[:,0,:,:]` is results for the first particle
* `r_out[:,:,1,:]` is all particles for all turns at the entrance to the second element

There are questions like whether you should 'squeeze' dimensions if they are of size 1.