### PR TITLE
Remove Python 3.3 and 3.4 from Travis configuration and add 3.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
     - os: linux
       python: "2.7"
     - os: linux
-      python: "3.3"
-    - os: linux
       python: "3.4"
     - os: linux
       python: "3.5"
+    - os: linux
+      python: "3.6"
 
     - os: osx
       sudo: required


### PR DESCRIPTION
Python 3.3 is no longer supported.

@carmignani I hope this will resolve the problem.