### PR TITLE
correct phase advance (tune) computation in atplot splitted lattice with vertical bends

### DIFF
--- a/atmat/atplot/atbaseplot.m
+++ b/atmat/atplot/atbaseplot.m
@@ -137,7 +137,8 @@ end
     function newelems=splitelem(elem)
         if isfield(elem,'Length') && elem.Length > 0
             nslices=ceil(elem.Length/elmlength);
-            newelems=atdivelem(elem,ones(1,nslices)./nslices);
+            newelems=atdivelem(elem,ones(1,nslices)./nslices,...
+                'rotations_traslations_at_all_slices',true);
         else
             newelems={elem};
         end

--- a/atmat/atplot/atbaseplot.m
+++ b/atmat/atplot/atbaseplot.m
@@ -137,8 +137,7 @@ end
     function newelems=splitelem(elem)
         if isfield(elem,'Length') && elem.Length > 0
             nslices=ceil(elem.Length/elmlength);
-            newelems=atdivelem(elem,ones(1,nslices)./nslices,...
-                'rotations_translations_at_all_slices',true);
+            newelems=atdivelem(elem,ones(1,nslices)./nslices,'KeepAxis');
         else
             newelems={elem};
         end

--- a/atmat/atplot/atbaseplot.m
+++ b/atmat/atplot/atbaseplot.m
@@ -138,7 +138,7 @@ end
         if isfield(elem,'Length') && elem.Length > 0
             nslices=ceil(elem.Length/elmlength);
             newelems=atdivelem(elem,ones(1,nslices)./nslices,...
-                'rotations_traslations_at_all_slices',true);
+                'rotations_translations_at_all_slices',true);
         else
             newelems={elem};
         end

--- a/atmat/lattice/atdivelem.m
+++ b/atmat/lattice/atdivelem.m
@@ -18,7 +18,7 @@ function line = atdivelem(elem,frac,varargin)
 %
 % Optional arguments:
 %
-% rotations_traslations_at_all_slices,  true/false(default), 
+% rotations_translations_at_all_slices,  true/false(default) 
 %
 % See also ATINSERTELEMS ATSLICE ATSPLITELEM
 
@@ -26,11 +26,11 @@ p=inputParser;
 
 addRequired(p,'elem');
 addRequired(p,'frac');
-addOptional(p,'rotations_traslations_at_all_slices',false,@islogical);
+addOptional(p,'rotations_translations_at_all_slices',false,@islogical);
 
 parse(p,elem,frac,varargin{:});
 
-rottrasl=p.Results.rotations_traslations_at_all_slices;
+rottrasl=p.Results.rotations_translations_at_all_slices;
 
 entfield=entrancefields();
 exfield=exitfields();

--- a/atmat/lattice/atdivelem.m
+++ b/atmat/lattice/atdivelem.m
@@ -19,17 +19,11 @@ function line = atdivelem(elem,frac,varargin)
 % Optional arguments:
 % 'KeepAxis', if present, rotations translations are kept at all slices 
 %
-% See also ATINSERTELEMS ATSLICE ATSPLITELEM
+% See also ATINSERTELEMS ATSLICE ATSPLITELEM ENTRANCEFIELDS EXITFIELDS
 
-rottrasl=getflag(varargin,'KeepAxis');
-
-entfield=entrancefields();
-exfield=exitfields();
-
-if rottrasl
-    entfield([1,2])=[]; % remove R1 T1 from list of field at entrance
-    exfield([1,2])=[]; % remove R2 T2 from list of field at entrance
-end
+% get fields names to keep at entrance and exit only
+entfield=entrancefields(varargin{:});
+exfield=exitfields(varargin{:});
 
 [entrancef,el]=mvfield(struct(),elem,entfield); % Extract entrance fields
 [exitf,el]=mvfield(struct(),el,exfield);           % extract exit fields

--- a/atmat/lattice/atdivelem.m
+++ b/atmat/lattice/atdivelem.m
@@ -1,4 +1,4 @@
-function line = atdivelem(elem,frac)
+function line = atdivelem(elem,frac,varargin)
 %LINE=ATDIVELEM(ELEM,FRAC) divide an element into pieces
 %
 %ELEM:  Element to be divided
@@ -16,10 +16,32 @@ function line = atdivelem(elem,frac)
 %>> qf=atquadrupole('QF',0.1,0.5);
 %>> line=atdivelem(qf,[0.5;0.5]); % Split a quadrupole in two halves
 %
+% Optional arguments:
+%
+% rotations_traslations_at_all_slices,  true/false(default), 
+%
 % See also ATINSERTELEMS ATSLICE ATSPLITELEM
 
-[entrancef,el]=mvfield(struct(),elem,entrancefields()); % Extract entrance fields
-[exitf,el]=mvfield(struct(),el,exitfields());           % extract exit fields
+p=inputParser;
+
+addRequired(p,'elem');
+addRequired(p,'frac');
+addOptional(p,'rotations_traslations_at_all_slices',false,@islogical);
+
+parse(p,elem,frac,varargin{:});
+
+rottrasl=p.Results.rotations_traslations_at_all_slices;
+
+entfield=entrancefields();
+exfield=exitfields();
+
+if rottrasl
+    entfield([1,2])=[]; % remove R1 T1 from list of field at entrance
+    exfield([1,2])=[]; % remove R2 T2 from list of field at entrance
+end
+
+[entrancef,el]=mvfield(struct(),elem,entfield); % Extract entrance fields
+[exitf,el]=mvfield(struct(),el,exfield);           % extract exit fields
                                         % split the bare element
 line=atsetfieldvalues(repmat({el},length(frac),1),'Length',el.Length*frac(:));
 if isfield(elem,'BendingAngle')

--- a/atmat/lattice/atdivelem.m
+++ b/atmat/lattice/atdivelem.m
@@ -17,20 +17,11 @@ function line = atdivelem(elem,frac,varargin)
 %>> line=atdivelem(qf,[0.5;0.5]); % Split a quadrupole in two halves
 %
 % Optional arguments:
-%
-% rotations_translations_at_all_slices,  true/false(default) 
+% 'KeepAxis', if present, rotations translations are kept at all slices 
 %
 % See also ATINSERTELEMS ATSLICE ATSPLITELEM
 
-p=inputParser;
-
-addRequired(p,'elem');
-addRequired(p,'frac');
-addOptional(p,'rotations_translations_at_all_slices',false,@islogical);
-
-parse(p,elem,frac,varargin{:});
-
-rottrasl=p.Results.rotations_translations_at_all_slices;
+rottrasl=getflag(varargin,'KeepAxis');
 
 entfield=entrancefields();
 exfield=exitfields();

--- a/atmat/lattice/entrancefields.m
+++ b/atmat/lattice/entrancefields.m
@@ -1,11 +1,24 @@
-function fnames = entrancefields()
+function fnames = entrancefields(varargin)
 %ENTRANCEFIELDS() Return the list of field names affecting the element entrance
+%
+% Optional arguments:
+% 'KeepAxis', if present, rotations translations are excluded from list 
+%
+%see also: exitfields atdivelem
+
+rottrasl=getflag(varargin,'KeepAxis');
+
+start=1;
+
+if rottrasl
+   start=3; % remove R1 T1 from list of field at entrance
+end
 
 persistent fnms
 if isempty(fnms)
     fnms={'T1','R1','EntranceAngle','FringeInt1',...
         'FringeBendEntrance','FringeQuadEntrance'};
 end
-fnames=fnms;
+fnames=fnms(start:end);
 end
 

--- a/atmat/lattice/exitfields.m
+++ b/atmat/lattice/exitfields.m
@@ -1,11 +1,24 @@
-function fnames = exitfields()
+function fnames = exitfields(varargin)
 %EXITFIELDS() Return the list of field names affecting the element exit
+%
+% Optional arguments:
+% 'KeepAxis', if present, rotations translations are excluded from list 
+%
+%see also: entrancefields atdivelem
+
+rottrasl=getflag(varargin,'KeepAxis');
+
+start=1;
+
+if rottrasl
+   start=3; % remove R1 T1 from list of field at entrance
+end
 
 persistent fnms
 if isempty(fnms)
     fnms={'T2','R2','ExitAngle','FringeInt2',...
         'FringeBendExit','FringeQuadExit'};
 end
-fnames=fnms;
+fnames=fnms(start:end);
 end
 


### PR DESCRIPTION
added option to atdivelem.m to keep rotations and translations at each slice. this option is then used by atplot.m