### PR TITLE
Remove compiler warnings

### DIFF
--- a/atintegrators/BndMPoleSymplectic4Pass.c
+++ b/atintegrators/BndMPoleSymplectic4Pass.c
@@ -55,8 +55,6 @@ void BndMPoleSymplectic4Pass(double *r, double le, double irho, double *A, doubl
     int c, m;
     double *r6;
     double SL, L1, L2, K1, K2, p_norm, NormL1, NormL2;
-    /*bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
-    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);*/
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
     SL = le/num_int_steps;

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -68,8 +68,6 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
     double L2 = SL*DRIFT2;
     double K1 = SL*KICK1;
     double K2 = SL*KICK2;
-    /*bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
-    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);*/
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
     double  qe = 1.60217733e-19;

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -40,7 +40,7 @@ struct elem
     double *EApertures;
 };
 
-BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, double *B,
+void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, double *B,
         int max_order, int num_int_steps,
         double entrance_angle, double exit_angle,
         int FringeBendEntrance, int FringeBendExit,
@@ -68,8 +68,8 @@ BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, doubl
     double L2 = SL*DRIFT2;
     double K1 = SL*KICK1;
     double K2 = SL*KICK2;
-    bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
-    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);
+    /*bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
+    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);*/
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
     double  qe = 1.60217733e-19;

--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -57,8 +57,6 @@ void BndMPoleSymplectic4RadPass(double *r, double le, double irho, double *A, do
 {	int c,m;
     double *r6;
     double SL, L1, L2, K1, K2;
-    /*bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
-    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);*/
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
     SL = le/num_int_steps;

--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -57,8 +57,8 @@ void BndMPoleSymplectic4RadPass(double *r, double le, double irho, double *A, do
 {	int c,m;
     double *r6;
     double SL, L1, L2, K1, K2;
-    bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
-    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);
+    /*bool useFringe1 = (fint1!=0.0 && gap!=0.0 && FringeBendEntrance!=0);
+    bool useFringe2 = (fint2!=0.0 && gap!=0.0 && FringeBendExit!=0);*/
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
     SL = le/num_int_steps;

--- a/atintegrators/ImpedanceTablePass.c
+++ b/atintegrators/ImpedanceTablePass.c
@@ -99,9 +99,10 @@ void impedance_tablePass(double *r_in,int num_particles, struct elem *Elem){
     int *iptr;
     
     /* first find the min and max of the distribution*/
-
+/*
     double srms;
     double smean;
+ */
     double smin = DBL_MAX;
     double smax = -DBL_MAX;
     double stot = 0.0;

--- a/atintegrators/atphyslib.c
+++ b/atintegrators/atphyslib.c
@@ -37,7 +37,9 @@ static void edge_fringe_entrance(double* r, double inv_rho, double edge_angle,
         fy = inv_rho*tan(edge_angle-fringecorr/(1+r[4]))/(1+r[4]);
     else if (method==3)
         fy = inv_rho*tan(edge_angle-fringecorr+r[1]/(1+r[4]));
-    
+    else    /* fall back to legacy version */
+        fy = inv_rho*tan(edge_angle-fringecorr/(1+r[4]));
+
     r[1]+=r[0]*fx;
     r[3]-=r[2]*fy;
 }
@@ -67,7 +69,9 @@ static void edge_fringe_exit(double* r, double inv_rho, double edge_angle,
         fy = inv_rho*tan(edge_angle-fringecorr/(1+r[4]))/(1+r[4]);
     else if (method==3)
         fy = inv_rho*tan(edge_angle-fringecorr-r[1]/(1+r[4]));
-    
+    else    /* fall back to legacy version */
+        fy = inv_rho*tan(edge_angle-fringecorr/(1+r[4]));
+
     r[1]+=r[0]*fx;
     r[3]-=r[2]*fy;
 }


### PR DESCRIPTION
Corrections to be safe if FringeBendEntrance/Exit is not in [1,2,3] : fallback to legacy treatment instead of crash, and to silence compiler warnings.