### PR TITLE
Replace mxGetPr

### DIFF
--- a/atintegrators/AperturePass.c
+++ b/atintegrators/AperturePass.c
@@ -52,7 +52,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         AperturePass(r_in,limits, num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/BendLinearPass.c
+++ b/atintegrators/BendLinearPass.c
@@ -241,7 +241,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BendLinearPass(r_in,Length,K,BendingAngle,ByError,
                 EntranceAngle,ExitAngle,FringeInt1,FringeInt2,
                 FullGap,T1,T2,R1,R2,num_particles);

--- a/atintegrators/BndMPoleSymplectic4E2Pass.c
+++ b/atintegrators/BndMPoleSymplectic4E2Pass.c
@@ -368,7 +368,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         
         /* ALLOCATE memory for the output array of the same size as the input */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BndMPoleSymplectic4E2Pass(r_in, Length, irho, PolynomA, PolynomB, MaxOrder, NumIntSteps, EntranceAngle, ExitAngle,
                 Fint1, Fint2, Gap, h1, h2, T1, T2, R1, R2, RApertures,EApertures,num_particles);
     }

--- a/atintegrators/BndMPoleSymplectic4E2RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4E2RadPass.c
@@ -446,7 +446,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         
         /* ALLOCATE memory for the output array of the same size as the input */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BndMPoleSymplectic4E2RadPass(r_in, Length, irho, PolynomA, PolynomB, MaxOrder, NumIntSteps, EntranceAngle, ExitAngle,
                 Fint1, Fint2, Gap, h1, h2, T1, T2, R1, R2, RApertures,EApertures,Energy,num_particles);
     }

--- a/atintegrators/BndMPoleSymplectic4Pass.c
+++ b/atintegrators/BndMPoleSymplectic4Pass.c
@@ -234,7 +234,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         irho = BendingAngle/Length;
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BndMPoleSymplectic4Pass(r_in, Length, irho, PolynomA, PolynomB,
                 MaxOrder,NumIntSteps,EntranceAngle,ExitAngle,
                 FringeBendEntrance,FringeBendExit,FringeInt1,FringeInt2,
@@ -278,5 +278,3 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
 }
 #endif /* MATLAB_MEX_FILE */
-
-

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -283,7 +283,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         irho = BendingAngle/Length;
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BndMPoleSymplectic4QuantPass(r_in, Length, irho, PolynomA, PolynomB,
                 MaxOrder,NumIntSteps,EntranceAngle,ExitAngle,
                 FringeBendEntrance,FringeBendExit,FringeInt1,FringeInt2,
@@ -306,11 +306,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (nlhs>1) {
             /* list of optional fields */
             plhs[1] = mxCreateCellMatrix(15,1);
-            mxSetCell(plhs[1],3,mxCreateString("FringeBendEntrance"));
-            mxSetCell(plhs[1],4,mxCreateString("FringeBendExit"));
             mxSetCell(plhs[1],0,mxCreateString("FullGap"));
             mxSetCell(plhs[1],1,mxCreateString("FringeInt1"));
             mxSetCell(plhs[1],2,mxCreateString("FringeInt2"));
+            mxSetCell(plhs[1],3,mxCreateString("FringeBendEntrance"));
+            mxSetCell(plhs[1],4,mxCreateString("FringeBendExit"));
             mxSetCell(plhs[1],5,mxCreateString("FringeQuadEntrance"));
             mxSetCell(plhs[1],6,mxCreateString("FringeQuadExit"));
             mxSetCell(plhs[1],7,mxCreateString("fringeIntM0"));
@@ -328,4 +328,3 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
 }
 #endif /* MATLAB_MEX_FILE */
-

--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -237,7 +237,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         irho = BendingAngle/Length;
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         BndMPoleSymplectic4RadPass(r_in, Length, irho, PolynomA, PolynomB,
                 MaxOrder,NumIntSteps,EntranceAngle,ExitAngle,
                 FringeBendEntrance,FringeBendExit,FringeInt1,FringeInt2,
@@ -260,11 +260,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (nlhs>1) {
             /* list of optional fields */
             plhs[1] = mxCreateCellMatrix(15,1);
-            mxSetCell(plhs[1],3,mxCreateString("FringeBendEntrance"));
-            mxSetCell(plhs[1],4,mxCreateString("FringeBendExit"));
             mxSetCell(plhs[1],0,mxCreateString("FullGap"));
             mxSetCell(plhs[1],1,mxCreateString("FringeInt1"));
             mxSetCell(plhs[1],2,mxCreateString("FringeInt2"));
+            mxSetCell(plhs[1],3,mxCreateString("FringeBendEntrance"));
+            mxSetCell(plhs[1],4,mxCreateString("FringeBendExit"));
             mxSetCell(plhs[1],5,mxCreateString("FringeQuadEntrance"));
             mxSetCell(plhs[1],6,mxCreateString("FringeQuadExit"));
             mxSetCell(plhs[1],7,mxCreateString("fringeIntM0"));
@@ -282,5 +282,3 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
 }
 #endif /* MATLAB_MEX_FILE */
-
-

--- a/atintegrators/CavityPass.c
+++ b/atintegrators/CavityPass.c
@@ -103,7 +103,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         CavityPass(r_in,Length,Voltage/Energy,Frequency,TimeLag,num_particles);
     }
     else if (nrhs == 0) {   /* return list of required fields */

--- a/atintegrators/CavityPass.c
+++ b/atintegrators/CavityPass.c
@@ -113,8 +113,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mxSetCell(plhs[0],2,mxCreateString("Energy"));
         mxSetCell(plhs[0],3,mxCreateString("Frequency"));
         if (nlhs>1) /* optional fields */
-        {   plhs[1] = mxCreateCellMatrix(2,1);
-            mxSetCell(plhs[1],0,mxCreateString("HarmNumber"));
+        {   plhs[1] = mxCreateCellMatrix(1,1);
             mxSetCell(plhs[1],0,mxCreateString("TimeLag"));
         }
     }

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -72,11 +72,11 @@ MODULE_DEF(CorrectorPass)        /* Dummy module initialisation */
 void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
-        double Length;
-        double *KickAngle;
         double *r_in;
         const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
+        double Length;
+        double *KickAngle;
         Length=atGetDouble(ElemData,"Length"); check_error();
         KickAngle = atGetDoubleArray(ElemData, "KickAngle");
         /* ALLOCATE memory for the output array of the same size as the input  */

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -6,7 +6,13 @@
    Length, KickAngle
 */
 
-#include "at.h"
+#include "atelem.c"
+
+struct elem
+{
+    double Length;
+    double *KickAngle;
+};
 
 void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int num_particles)
 /* xkick, ykick - horizontal and vertical kicks in radiand 
@@ -18,7 +24,7 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
 	if (len==0)
 	    for(c = 0;c<num_particles;c++) {
 	        c6 = c*6;
-		    if(!mxIsNaN(r_in[c6])) {
+		    if(!atIsNaN(r_in[c6])) {
 		        r_in[c6+1] += xkick;
    		        r_in[c6+3] += ykick; 		    
    		    }
@@ -27,7 +33,7 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
         #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD*10) default(shared) shared(r_in,num_particles) private(c,c6)
         for(c = 0;c<num_particles;c++) {
             c6 = c*6;
-		    if(!mxIsNaN(r_in[c6])) {
+		    if(!atIsNaN(r_in[c6])) {
 		        p_norm = 1/(1+r_in[c6+4]);
 			    NormL  = len*p_norm;
 	            r_in[c6+5] += NormL*p_norm*(xkick*xkick/3 + ykick*ykick/3 +
@@ -42,102 +48,49 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
 		}	
 }
 
-MODULE_DEF(CorrectorPass)        /* Dummy module initialisation */
-
-#ifdef MATLAB_MEX_FILE
-
-#include "elempass.h"
-#define NUM_FIELDS_2_REMEMBER 2
-
-ExportMode int* passFunction(const mxArray *ElemData,int *FieldNumbers,
-				double *r_in, int num_particles, int mode)
-
-
-
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
 {
-    double *kickptr;
-    double le;
-	int *returnptr;
-	int *NewFieldNumbers, fnum;
-	switch (mode) {
-			case MAKE_LOCAL_COPY: 	/* Find field numbers first
-										Save a list of field number in an array
-										and make returnptr point to that array
-									*/
-                NewFieldNumbers = (int*)mxCalloc(NUM_FIELDS_2_REMEMBER,sizeof(int));
-
-                fnum = mxGetFieldNumber(ElemData,"KickAngle");
-                if(fnum<0)
-                    mexErrMsgTxt("Required field 'KickAngle' was not found in the element data structure");
-                NewFieldNumbers[0] = fnum;
-
-                fnum = mxGetFieldNumber(ElemData,"Length");
-                if(fnum<0)
-                    mexErrMsgTxt("Required field 'Length' was not found in the element data structure");
-                NewFieldNumbers[1] = fnum;
-
-                kickptr = mxGetPr(mxGetFieldByNumber(ElemData,0,NewFieldNumbers[0]));
-                le = mxGetScalar(mxGetFieldByNumber(ElemData,0,NewFieldNumbers[1]));
-                returnptr = NewFieldNumbers;
-				break;
-
-			case	USE_LOCAL_COPY:	/* Get fields from MATLAB using field numbers
-										The second argument ponter to the array of field 
-										numbers is previously created with 
-										QuadLinPass( ..., MAKE_LOCAL_COPY)
-									*/
-                kickptr = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[0]));
-                le = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[1]));
-                returnptr = FieldNumbers;
-                break;
-			default:
-				mexErrMsgTxt("No match for calling mode in function CorrectorPass\n");
-	}
-	CorrectorPass(r_in, kickptr[0], kickptr[1], le, num_particles);
-	return returnptr;
+    if (!Elem) {
+        double Length;
+        double *KickAngle;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        KickAngle = atGetDoubleArray(ElemData, "KickAngle");
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->Length=Length;
+        Elem->KickAngle = KickAngle;
+    }
+	CorrectorPass(r_in, Elem->KickAngle[0], Elem->KickAngle[1], Elem->Length, num_particles);
+    return Elem;
 }
 
+MODULE_DEF(CorrectorPass)        /* Dummy module initialisation */
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
+#ifdef MATLAB_MEX_FILE
 void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-    double *kickptr,le;
-	int m,n;
-	double *r_in;   
-	mxArray *tmpmxptr;
-	
-	if(nrhs) {
-	/* ALLOCATE memory for the output array of the same size as the input */
-	m = mxGetM(prhs[1]);
-	n = mxGetN(prhs[1]);
-	if(m!=6)
-		mexErrMsgTxt("Second argument must be a 6 x N matrix");
-   
-	
-	tmpmxptr=mxGetField(prhs[0],0,"KickAngle");
-	if(tmpmxptr)
-        kickptr = mxGetPr(tmpmxptr);
-    else
-		mexErrMsgTxt("Required field 'KickAngle' was not found in the element data structure"); 
-
-				
-	tmpmxptr=mxGetField(prhs[0],0,"Length");
-	if(tmpmxptr)
-		le = mxGetScalar(tmpmxptr);
-	else
-		mexErrMsgTxt("Required field 'Length' was not found in the element data structure"); 
-
-	
-	plhs[0] = mxDuplicateArray(prhs[1]);
-	r_in = mxGetPr(plhs[0]);
-	CorrectorPass(r_in, kickptr[0], kickptr[1],le, n);	
-    }
-    else {   /* return list of required fields */
+    if (nrhs == 2) {
+        double Length;
+        double *KickAngle;
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        KickAngle = atGetDoubleArray(ElemData, "KickAngle");
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+        CorrectorPass(r_in, KickAngle[0], KickAngle[1], Length, num_particles);
+      }
+    else {
 	    plhs[0] = mxCreateCellMatrix(2,1);
 	    mxSetCell(plhs[0],0,mxCreateString("Length"));
 	    mxSetCell(plhs[0],1,mxCreateString("KickAngle"));
 	    if(nlhs>1) /* Required and optional fields */ 
 	    {   plhs[1] = mxCreateCellMatrix(0,0); /* No optional fields */
 	    }
-	}
+    }
 }
-#endif
+#endif /*MATLAB_MEX_FILE*/

--- a/atintegrators/DeltaQPass.c
+++ b/atintegrators/DeltaQPass.c
@@ -164,7 +164,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         DeltaQPass(r_in, num_particles, alphax, alphay, 
             betax, betay, qpx, qpy,
             a1, a2, a3, T1, T2, R1, R2);

--- a/atintegrators/DriftPass.c
+++ b/atintegrators/DriftPass.c
@@ -107,7 +107,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         DriftPass(r_in, Length, T1, T2, R1, R2, RApertures, EApertures, num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/EAperturePass.c
+++ b/atintegrators/EAperturePass.c
@@ -52,7 +52,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         EAperturePass(r_in,Axes, num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -18,10 +18,10 @@ struct elem {
     double Length;
     double *xkick;
     double *ykick;
-    double *xtable;
-    double *ytable;
-    int n_map;
-    int m_map;
+    double *x_map;
+    double *y_map;
+    int nx_map;
+    int ny_map;
     int Nslice;
     /* Optional fields */
     double *xkick1;
@@ -32,48 +32,45 @@ struct elem {
     double *T2;
 };
 
-double *GLOBAL_x, *GLOBAL_y;
-int GLOBAL_m,GLOBAL_n;
+double *GLOBAL_x_map, *GLOBAL_y_map;
+int GLOBAL_nx_map,GLOBAL_ny_map;
 
 static double get_kick(double *r6, double *ktable)
 {
     double f;
     /*cubic interpolation*/
-    /*splin2(GLOBAL_y,GLOBAL_x,GLOBAL_xkick,GLOBAL_xkick2,GLOBAL_n,GLOBAL_m,y,x,&f);*/
+    /*splin2(GLOBAL_y_map,GLOBAL_x_map,GLOBAL_xkick,GLOBAL_xkick2,GLOBAL_n,GLOBAL_nx,y,x,&f);*/
     
     /*biliniar interpolation*/
 #ifdef MATLAB_MEX_FILE
-    /* Transpose coordinates because kick-table is FORTRAN-ordered */
-    linint(GLOBAL_y, GLOBAL_x, ktable, GLOBAL_m, GLOBAL_n, r6[2], r6[0], &f);
+    /* Transpose coordinates because the kick-table is FORTRAN-ordered */
+    linint(GLOBAL_y_map, GLOBAL_x_map, ktable, GLOBAL_ny_map, GLOBAL_nx_map, r6[2], r6[0], &f);
 #else
-    /* Assume kick-table is C-ordered */
-    linint(GLOBAL_x, GLOBAL_y, ktable, GLOBAL_m, GLOBAL_n, r6[0], r6[2], &f);
+    /* Assume the kick-table is C-ordered */
+    linint(GLOBAL_x_map, GLOBAL_y_map, ktable, GLOBAL_nx_map, GLOBAL_ny_map, r6[0], r6[2], &f);
 #endif
     return f;
  }
 
 void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1,
-        double *xkick, double *ykick, double *x, double *y,int n,int m, int Nslice,
+        double *xkick, double *ykick, double *x_map, double *y_map,int nx_map,int ny_map, int Nslice,
         double *T1, double *T2, double *R1, double *R2, int num_particles)
 {
     double *r6, deltaxp, deltayp, limitsptr[4];
-    int c;
+    int c, ns;
     double L1 = le/(2*Nslice);
     
     /*Act as AperturePass*/
-    limitsptr[0]=x[0];
-    limitsptr[1]=x[n-1];
-    limitsptr[2]=y[0];
-    limitsptr[3]=y[m-1];
+    limitsptr[0]=x_map[0];
+    limitsptr[1]=x_map[nx_map-1];
+    limitsptr[2]=y_map[0];
+    limitsptr[3]=y_map[ny_map-1];
     
-    /*globalize*/
-    
-    /* For cubic interpolation only*/
-    
-    GLOBAL_x=x;
-    GLOBAL_y=y;
-    GLOBAL_m=m; /* y used as colums*/
-    GLOBAL_n=n; /* x used as rows*/
+    /*globalize*/    
+    GLOBAL_x_map=x_map;
+    GLOBAL_y_map=y_map;
+    GLOBAL_nx_map=nx_map;
+    GLOBAL_ny_map=ny_map;
     
     for (c=0; c<num_particles; c++) {
         r6 = r+c*6;
@@ -82,9 +79,9 @@ void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1,
             if (T1) ATaddvv(r6,T1);
             if (R1) ATmultmv(r6,R1);
             /* Check physical apertures at the entrance of the magnet */
-              checkiflostRectangularAp(r6, limitsptr);
+            checkiflostRectangularAp(r6, limitsptr);
             /*Tracking in the main body*/
-            for (m=0; m<Nslice; m++) { /* Loop over slices*/
+            for (ns=0; ns<Nslice; ns++) { /* Loop over slices*/
                 ATdrift6(r6,L1);
                 if (!atIsNaN(r6[0])&&!atIsNaN(r6[2])) {
                     /*The kick from IDs varies quadratically, not linearly, with energy.   */
@@ -109,15 +106,15 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         double *r_in, int num_particles, struct parameters *Param)
 {
     if (!Elem) {
-        int Nslice, n_map,m_map;
-        double Length, *xkick, *ykick, *xtable, *ytable;
+        int Nslice, ny_map,nx_map;
+        double Length, *xkick, *ykick, *x_map, *y_map;
         double *xkick1, *ykick1;
         double *R1, *R2, *T1, *T2;
         Length=atGetDouble(ElemData,"Length"); check_error();
-        xkick=atGetDoubleArray(ElemData,"xkick"); check_error();
+        xkick=atGetDoubleArraySz(ElemData,"xkick", &nx_map, &ny_map); check_error();
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
-        xtable=atGetDoubleArraySz(ElemData,"xtable", &m_map, &n_map); check_error();
-        ytable=atGetDoubleArray(ElemData,"ytable"); check_error();
+        x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
+        y_map=atGetDoubleArray(ElemData,"ytable"); check_error();
         Nslice=atGetLong(ElemData,"Nslice"); check_error();
         /*optional fields*/
         xkick1=atGetOptionalDoubleArray(ElemData,"xkick1"); check_error();
@@ -130,10 +127,10 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->Length=Length;
         Elem->xkick=xkick;
         Elem->ykick=ykick;
-        Elem->xtable=xtable;
-        Elem->ytable=ytable;
-        Elem->n_map=n_map;
-        Elem->m_map=m_map;
+        Elem->x_map=x_map;
+        Elem->y_map=y_map;
+        Elem->nx_map=nx_map;
+        Elem->ny_map=ny_map;
         Elem->Nslice=Nslice;
         Elem->xkick1=xkick1;
         Elem->ykick1=ykick1;
@@ -143,7 +140,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->T2=T2;
     }
     IdKickMapModelPass(r_in, Elem->Length, Elem->xkick1, Elem->ykick1,
-            Elem->xkick, Elem->ykick, Elem->xtable, Elem->ytable, Elem->n_map, Elem->m_map,Elem->Nslice,
+            Elem->xkick, Elem->ykick, Elem->x_map, Elem->y_map, Elem->nx_map, Elem->ny_map,Elem->Nslice,
             Elem->T1, Elem->T2, Elem->R1, Elem->R2, num_particles);
     return Elem;
 }
@@ -155,18 +152,18 @@ MODULE_DEF(IdTablePass)        /* Dummy module initialisation */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
-        int Nslice, n_map,m_map;
-        double Length, *xkick, *ykick, *xtable, *ytable;
+        int Nslice, ny_map, nx_map;
+        double Length, *xkick, *ykick, *x_map, *y_map;
         double *xkick1, *ykick1;
         double *R1, *R2, *T1, *T2;
         double *r_in;
         const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
         Length=atGetDouble(ElemData,"Length"); check_error();
-        xkick=atGetDoubleArray(ElemData,"xkick"); check_error();
+        xkick=atGetDoubleArraySz(ElemData,"xkick", &nx_map, &ny_map); check_error();
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
-        xtable=atGetDoubleArraySz(ElemData,"xtable", &m_map, &n_map); check_error();
-        ytable=atGetDoubleArray(ElemData,"ytable"); check_error();
+        x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
+        y_map=atGetDoubleArray(ElemData,"ytable"); check_error();
         Nslice=atGetLong(ElemData,"Nslice"); check_error();
         /*optional fields*/
         xkick1=atGetOptionalDoubleArray(ElemData,"xkick1"); check_error();
@@ -178,8 +175,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetPr(plhs[0]);
-        IdKickMapModelPass(r_in, Length, xkick1, ykick1, xkick, ykick, xtable, ytable,
-                n_map, m_map, Nslice, T1, T2, R1, R2, num_particles);
+        IdKickMapModelPass(r_in, Length, xkick1, ykick1, xkick, ykick, x_map, y_map,
+                nx_map, ny_map, Nslice, T1, T2, R1, R2, num_particles);
     }
     else if (nrhs == 0) {
         /* return list of required fields */

--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -152,13 +152,13 @@ MODULE_DEF(IdTablePass)        /* Dummy module initialisation */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
         int Nslice, ny_map, nx_map;
         double Length, *xkick, *ykick, *x_map, *y_map;
         double *xkick1, *ykick1;
         double *R1, *R2, *T1, *T2;
-        double *r_in;
-        const mxArray *ElemData = prhs[0];
-        int num_particles = mxGetN(prhs[1]);
         Length=atGetDouble(ElemData,"Length"); check_error();
         xkick=atGetDoubleArraySz(ElemData,"xkick", &nx_map, &ny_map); check_error();
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
@@ -174,7 +174,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         IdKickMapModelPass(r_in, Length, xkick1, ykick1, xkick, ykick, x_map, y_map,
                 nx_map, ny_map, Nslice, T1, T2, R1, R2, num_particles);
     }

--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -10,78 +10,57 @@
  *
  */
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
 #include "interpolate.c"
 
-double *GLOBAL_x,*GLOBAL_y,*GLOBAL_xkick1,*GLOBAL_ykick1,*GLOBAL_xkick,*GLOBAL_ykick,*GLOBAL_xkick2,*GLOBAL_ykick2;
+struct elem {
+    double Length;
+    double *xkick;
+    double *ykick;
+    double *xtable;
+    double *ytable;
+    int n_map;
+    int m_map;
+    int Nslice;
+    /* Optional fields */
+    double *xkick1;
+    double *ykick1;
+    double *R1;
+    double *R2;
+    double *T1;
+    double *T2;
+};
+
+double *GLOBAL_x, *GLOBAL_y;
 int GLOBAL_m,GLOBAL_n;
 
-/*Definition of the interpolated functions*/
-static double Map_x(double x,double y)
+static double get_kick(double *r6, double *ktable)
 {
     double f;
     /*cubic interpolation*/
     /*splin2(GLOBAL_y,GLOBAL_x,GLOBAL_xkick,GLOBAL_xkick2,GLOBAL_n,GLOBAL_m,y,x,&f);*/
     
     /*biliniar interpolation*/
-    linint(GLOBAL_y,GLOBAL_x,GLOBAL_xkick,GLOBAL_m,GLOBAL_n,y,x,&f);
+#ifdef MATLAB_MEX_FILE
+    /* Transpose coordinates because kick-table is FORTRAN-ordered */
+    linint(GLOBAL_y, GLOBAL_x, ktable, GLOBAL_m, GLOBAL_n, r6[2], r6[0], &f);
+#else
+    /* Assume kick-table is C-ordered */
+    linint(GLOBAL_x, GLOBAL_y, ktable, GLOBAL_m, GLOBAL_n, r6[0], r6[2], &f);
+#endif
     return f;
-}
+ }
 
-static double Map_y(double x,double y)
+void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1,
+        double *xkick, double *ykick, double *x, double *y,int n,int m, int Nslice,
+        double *T1, double *T2, double *R1, double *R2, int num_particles)
 {
-    double f;
-    /*cubic interpolation*/
-    /*splin2(GLOBAL_y,GLOBAL_x,GLOBAL_ykick,GLOBAL_ykick2,GLOBAL_m,GLOBAL_n,y,x,&f);*/
-    
-    /*biliniar interpolation*/
-    linint(GLOBAL_y,GLOBAL_x,GLOBAL_ykick,GLOBAL_m,GLOBAL_n,y,x,&f);
-    return f;
-}
-
-static double Map1_x(double x,double y)
-{
-    double f;
-    /*cubic interpolation*/
-    /*splin2(GLOBAL_y,GLOBAL_x,GLOBAL_xkick1,GLOBAL_xkick2,GLOBAL_n,GLOBAL_m,y,x,&f);*/
-    
-    /*biliniar interpolation*/
-    linint(GLOBAL_y,GLOBAL_x,GLOBAL_xkick1,GLOBAL_m,GLOBAL_n,y,x,&f);
-    return f;
-}
-
-static double Map1_y(double x,double y)
-{
-    double f;
-    /*cubic interpolation*/
-    /*splin2(GLOBAL_y,GLOBAL_x,GLOBAL_ykick1,GLOBAL_ykick2,GLOBAL_m,GLOBAL_n,y,x,&f);*/
-    
-    /*biliniar interpolation*/
-    linint(GLOBAL_y,GLOBAL_x,GLOBAL_ykick1,GLOBAL_m,GLOBAL_n,y,x,&f);
-    return f;
-}
-/*
-static void markaslost(double *r6,int idx)
-{
-    r6[idx] = mxGetInf();
-}
-*/
-/* Set T1, T2, R1, R2 to NULL pointers to ignore misalignmets*/
-void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1, double *xkick, double *ykick, double *x, double *y,int n,int m, int Nslice, double *T1, double *T2, double *R1, double *R2, int num_particles)
-{
-    double *r6,deltaxp,deltayp,deltaxp1,deltayp1,*limitsptr;
+    double *r6, deltaxp, deltayp, limitsptr[4];
     int c;
-    bool usexkick1 = (xkick1 != NULL);
-    bool useykick1 = (ykick1 != NULL);
-    bool useT1 = (T1 != NULL);
-    bool useT2 = (T2 != NULL);
-    bool useR1 = (R1 != NULL);
-    bool useR2 = (R2 != NULL);
     double L1 = le/(2*Nslice);
     
     /*Act as AperturePass*/
-    limitsptr=(double*)mxCalloc(4,sizeof(double));
     limitsptr[0]=x[0];
     limitsptr[1]=x[n-1];
     limitsptr[2]=y[0];
@@ -91,179 +70,116 @@ void IdKickMapModelPass(double *r, double le, double *xkick1, double *ykick1, do
     
     /* For cubic interpolation only*/
     
-    /*GLOBAL_xkick2=(double*)mxCalloc(n*m,sizeof(double));
-     * GLOBAL_ykick2=(double*)mxCalloc(n*m,sizeof(double));
-     * splie2(y,x,xkick,m,n,GLOBAL_xkick2);
-     * splie2(y,x,ykick,m,n,GLOBAL_ykick2); */
-    
     GLOBAL_x=x;
     GLOBAL_y=y;
-    GLOBAL_xkick1=xkick1;
-    GLOBAL_ykick1=ykick1;
-    GLOBAL_xkick=xkick;
-    GLOBAL_ykick=ykick;
     GLOBAL_m=m; /* y used as colums*/
     GLOBAL_n=n; /* x used as rows*/
     
     for (c=0; c<num_particles; c++) {
         r6 = r+c*6;
-        
-        if(!mxIsNaN(r6[0]) && mxIsFinite(r6[4])) {
-            /*
-             * function bend6 internally calculates the square root
-             * of the energy deviation of the particle
-             * To protect against DOMAIN and OVERFLOW error, check if the
-             * fifth component of the phase spacevector r6[4] is finite
-             */
-            if (r6[0]<limitsptr[0] || r6[0]>limitsptr[1])
-                markaslost(r6,0);
-            else if (r6[2]<limitsptr[2] || r6[2]>limitsptr[3])
-                markaslost(r6,2);
-            else {
-                /* Misalignment at entrance */
-                if (useT1) ATaddvv(r6,T1);
-                if (useR1) ATmultmv(r6,R1);
-                /*Tracking in the main body*/
-                for (m=0; m<Nslice; m++) { /* Loop over slices*/
-                    ATdrift6(r6,L1);
-                    if (!mxIsNaN(r6[0])&&!mxIsNaN(r6[2])) {
-                        /*The kick from IDs varies quadratically, not linearly, with energy.   */
-                        deltaxp = (1.0/Nslice)*Map_x(r6[0],r6[2])/(1.0+r6[4]);
-                        deltayp = (1.0/Nslice)*Map_y(r6[0],r6[2])/(1.0+r6[4]);
-                        if(usexkick1)  deltaxp1 = (1.0/Nslice)*Map1_x(r6[0],r6[2]);
-                        if(useykick1)  deltayp1 = (1.0/Nslice)*Map1_y(r6[0],r6[2]);
-                        r6[1] = r6[1] + deltaxp;
-                        if(usexkick1) r6[1]=r6[1]+deltaxp1;
-                        r6[3] = r6[3] + deltayp;
-                        if(useykick1) r6[3]= r6[3] + deltayp1;
-                    }
-                    ATdrift6(r6,L1);
+        if (!atIsNaN(r6[0])) {
+            /* Misalignment at entrance */
+            if (T1) ATaddvv(r6,T1);
+            if (R1) ATmultmv(r6,R1);
+            /* Check physical apertures at the entrance of the magnet */
+              checkiflostRectangularAp(r6, limitsptr);
+            /*Tracking in the main body*/
+            for (m=0; m<Nslice; m++) { /* Loop over slices*/
+                ATdrift6(r6,L1);
+                if (!atIsNaN(r6[0])&&!atIsNaN(r6[2])) {
+                    /*The kick from IDs varies quadratically, not linearly, with energy.   */
+                    deltaxp = get_kick(r6, xkick)/(1.0+r6[4]);
+                    deltayp = get_kick(r6, ykick)/(1.0+r6[4]);
+                    if (xkick1)  deltaxp += get_kick(r6, xkick1);
+                    if (ykick1)  deltayp += get_kick(r6, ykick1);
+                    r6[1] = r6[1] + deltaxp / Nslice;
+                    r6[3] = r6[3] + deltayp / Nslice;
                 }
-                /* Misalignment at exit */
-                if (useR2) ATmultmv(r6,R2);
-                if (useT2) ATaddvv(r6,T2);
+                ATdrift6(r6,L1);
             }
+            /* Misalignment at exit */
+            if (R2) ATmultmv(r6,R2);
+            if (T2) ATaddvv(r6,T2);
         }
     }
 }
 
-MODULE_DEF(IdTablePass)        /* Dummy module initialisation */
-
-#ifdef MATLAB_MEX_FILE
-
-#include "elempass.h"
-#include "mxutils.c"
-
-ExportMode int* passFunction(const mxArray *ElemData,int *FieldNumbers,
-        double *r_in,int num_particles,int mode)
-#define NUM_FIELDS_2_REMEMBER 12
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
 {
-    int n_map,m_map;
-    int Nslice;
-    double le;
-    double *pr1, *pr2, *pt1, *pt2, *xkick, *ykick, *xkick1, *ykick1, *x, *y;
-    
-    switch(mode) {
-        case MAKE_LOCAL_COPY:
-            /* Find field numbers first
-             * Save a list of field number in an array
-             * and make returnptr point to that array
-             */
-            FieldNumbers = (int*)mxCalloc(NUM_FIELDS_2_REMEMBER,sizeof(int));
-            
-            FieldNumbers[0] = GetRequiredFieldNumber(ElemData, "Length");
-            FieldNumbers[1] = GetRequiredFieldNumber(ElemData, "xkick");
-            FieldNumbers[2] = GetRequiredFieldNumber(ElemData, "ykick");
-            FieldNumbers[3] = GetRequiredFieldNumber(ElemData, "xtable");
-            FieldNumbers[4] = GetRequiredFieldNumber(ElemData, "ytable");
-            FieldNumbers[5] = GetRequiredFieldNumber(ElemData, "Nslice");
-            
-            /* Optional fields */
-            
-            FieldNumbers[6] = mxGetFieldNumber(ElemData, "xkick1");
-            FieldNumbers[7] = mxGetFieldNumber(ElemData, "ykick1");
-            FieldNumbers[8] = mxGetFieldNumber(ElemData, "R1");
-            FieldNumbers[9] = mxGetFieldNumber(ElemData, "R2");
-            FieldNumbers[10] = mxGetFieldNumber(ElemData, "T1");
-            FieldNumbers[11] = mxGetFieldNumber(ElemData, "T2");
-            /* Fall through next section... */
-            
-        case	USE_LOCAL_COPY:
-            /* Get fields from MATLAB using field numbers
-             * The second argument ponter to the array of field
-             * numbers is previously created with
-             * BendLinearPass( ..., MAKE_LOCAL_COPY)
-             */
-            le = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[0]));
-            xkick = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[1]));
-            ykick = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[2]));
-            x = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[3]));
-            y = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[4]));
-            Nslice = (int)mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[5]));
-            
-            n_map = mxGetN(mxGetFieldByNumber(ElemData,0,FieldNumbers[1]));
-            m_map = mxGetM(mxGetFieldByNumber(ElemData,0,FieldNumbers[1]));
-            
-            /* Optional fields */
-            
-            xkick1 = (FieldNumbers[6] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[6])) : NULL;
-            ykick1 = (FieldNumbers[7] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[7])) : NULL;
-            pr1 = (FieldNumbers[8] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[8])) : NULL;
-            pr2 = (FieldNumbers[9] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[9])) : NULL;
-            pt1 = (FieldNumbers[10] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[10])) : NULL;
-            pt2 = (FieldNumbers[11] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[11])) : NULL;
-            break;
+    if (!Elem) {
+        int Nslice, n_map,m_map;
+        double Length, *xkick, *ykick, *xtable, *ytable;
+        double *xkick1, *ykick1;
+        double *R1, *R2, *T1, *T2;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        xkick=atGetDoubleArray(ElemData,"xkick"); check_error();
+        ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
+        xtable=atGetDoubleArraySz(ElemData,"xtable", &m_map, &n_map); check_error();
+        ytable=atGetDoubleArray(ElemData,"ytable"); check_error();
+        Nslice=atGetLong(ElemData,"Nslice"); check_error();
+        /*optional fields*/
+        xkick1=atGetOptionalDoubleArray(ElemData,"xkick1"); check_error();
+        ykick1=atGetOptionalDoubleArray(ElemData,"ykick1"); check_error();
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->Length=Length;
+        Elem->xkick=xkick;
+        Elem->ykick=ykick;
+        Elem->xtable=xtable;
+        Elem->ytable=ytable;
+        Elem->n_map=n_map;
+        Elem->m_map=m_map;
+        Elem->Nslice=Nslice;
+        Elem->xkick1=xkick1;
+        Elem->ykick1=ykick1;
+        Elem->R1=R1;
+        Elem->R2=R2;
+        Elem->T1=T1;
+        Elem->T2=T2;
     }
-    
-    IdKickMapModelPass(r_in, le,xkick1,ykick1,xkick,ykick,x,y,n_map,m_map,Nslice,
-            pt1, pt2, pr1, pr2, num_particles);
-    
-    return FieldNumbers;
+    IdKickMapModelPass(r_in, Elem->Length, Elem->xkick1, Elem->ykick1,
+            Elem->xkick, Elem->ykick, Elem->xtable, Elem->ytable, Elem->n_map, Elem->m_map,Elem->Nslice,
+            Elem->T1, Elem->T2, Elem->R1, Elem->R2, num_particles);
+    return Elem;
 }
 
+MODULE_DEF(IdTablePass)        /* Dummy module initialisation */
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
+#ifdef MATLAB_MEX_FILE
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
+        int Nslice, n_map,m_map;
+        double Length, *xkick, *ykick, *xtable, *ytable;
+        double *xkick1, *ykick1;
+        double *R1, *R2, *T1, *T2;
         double *r_in;
-        double *xkick1, *ykick1, *pr1, *pr2, *pt1, *pt2;
-        mxArray *tmpmxptr = GetRequiredField(prhs[0], "xkick");
-        
-        double le = mxGetScalar(GetRequiredField(prhs[0], "Length"));
-        double *xkick =  mxGetPr(tmpmxptr);
-        int n_map = mxGetN(tmpmxptr);
-        int m_map = mxGetM(tmpmxptr);
-        double *ykick =  mxGetPr(GetRequiredField(prhs[0], "ykick"));
-        double *x =  mxGetPr(GetRequiredField(prhs[0], "xtable"));
-        double *y =  mxGetPr(GetRequiredField(prhs[0], "ytable"));
-        int Nslice = (int)mxGetScalar(GetRequiredField(prhs[0], "Nslice"));
+        const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
-        if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
-        
-        /*Optional fields*/
-        
-        tmpmxptr = mxGetField(prhs[0],0,"xkick1");
-        xkick1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"ykick1");
-        ykick1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"R1");
-        pr1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"R2");
-        pr2 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"T1");
-        pt1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"T2");
-        pt2 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        xkick=atGetDoubleArray(ElemData,"xkick"); check_error();
+        ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
+        xtable=atGetDoubleArraySz(ElemData,"xtable", &m_map, &n_map); check_error();
+        ytable=atGetDoubleArray(ElemData,"ytable"); check_error();
+        Nslice=atGetLong(ElemData,"Nslice"); check_error();
+        /*optional fields*/
+        xkick1=atGetOptionalDoubleArray(ElemData,"xkick1"); check_error();
+        ykick1=atGetOptionalDoubleArray(ElemData,"ykick1"); check_error();
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetPr(plhs[0]);
-        IdKickMapModelPass(r_in, le, xkick1,ykick1, xkick,ykick,x,y,n_map,m_map,Nslice,
-                pt1, pt2, pr1, pr2, num_particles);
+        IdKickMapModelPass(r_in, Length, xkick1, ykick1, xkick, ykick, xtable, ytable,
+                n_map, m_map, Nslice, T1, T2, R1, R2, num_particles);
     }
     else if (nrhs == 0) {
         /* return list of required fields */
@@ -275,7 +191,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mxSetCell(plhs[0],4,mxCreateString("ytable"));
         mxSetCell(plhs[0],5,mxCreateString("Nslice"));
         
-        if (nlhs>1) {
+        if (nlhs > 1) {
             /* Required and optional fields */
             plhs[1] = mxCreateCellMatrix(6,1);
             mxSetCell(plhs[1],0,mxCreateString("xkick1"));

--- a/atintegrators/IdentityPass.c
+++ b/atintegrators/IdentityPass.c
@@ -88,7 +88,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         IdentityPass(r_in,T1,T2,R1,R2,RApertures,EApertures,num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/ImpedanceTablePass.c
+++ b/atintegrators/ImpedanceTablePass.c
@@ -353,7 +353,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix: particle array");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         impedance_tablePass(r_in, num_particles, Elem);
     }
     else if (nrhs == 0) {

--- a/atintegrators/Matrix66Pass.c
+++ b/atintegrators/Matrix66Pass.c
@@ -74,7 +74,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         Matrix66Pass(r_in, M66, T1, T2, R1, R2, num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/MatrixTijkPass.c
+++ b/atintegrators/MatrixTijkPass.c
@@ -3,8 +3,19 @@
 */
 
 
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
+
+struct elem {
+    double Length;
+    double *M66;
+    double *Tijk;
+    /* Optional fields */
+    double *R1;
+    double *R2;
+    double *T1;
+    double *T2;
+};
 
 static void ATmultTijk(double *r, const double* T)
 /*	multiplies 6-component column vector r by 6x6x6 tensor T:
@@ -27,7 +38,7 @@ static void ATmultTijk(double *r, const double* T)
 	r[i]+=temp[i];
 } 
 
-void MatrixTijkPass(double *r, const double *M, const double *Tijk,
+void MatrixTijkPass(double *r, const double *M66, const double *Tijk,
         const double *T1, const double *T2,
         const double *R1, const double *R2, int num_particles)
 
@@ -37,106 +48,76 @@ void MatrixTijkPass(double *r, const double *M, const double *Tijk,
     
     for (c = 0; c<num_particles; c++) {	/*Loop over particles  */
         r6 = r+c*6;
-        if (!mxIsNaN(r6[0])) {
-            if (T1 != NULL) ATaddvv(r6, T1);
-            if (R1 != NULL) ATmultmv(r6, R1);
-            ATmultmv(r6, M);
+        if (!atIsNaN(r6[0])) {
+            /* Misalignment at entrance */
+            if (T1) ATaddvv(r6, T1);
+            if (R1) ATmultmv(r6, R1);
+            ATmultmv(r6, M66);
             ATmultTijk(r6,Tijk);
-            if (R2 != NULL) ATmultmv(r6, R2);
-            if (T2 != NULL) ATaddvv(r6, T2);
+            /* Misalignment at exit */
+            if (R2) ATmultmv(r6, R2);
+            if (T2) ATaddvv(r6, T2);
         }
 	}
 }
 
-MODULE_DEF(MatrixTijkPass)        /* Dummy module initialisation */
-
-#ifdef MATLAB_MEX_FILE
-
-#include "elempass.h"
-#include "mxutils.c"
-
-ExportMode int* passFunction(const mxArray *ElemData,int *FieldNumbers,
-        double *r_in, int num_particles, int mode)
-
-#define NUM_FIELDS_2_REMEMBER 5
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
 {
-    double *M, *T;
-    double  *pr1, *pr2, *pt1, *pt2;
-    
-    switch(mode) {
-        case MAKE_LOCAL_COPY: 	/* Find field numbers first
-         * Save a list of field number in an array
-         * and make returnptr point to that array
-         */
-            FieldNumbers = (int *) mxCalloc(NUM_FIELDS_2_REMEMBER,sizeof(int));
-            FieldNumbers[0] = GetRequiredFieldNumber(ElemData, "M66");
-            FieldNumbers[1] = GetRequiredFieldNumber(ElemData, "Tijk");
-            
-            
-            FieldNumbers[2] = mxGetFieldNumber(ElemData,"R1");
-            FieldNumbers[3] = mxGetFieldNumber(ElemData,"R2");
-            FieldNumbers[4] = mxGetFieldNumber(ElemData,"T1");
-            FieldNumbers[5] = mxGetFieldNumber(ElemData,"T2");
-            /* Fall through next section... */
-            
-        case	USE_LOCAL_COPY:	/* Get fields from MATLAB using field numbers
-         * The second argument ponter to the array of field
-         * numbers is previously created with
-         * QuadLinPass( ..., MAKE_LOCAL_COPY)
-         */
-            M = mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[0]));
-            T = mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[1]));
-            
-            /* Optional fields */
-            pr1 = (FieldNumbers[2] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[2])) : NULL;
-            pr2 = (FieldNumbers[3] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[3])) : NULL;
-            pt1 = (FieldNumbers[4] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[4])) : NULL;
-            pt2 = (FieldNumbers[5] >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData, 0, FieldNumbers[5])) : NULL;
-            break;
-            
-        default:
-            mexErrMsgTxt("No match for calling mode in function MatrixTijkPass\n");
-            
+    if (!Elem) {
+        double Length=0.0, *M66, *Tijk;
+        double *R1, *R2, *T1, *T2;
+/*      Length=atGetDouble(ElemData,"Length"); check_error();*/
+        M66=atGetDoubleArray(ElemData,"M66"); check_error();
+        Tijk=atGetDoubleArray(ElemData,"Tijk"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->Length=Length;
+        Elem->M66=M66;
+        Elem->Tijk=Tijk;
+        /*optional fields*/
+        Elem->R1=R1;
+        Elem->R2=R2;
+        Elem->T1=T1;
+        Elem->T2=T2;
     }
-    MatrixTijkPass(r_in, M, T, pt1, pt2, pr1, pr2, num_particles);
-    return FieldNumbers;
+    MatrixTijkPass(r_in, Elem->M66, Elem->Tijk, Elem->T1, Elem->T2, Elem->R1, Elem->R2, num_particles);
+    return Elem;
 }
 
+MODULE_DEF(MatrixTijkPass)        /* Dummy module initialisation */
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
+#ifdef MATLAB_MEX_FILE
 void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
         double *r_in;
-        double  *pr1, *pr2, *pt1, *pt2;
-        mxArray *tmpmxptr;
-        
-        double *M = mxGetPr(GetRequiredField(prhs[0], "M66"));
-        double *T = mxGetPr(GetRequiredField(prhs[0], "Tijk"));
-        
+        const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
-        if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
-        
-        /* Optional arguments */
-        tmpmxptr = mxGetField(prhs[0],0,"R1");
-        pr1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"R2");
-        pr2 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"T1");
-        pt1 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
-        
-        tmpmxptr = mxGetField(prhs[0],0,"T2");
-        pt2 = tmpmxptr ? mxGetPr(tmpmxptr) : NULL;
- 		
+        double Length, *M66, *Tijk;
+        double *R1, *R2, *T1, *T2;
+/*      Length=atGetDouble(ElemData,"Length"); check_error();*/
+        M66=atGetDoubleArray(ElemData,"M66"); check_error();
+        Tijk=atGetDoubleArray(ElemData,"Tijk"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error(); 		
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
-        MatrixTijkPass(r_in, M, T, pt1, pt2, pr1, pr2, num_particles);	
+        r_in = mxGetDoubles(plhs[0]);
+        MatrixTijkPass(r_in, M66, Tijk, T1, T2, R1, R2, num_particles);	
 	}
     else if (nrhs == 0) {
         /* list of required fields */
-	    plhs[0] = mxCreateCellMatrix(1,1);
+	    plhs[0] = mxCreateCellMatrix(2,1);
 	    mxSetCell(plhs[0],0,mxCreateString("M66"));
 	    mxSetCell(plhs[0],1,mxCreateString("Tijk"));
 	    if (nlhs>1) {

--- a/atintegrators/QuadLinearPass.c
+++ b/atintegrators/QuadLinearPass.c
@@ -163,12 +163,12 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (nrhs == 0) {
         /* list of required fields */
-        plhs[0] = mxCreateCellMatrix(5,1);
+        plhs[0] = mxCreateCellMatrix(2,1);
         mxSetCell(plhs[0],0,mxCreateString("Length"));
-        mxSetCell(plhs[0],4,mxCreateString("K"));
+        mxSetCell(plhs[0],1,mxCreateString("K"));
         if (nlhs>1) {
             /* list of optional fields */
-            plhs[1] = mxCreateCellMatrix(8,1);
+            plhs[1] = mxCreateCellMatrix(4,1);
             mxSetCell(plhs[1],0,mxCreateString("T1"));
             mxSetCell(plhs[1],1,mxCreateString("T2"));
             mxSetCell(plhs[1],2,mxCreateString("R1"));

--- a/atintegrators/QuadLinearPass.c
+++ b/atintegrators/QuadLinearPass.c
@@ -158,7 +158,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         K=atGetOptionalDouble(ElemData,"K", PolynomB ? PolynomB[1] : 0.0); check_error();
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         QuadLinearPass(r_in,Length,K,T1,T2,R1,R2,num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -149,7 +149,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         QuantDiffPass(r_in, Lmatp, Seed, 0, num_particles);
     }
     else if (nrhs == 0) {

--- a/atintegrators/RFCavityPass.c
+++ b/atintegrators/RFCavityPass.c
@@ -113,7 +113,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
       if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
       /* ALLOCATE memory for the output array of the same size as the input  */
       plhs[0] = mxDuplicateArray(prhs[1]);
-      r_in = mxGetPr(plhs[0]);
+      r_in = mxGetDoubles(plhs[0]);
       RFCavityPass(r_in, Length, Voltage/Energy, Frequency, HarmNumber, TimeLag, 0, T0, num_particles);
 
     }

--- a/atintegrators/SolenoidLinearPass.c
+++ b/atintegrators/SolenoidLinearPass.c
@@ -7,6 +7,16 @@
 #include "atelem.c"
 #include "atlalib.c"
 
+struct elem {
+    double Length;
+    double ks;
+    /* Optional fields */
+    double *R1;
+    double *R2;
+    double *T1;
+    double *T2;
+};
+
 void SolenoidLinearPass(double *r_in, double le, double ks, double *T1, double *T2, double *R1, double *R2, int num_particles)
 /* Constant field hard edge model is assumed
    le - physical length
@@ -17,39 +27,14 @@ void SolenoidLinearPass(double *r_in, double le, double ks, double *T1, double *
 {	int c;
 	double *r6, p_norm, H, S, C, x, xpr, y, ypr, NormL;
 	
-	bool useT1, useT2, useR1, useR2;
-	
-	if (T1==NULL)
-	    useT1=false;
-	else 
-	    useT1=true;  
-	    
-    if (T2==NULL)
-	    useT2=false; 
-	else 
-	    useT2=true;  
-	
-	if (R1==NULL)
-	    useR1=false;
-	else 
-	    useR1=true;  
-	    
-    if (R2==NULL)
-	    useR2=false;
-	else 
-	    useR2=true;
-	
-	if(ks!=0)
-	    for(c = 0;c<num_particles;c++)
-		{	r6= r_in+c*6;
+	if (ks!=0)
+	    for (c = 0;c<num_particles;c++) {
+		    r6 = r_in+c*6;
 			p_norm = 1/(1+r6[4]); 
-			
-			
-			/* Misalignment at entrance */
-	        if (useT1)
-			    ATaddvv(r6,T1);
-			if (useR1)
-			    ATmultmv(r6,R1);
+
+            /* Misalignment at entrance */
+	        if (T1) ATaddvv(r6,T1);
+			if (R1) ATmultmv(r6,R1);
 			    
 			x   = r6[0];
 	        xpr = r6[1]*p_norm;
@@ -59,7 +44,6 @@ void SolenoidLinearPass(double *r_in, double le, double ks, double *T1, double *
 			S  = sin(le*H);
 			C  = cos(le*H);
 			
-			
 			r6[0]=     x*C*C         +  xpr*C*S/H       +   y*C*S         +   ypr*S*S/H;
 	        r6[1]= ( - x*H*C*S       +  xpr*C*C         -   y*H*S*S       +   ypr*C*S         )/p_norm; 
             r6[2]=   - x*C*S         -  xpr*S*S/H       +   y*C*C         +   ypr*C*S/H;
@@ -67,223 +51,89 @@ void SolenoidLinearPass(double *r_in, double le, double ks, double *T1, double *
    			r6[5]+= le*(H*H*(x*x+y*y) + 2*H*(xpr*y-ypr*x) +xpr*xpr+ypr*ypr)/2;
 			
    			/* Misalignment at exit */	
-			if (useR2)
-			    ATmultmv(r6,R2);
-		    if (useT2)   
-			    ATaddvv(r6,T2);
-   			
-   			
+			if (R2) ATmultmv(r6,R2);
+		    if (T2) ATaddvv(r6,T2);
 		}
     else /* Drift */
-        for(c = 0;c<num_particles;c++)
-		{	r6= r_in+c*6;
+        for (c = 0;c<num_particles;c++) {
+		    r6 = r_in+c*6;
 			p_norm = 1/(1+r6[4]);  
 			NormL  = le*p_norm;
    			r6[0]+= NormL*r6[1];
    			r6[2]+= NormL*r6[3];
    			r6[5]+= NormL*p_norm*(r6[1]*r6[1]+r6[3]*r6[3])/2;
-			
 		}
+}
+
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
+{
+    if (!Elem) {
+        double Length, ks;
+        double *R1, *R2, *T1, *T2;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        ks=atGetDouble(ElemData,"K"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->Length=Length;
+        Elem->ks=ks;
+        /*optional fields*/
+        Elem->R1=R1;
+        Elem->R2=R2;
+        Elem->T1=T1;
+        Elem->T2=T2;
+    }
+	SolenoidLinearPass(r_in, Elem->Length, Elem->ks,
+            Elem->T1, Elem->T2, Elem->R1, Elem->R2, num_particles);
+    return Elem;
 }
 
 MODULE_DEF(SolenoidLinearPass)        /* Dummy module initialisation */
 
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
 #ifdef MATLAB_MEX_FILE
-
-#include "elempass.h"
-
-ExportMode int* passFunction(const mxArray *ElemData,int *FieldNumbers,
-				double *r_in, int num_particles, int mode)
-
-
-#define NUM_FIELDS_2_REMEMBER 6
-
-{	double le, ks, *pr1, *pr2, *pt1, *pt2 ;
-	int *returnptr;
-	int *NewFieldNumbers, fnum;
-    
-	
-	
-	switch(mode)
-		{	case NO_LOCAL_COPY:	/* Not used since AT1.3 Get fields by names from MATLAB workspace  */
-				{	
-				}	break;	
-			
-			case MAKE_LOCAL_COPY: 	/* Find field numbers first 
-									    Save a list of field number in an array
-										 and make returnptr point to that array
-								    */
-				{	
-					NewFieldNumbers = (int*)mxCalloc(NUM_FIELDS_2_REMEMBER,sizeof(int));
-					
-					fnum = mxGetFieldNumber(ElemData,"Length");
-					if(fnum<0) 
-					    mexErrMsgTxt("Required field 'Length' was not found in the element data structure"); 
-					NewFieldNumbers[0] = fnum;
-					le = mxGetScalar(mxGetFieldByNumber(ElemData,0,NewFieldNumbers[0]));
-					
-					fnum = mxGetFieldNumber(ElemData,"K");
-					if(fnum<0) 
-					    mexErrMsgTxt("Required field 'K' was not found in the element data structure"); 
-					NewFieldNumbers[1] = fnum;
-					ks = mxGetScalar(mxGetFieldByNumber(ElemData,0,NewFieldNumbers[1]));
-					
-					fnum = mxGetFieldNumber(ElemData,"R1");
-					NewFieldNumbers[2] = fnum;
-					if(fnum<0)
-					    pr1 = NULL;
-					else
-					    pr1 = mxGetPr(mxGetFieldByNumber(ElemData,0,fnum));
-					
-
-					fnum = mxGetFieldNumber(ElemData,"R2");
-					NewFieldNumbers[3] = fnum;
-					if(fnum<0)
-					    pr2 = NULL;
-					else
-					    pr2 = mxGetPr(mxGetFieldByNumber(ElemData,0,fnum));
-					
-					
-                    fnum = mxGetFieldNumber(ElemData,"T1");
-	                NewFieldNumbers[4] = fnum;
-					if(fnum<0)
-					    pt1 = NULL;
-					else
-					    pt1 = mxGetPr(mxGetFieldByNumber(ElemData,0,fnum));
-					
-	                
-	                fnum = mxGetFieldNumber(ElemData,"T2");
-	                NewFieldNumbers[5] = fnum;
-					if(fnum<0)
-					    pt2 = NULL;
-					else
-					    pt2 = mxGetPr(mxGetFieldByNumber(ElemData,0,fnum));
-					
-					returnptr = NewFieldNumbers;
-				}	break;
-
-			case	USE_LOCAL_COPY:	/* Get fields from MATLAB using field numbers
-										 The second argument ponter to the array of field 
-										 numbers is previously created with 
-										 QuadLinPass( ..., MAKE_LOCAL_COPY)
-								    */
-											
-				{	le = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[0]));
-					ks = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[1]));
-					/* Optional fields */
-					if(FieldNumbers[2]<0)
-					    pr1 = NULL;
-					else
-					    pr1 = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[2]));
-					
-					if(FieldNumbers[3]<0)
-					    pr2 = NULL;
-					else
-					    pr2 = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[3]));
-					
-					    
-					if(FieldNumbers[4]<0)
-					    pt1 = NULL;
-					else    
-					    pt1 = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[4]));
-					    
-					if(FieldNumbers[5]<0)
-					    pt2 = NULL;
-					else 
-					    pt2 = mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[5]));
-					returnptr = FieldNumbers;
-				}	break;
-
-	}
-
-	
-	
-	SolenoidLinearPass(r_in, le, ks, pt1, pt2, pr1, pr2, num_particles);
-	return(returnptr);
-}
-
-
-
-
-
-
-
-
-
 void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
-{ 	int m,n;
-	double *r_in, le, ks, *pr1, *pr2, *pt1, *pt2;   
-	mxArray *tmpmxptr;
-	
-	
-	if(nrhs)
-	{
-	/* ALLOCATE memory for the output array of the same size as the input */
-	m = mxGetM(prhs[1]);
-	n = mxGetN(prhs[1]);
-	if(m!=6) 
-		mexErrMsgTxt("Second argument must be a 6 x N matrix");
-
-	
-	tmpmxptr=mxGetField(prhs[0],0,"Length");
-	if(tmpmxptr)
-		le = mxGetScalar(tmpmxptr);
-	else
-		mexErrMsgTxt("Required field 'Length' was not found in the element data structure"); 
-				
-					    
-	tmpmxptr=mxGetField(prhs[0],0,"K");
-	if(tmpmxptr)
-		ks = mxGetScalar(tmpmxptr);
-	else
-		mexErrMsgTxt("Required field 'K' was not found in the element data structure"); 
-					    
-	/* Optionnal arguments */    
-	tmpmxptr = mxGetField(prhs[0],0,"R1");
-	if(tmpmxptr)
-	    pr1 = mxGetPr(tmpmxptr);
-	else
-	    pr1=NULL; 
-	    
-	tmpmxptr = mxGetField(prhs[0],0,"R2");
-	if(tmpmxptr)
-	    pr2 = mxGetPr(tmpmxptr);
-	else
-	    pr2=NULL; 
-
-	tmpmxptr = mxGetField(prhs[0],0,"T1");
-
-	
-	if(tmpmxptr)
-	    pt1=mxGetPr(tmpmxptr);
-	else
-	    pt1=NULL;
-
-	tmpmxptr = mxGetField(prhs[0],0,"T2");
-	if(tmpmxptr)
-	    pt2=mxGetPr(tmpmxptr);
-	else
-	    pt2=NULL;
-
-    plhs[0] = mxDuplicateArray(prhs[1]);
-    r_in = mxGetPr(plhs[0]);
-	SolenoidLinearPass(r_in, le, ks, pt1, pt2, pr1, pr2, n);
-	}
-	else
-	{   /* return list of required fields */
-	    plhs[0] = mxCreateCellMatrix(2,1);
-	    mxSetCell(plhs[0],0,mxCreateString("Length"));
-	    mxSetCell(plhs[0],1,mxCreateString("K"));
-	    if(nlhs>1) /* Required and optional fields */ 
-	    {   plhs[1] = mxCreateCellMatrix(4,1);
-	        mxSetCell(plhs[1],0,mxCreateString("T1"));
-	        mxSetCell(plhs[1],1,mxCreateString("T2"));
-	        mxSetCell(plhs[1],2,mxCreateString("R1"));
-	        mxSetCell(plhs[1],3,mxCreateString("R2"));
-	    }
-	}
-
-
+{
+    if (nrhs == 2 ) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        double Length, ks;
+        double *R1, *R2, *T1, *T2;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        ks=atGetDouble(ElemData,"K"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+	    SolenoidLinearPass(r_in, Length, ks, T1, T2, R1, R2, num_particles);
+    }
+    else if (nrhs == 0) {
+        /* list of required fields */
+        plhs[0] = mxCreateCellMatrix(2,1);
+        mxSetCell(plhs[0],0,mxCreateString("Length"));
+        mxSetCell(plhs[0],1,mxCreateString("K"));
+        if (nlhs>1) {
+            /* list of optional fields */
+            plhs[1] = mxCreateCellMatrix(4,1);
+            mxSetCell(plhs[1],0,mxCreateString("T1"));
+            mxSetCell(plhs[1],1,mxCreateString("T2"));
+            mxSetCell(plhs[1],2,mxCreateString("R1"));
+            mxSetCell(plhs[1],3,mxCreateString("R2"));
+        }
+    }
+    else {
+        mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");
+    }
 }
-
 #endif /*MATLAB_MEX_FILE*/

--- a/atintegrators/StrMPoleSymplectic4Pass.c
+++ b/atintegrators/StrMPoleSymplectic4Pass.c
@@ -191,7 +191,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         StrMPoleSymplectic4Pass(r_in,Length,PolynomA,PolynomB,MaxOrder,NumIntSteps,
                 FringeQuadEntrance,FringeQuadExit,fringeIntM0,fringeIntP0,
                 T1,T2,R1,R2,RApertures,EApertures,KickAngle,num_particles);

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -238,7 +238,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         StrMPoleSymplectic4QuantPass(r_in,Length,PolynomA,PolynomB,MaxOrder,NumIntSteps,
                 FringeQuadEntrance,FringeQuadExit,fringeIntM0,fringeIntP0,
                 T1,T2,R1,R2,RApertures,EApertures,KickAngle,Energy,num_particles);

--- a/atintegrators/StrMPoleSymplectic4RadPass.c
+++ b/atintegrators/StrMPoleSymplectic4RadPass.c
@@ -194,7 +194,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
-        r_in = mxGetPr(plhs[0]);
+        r_in = mxGetDoubles(plhs[0]);
         StrMPoleSymplectic4RadPass(r_in,Length,PolynomA,PolynomB,MaxOrder,NumIntSteps,
                 FringeQuadEntrance,FringeQuadExit,fringeIntM0,fringeIntP0,
                 T1,T2,R1,R2,RApertures,EApertures,KickAngle,Energy,num_particles);

--- a/atintegrators/WiggLinearPass.c
+++ b/atintegrators/WiggLinearPass.c
@@ -1,5 +1,16 @@
-#include "at.h"
+#include "atelem.c"
 #include "atlalib.c"
+
+struct elem {
+    double Length;
+    double InvRho;
+    /* Optional fields */
+    double KxKz;
+    double *R1;
+    double *R2;
+    double *T1;
+    double *T2;
+};
 
 /******************************************************************************/
 /* PHYSICS SECTION ************************************************************/
@@ -53,156 +64,104 @@ static void foc6(double *r, double L, double Kx, double Kz)
 
 void WiggLinearPass(double *r, double le, double invrho, double kxkz, double *T1, double *T2, double *R1, double *R2, int num_particles)
 {
-   int c;
-   double *r6;
-   double kz = 0.5/(1.0+kxkz)*invrho*invrho;
-   double kx = kxkz*kz;
+    int c;
+    double *r6;
+    double kz = 0.5/(1.0+kxkz)*invrho*invrho;
+    double kx = kxkz*kz;
+    
+    for (c = 0;c<num_particles;c++) {
+        r6 = r+c*6;
+        if (!atIsNaN(r6[0])) {
+            /* Misalignment at entrance */
+            if (T1 != NULL) ATaddvv(r6,T1);
+            if (R1 != NULL) ATmultmv(r6,R1);
+            
+            foc6(r6, le, kx, kz);
+            
+            /* Misalignment at exit */
+            if (T2 != NULL) ATmultmv(r6,R2);
+            if (R2 != NULL) ATaddvv(r6,T2);
+        }
+    }
+}
 
-   for(c = 0;c<num_particles;c++) {
-      r6 = r+c*6;
-      if (!mxIsNaN(r6[0]) && mxIsFinite(r6[4])) {
-      /* function quad6 internally calculates the square root
-         of the energy deviation of the particle 
-         To protect against DOMAIN and OVERFLOW error, check if the
-         fifth component of the phase spacevector r6[4] is finite
-       */
-	  /* Misalignment at entrance */
-	 if (T1 != NULL) ATaddvv(r6,T1);
-	 if (R1 != NULL) ATmultmv(r6,R1);
+/********** END PHYSICS SECTION ***********************************************/
+/******************************************************************************/
 
-	 foc6(r6, le, kx, kz);
-
-	 /* Misalignment at exit */	
-	 if (T2 != NULL) ATmultmv(r6,R2);
-	 if (R2 != NULL) ATaddvv(r6,T2);
-      }
-   }
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
+{
+    if (!Elem) {
+        double Length, InvRho, KxKz;
+        double*R1, *R2, *T1, *T2;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        InvRho=atGetDouble(ElemData,"InvRho"); check_error();
+        /*optional fields*/
+        KxKz=atGetOptionalDouble(ElemData,"KxKz", 0.0); check_error();
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->Length=Length;
+        Elem->InvRho=InvRho;
+        /*optional fields*/
+        Elem->KxKz=KxKz;
+        Elem->R1=R1;
+        Elem->R2=R2;
+        Elem->T1=T1;
+        Elem->T2=T2;
+    }
+    WiggLinearPass(r_in, Elem->Length, Elem->InvRho, Elem->KxKz,
+            Elem->T1, Elem->T2, Elem->R1, Elem->R2 , num_particles);
+    return Elem;
 }
 
 MODULE_DEF(WiggLinearPass)        /* Dummy module initialisation */
 
-/********** END PHYSICS SECTION ***********************************************/
-/******************************************************************************/
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
 #ifdef MATLAB_MEX_FILE
-
-#include "elempass.h"
-
-static int ReqFieldNumber(const mxArray *ElemData, const char *fname)
+void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-   int fnum = mxGetFieldNumber(ElemData, fname);
-   if (fnum < 0) mexErrMsgIdAndTxt("At:MissingField","Required field '%s' was not found in the element data structure", fname);
-   return fnum;
-}
-
-ExportMode int* passFunction(const mxArray *ElemData, int *FieldNumbers,
-				double *r_in, int num_particles, int mode)
-
-#define NUM_FIELDS_2_REMEMBER 7
-
-{
-   double *pr1, *pr2, *pt1, *pt2 , le, invrho, kxkz;   
-   int fnum, inum;
-
-   switch(mode) {
-      case NO_LOCAL_COPY:	/* Obsolete in AT1.3 et fields by names from MATLAB workspace  */
-         break;	
-				
-      case MAKE_LOCAL_COPY: 	/* Find field numbers first
-				Save a list of field number in an array
-				and make returnptr point to that array
-				*/
-	 FieldNumbers = (int*)mxCalloc(NUM_FIELDS_2_REMEMBER,sizeof(int));
-	 inum = 0;
-	 
-	 FieldNumbers[inum++] = ReqFieldNumber(ElemData, "Length");
-	 FieldNumbers[inum++] = ReqFieldNumber(ElemData, "InvRho");
-
-	 FieldNumbers[inum++] = mxGetFieldNumber(ElemData,"KxKz");
-	 FieldNumbers[inum++] = mxGetFieldNumber(ElemData,"R1");
-	 FieldNumbers[inum++] = mxGetFieldNumber(ElemData,"R2");
-	 FieldNumbers[inum++] = mxGetFieldNumber(ElemData,"T1");
-	 FieldNumbers[inum++] = mxGetFieldNumber(ElemData,"T2");
-
-      case USE_LOCAL_COPY:	/* Get fields from MATLAB using field numbers
-				The second argument ponter to the array of field 
-				numbers is previously created with 
-				QuadLinPass( ..., MAKE_LOCAL_COPY)
-				*/
-	 inum = 0;
-	 
-	 le = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[inum++]));
-	 invrho = mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[inum++]));
-
-	 /* Optional fields */
-	 kxkz = ((fnum=FieldNumbers[inum++]) >= 0) ? mxGetScalar(mxGetFieldByNumber(ElemData,0,FieldNumbers[fnum])) : 0.0;
-	 pr1 = ((fnum=FieldNumbers[inum++]) >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[fnum])) : NULL;
-	 pr2 = ((fnum=FieldNumbers[inum++]) >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[fnum])) : NULL;
-	 pt1 = ((fnum=FieldNumbers[inum++]) >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[fnum])) : NULL;
-	 pt2 = ((fnum=FieldNumbers[inum++]) >= 0) ? mxGetPr(mxGetFieldByNumber(ElemData,0,FieldNumbers[fnum])) : NULL;
-	 break;
-
-   }
-   WiggLinearPass(r_in, le, invrho, kxkz, pt1, pt2, pr1, pr2 , num_particles);
-   return FieldNumbers;	
-}
-
-
-/********** END WINDOWS DLL GATEWAY SECTION ***************************************/
-/********** MATLAB GATEWAY  ***************************************/
-
-static const mxArray *ReqField(const mxArray *ElemData, const char *fname)
-{
-   const mxArray *tmpmxptr = mxGetField(ElemData, 0, fname);
-   if (tmpmxptr == NULL) mexErrMsgIdAndTxt("At:MissingField","Required field '%s was not found in the element data structure", fname);
-   return tmpmxptr;
-}
-
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
-{
-   int m, n;
-   double *r_in;   
-   double  *pr1, *pr2, *pt1, *pt2 , le, invrho, kxkz; 
-   mxArray *tmpmxptr;
-
-
-   if (nrhs) {
-	
-	/* ALLOCATE memory for the output array of the same size as the input */
-	m = mxGetM(prhs[1]);
-	n = mxGetN(prhs[1]);
-
-	if (m != 6) mexErrMsgTxt("Second argument must be a 6 x N matrix");
-	
-	/* Required Fields */
-	
-	le = mxGetScalar(ReqField(prhs[0], "Length"));
-	invrho = mxGetScalar(ReqField(prhs[0], "InvRho"));
-	
-	/* Optionnal arguments */    
-	kxkz = (tmpmxptr = mxGetField(prhs[0],0,"KxKz")) ? mxGetScalar(tmpmxptr) : 0.0;
-	pr1 = (tmpmxptr = mxGetField(prhs[0],0,"R1")) ? mxGetPr(tmpmxptr) : NULL;
-	pr2 = (tmpmxptr = mxGetField(prhs[0],0,"R2")) ? mxGetPr(tmpmxptr) : NULL;
-	pt1 = (tmpmxptr = mxGetField(prhs[0],0,"T1")) ? mxGetPr(tmpmxptr) : NULL;
-	pt2 = (tmpmxptr = mxGetField(prhs[0],0,"T2")) ? mxGetPr(tmpmxptr) : NULL;
-
-
-	plhs[0] = mxDuplicateArray(prhs[1]);
-	r_in = mxGetPr(plhs[0]);
-	WiggLinearPass(r_in, le, invrho, kxkz, pt1, pt2, pr1, pr2, n);
-   }
-   else {   /* return list of required fields */
-      plhs[0] = mxCreateCellMatrix(2,1);
-      mxSetCell(plhs[0],0,mxCreateString("Length"));
-      mxSetCell(plhs[0],1,mxCreateString("InvRho"));
-
-      if (nlhs>1) { /* Required and optional fields */ 
-          plhs[1] = mxCreateCellMatrix(5,1);
-          mxSetCell(plhs[1],0,mxCreateString("KxKz"));
-	  mxSetCell(plhs[1],1,mxCreateString("T1"));
-	  mxSetCell(plhs[1],2,mxCreateString("T2"));
-	  mxSetCell(plhs[1],3,mxCreateString("R1"));
-	  mxSetCell(plhs[1],4,mxCreateString("R2"));
-      }
-   }
+    if (nrhs == 2 ) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        double Length, InvRho, KxKz;
+        double*R1, *R2, *T1, *T2;
+        Length=atGetDouble(ElemData,"Length"); check_error();
+        InvRho=atGetDouble(ElemData,"InvRho"); check_error();
+        /*optional fields*/
+        KxKz=atGetOptionalDouble(ElemData,"KxKz", 0.0); check_error();
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+        WiggLinearPass(r_in, Length, InvRho, KxKz, T1, T2, R1, R2 , num_particles);
+    }
+    else if (nrhs == 0) {
+        /* list of required fields */
+        plhs[0] = mxCreateCellMatrix(2,1);
+        mxSetCell(plhs[0],0,mxCreateString("Length"));
+        mxSetCell(plhs[0],1,mxCreateString("InvRho"));
+        
+        if (nlhs>1) {
+            /* list of optional fields */
+            plhs[1] = mxCreateCellMatrix(5,1);
+            mxSetCell(plhs[1],0,mxCreateString("KxKz"));
+            mxSetCell(plhs[1],1,mxCreateString("T1"));
+            mxSetCell(plhs[1],2,mxCreateString("T2"));
+            mxSetCell(plhs[1],3,mxCreateString("R1"));
+            mxSetCell(plhs[1],4,mxCreateString("R2"));
+        }
+    }
+    else {
+        mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");
+    }
 }
 #endif /*MATLAB_MEX_FILE*/

--- a/atintegrators/atcommon.h
+++ b/atintegrators/atcommon.h
@@ -50,6 +50,12 @@
 #include <mex.h>
 #include <matrix.h>
 
+/* Get ready for R2018a C matrix API */
+#ifndef mxGetDoubles
+#define mxGetDoubles mxGetPr
+typedef double mxDouble;
+#endif
+
 #else
 
 #if defined(_WIN32) && (_MSC_VER < 1800)

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -68,11 +68,19 @@ static double atGetDouble(const mxArray *ElemData, const char *fieldname)
     return mxGetScalar(field);
 }
 
-static double* atGetDoubleArray(const mxArray *ElemData, const char *fieldname)
+static double* atGetDoubleArraySz(const mxArray *ElemData, const char *fieldname, int *msz, int *nsz)
 {
     mxArray *field=mxGetField(ElemData,0,fieldname);
     if (!field) mexErrMsgIdAndTxt("AT:WrongArg", "The required attribute %s is missing.", fieldname);
+    *msz = mxGetM(field);
+    *nsz = mxGetN(field);
     return mxGetDoubles(field);
+}
+
+static double* atGetDoubleArray(const mxArray *ElemData, const char *fieldname)
+{
+    int msz, nsz;
+    return atGetDoubleArraySz(ElemData, fieldname, &msz, &nsz);
 }
 
 static long atGetOptionalLong(const mxArray *ElemData, const char *fieldname, long default_value)
@@ -87,10 +95,22 @@ static double atGetOptionalDouble(const mxArray *ElemData, const char *fieldname
     return (field) ? mxGetScalar(field) : default_value;
 }
 
+static double* atGetOptionalDoubleArraySz(const mxArray *ElemData, const char *fieldname, int *msz, int *nsz)
+{
+    double *ptr = NULL;
+    mxArray *field=mxGetField(ElemData,0,fieldname);
+    if (field) {
+        *msz = mxGetM(field);
+        *nsz = mxGetN(field);
+        ptr = mxGetDoubles(field);
+    }
+    return ptr;
+}
+
 static double* atGetOptionalDoubleArray(const mxArray *ElemData, const char *fieldname)
 {
-    mxArray *field=mxGetField(ElemData,0,fieldname);
-    return (field) ? mxGetDoubles(field) : NULL;
+    int msz, nsz;
+    return atGetOptionalDoubleArraySz(ElemData, fieldname, &msz, &nsz);
 }
 
 #endif /* MATLAB_MEX_FILE */
@@ -146,9 +166,11 @@ static double atGetOptionalDouble(const PyObject *element, const char *name, dou
     return d;
 }
 
-static double *atGetDoubleArray(const PyObject *element, char *name)
+static double *atGetDoubleArraySz(const PyObject *element, char *name, int *msz, int *nsz)
 {
     char errmessage[60];
+    int ndims;
+    npy_intp *dims;
     PyArrayObject *array;
     if (!array_imported) {
         init_numpy();
@@ -173,17 +195,33 @@ static double *atGetDoubleArray(const PyObject *element, char *name)
         PyErr_SetString(PyExc_RuntimeError, errmessage);
         return NULL;
     }
+    ndims = PyArray_NDIM(array);
+    dims = PyArray_SHAPE(array);
+    *nsz = (ndims >= 2) ? dims[1] : 0;
+    *msz = (ndims >= 1) ? dims[0] : 0;
     return PyArray_DATA(array);
 }
 
-static double *atGetOptionalDoubleArray(const PyObject *element, char *name)
+static double *atGetDoubleArray(const PyObject *element, char *name)
+{
+    int msz, nsz;
+    return atGetDoubleArraySz(element, name, &msz, &nsz);
+}
+
+static double *atGetOptionalDoubleArraySz(const PyObject *element, char *name, int *msz, int *nsz)
 {
     PyObject *obj = PyObject_GetAttrString((PyObject *)element, name);
     if (obj == NULL) {
         PyErr_Clear();
         return NULL;
     }
-    return atGetDoubleArray(element, name);
+    return atGetDoubleArraySz(element, name, msz, nsz);
+}
+
+static double *atGetOptionalDoubleArray(const PyObject *element, char *name)
+{
+    int msz, nsz;
+    return atGetOptionalDoubleArraySz(element, name, &msz, &nsz);
 }
 
 #endif /* defined(PYAT) */

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -72,7 +72,7 @@ static double* atGetDoubleArray(const mxArray *ElemData, const char *fieldname)
 {
     mxArray *field=mxGetField(ElemData,0,fieldname);
     if (!field) mexErrMsgIdAndTxt("AT:WrongArg", "The required attribute %s is missing.", fieldname);
-    return mxGetPr(field);
+    return mxGetDoubles(field);
 }
 
 static long atGetOptionalLong(const mxArray *ElemData, const char *fieldname, long default_value)
@@ -90,7 +90,7 @@ static double atGetOptionalDouble(const mxArray *ElemData, const char *fieldname
 static double* atGetOptionalDoubleArray(const mxArray *ElemData, const char *fieldname)
 {
     mxArray *field=mxGetField(ElemData,0,fieldname);
-    return (field) ? mxGetPr(field) : NULL;
+    return (field) ? mxGetDoubles(field) : NULL;
 }
 
 #endif /* MATLAB_MEX_FILE */

--- a/atintegrators/atlalib.c
+++ b/atintegrators/atlalib.c
@@ -4,8 +4,7 @@
 
 
 1. Use mxCalloc, mxMalloc , mxFree for memory allocation/deallocation
-2. Vector and matrix input arguments are (*double) obtained with
-   mxGetPr
+2. Vector and matrix input arguments are (*double) obtained with mxGetDoubles
     Note: MATLAB internally represents matrixes as column-by-column
    1-dimentional arrays. For example  
                   A B C

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -15,7 +15,7 @@ switch computer
 end
 
 try
-    if ~verLessThan('matlab','9.4')
+    if ~verLessThan('matlab','9.5')
         PLATFORMOPTION = [PLATFORMOPTION '-R2018a '];
     elseif ~verLessThan('matlab','7.11') %R2010b
         PLATFORMOPTION = [PLATFORMOPTION '-largeArrayDims '];

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -15,7 +15,9 @@ switch computer
 end
 
 try
-    if ~verLessThan('matlab','7.11') %R2010b
+    if ~verLessThan('matlab','9.4')
+        PLATFORMOPTION = [PLATFORMOPTION '-R2018a '];
+    elseif ~verLessThan('matlab','7.11') %R2010b
         PLATFORMOPTION = [PLATFORMOPTION '-largeArrayDims '];
     end
     if ~verLessThan('matlab','8.3') %R2014a

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -15,7 +15,7 @@ switch computer
 end
 
 try
-    if ~verLessThan('matlab','9.5')
+    if ~verLessThan('matlab','9.4')
         PLATFORMOPTION = [PLATFORMOPTION '-R2018a '];
     elseif ~verLessThan('matlab','7.11') %R2010b
         PLATFORMOPTION = [PLATFORMOPTION '-largeArrayDims '];

--- a/atmat/atphysics/NonLinearDynamics/RDTelegantAT.cpp
+++ b/atmat/atphysics/NonLinearDynamics/RDTelegantAT.cpp
@@ -11,6 +11,13 @@
 #include <cmath>
 #include <cstring>
 
+/* Get ready for R2018a C matrix API */
+#ifndef mxGetDoubles
+#define mxGetDoubles mxGetPr
+#define mxSetDoubles mxSetPr
+typedef double mxDouble;
+#endif
+
 typedef struct {
   double betax, betay;
   double rbetax, rbetay;           /* rbetax = sqrt(betax) */
@@ -485,16 +492,16 @@ void mexFunction( int nlhs, mxArray *plhs[],
 	tune[1]=Tuney;
 		
     /* create a pointer to the real data in the input matrix  */
-    s = mxGetPr(prhs[0]);
-    betax = mxGetPr(prhs[1]);
-    betay = mxGetPr(prhs[2]);
-    etax = mxGetPr(prhs[3]);
-    phix = mxGetPr(prhs[4]);
-    phiy = mxGetPr(prhs[5]);
-    Lista2L = mxGetPr(prhs[6]);
-    Listb2L = mxGetPr(prhs[7]);
-    Listb3L = mxGetPr(prhs[8]);
-    Listb4L = mxGetPr(prhs[9]);
+    s = mxGetDoubles(prhs[0]);
+    betax = mxGetDoubles(prhs[1]);
+    betay = mxGetDoubles(prhs[2]);
+    etax = mxGetDoubles(prhs[3]);
+    phix = mxGetDoubles(prhs[4]);
+    phiy = mxGetDoubles(prhs[5]);
+    Lista2L = mxGetDoubles(prhs[6]);
+    Listb2L = mxGetDoubles(prhs[7]);
+    Listb3L = mxGetDoubles(prhs[8]);
+    Listb4L = mxGetDoubles(prhs[9]);
 	
 	//printf("s0=%f, s1=%f, s2=%f \n",s[0],s[1],s[2]);	
 	//printf("NumElem=%d\n",NumElem);
@@ -514,9 +521,9 @@ void mexFunction( int nlhs, mxArray *plhs[],
 							Lista2L, Listb2L, Listb3L, Listb4L, tune, 
 							Geometric1, Geometric2, Chromatic1, Coupling1, TuneShifts, nPeriods);
 
-	outMatrixRe = mxGetPr(plhs[0]);
-	outMatrixIm = mxGetPr(plhs[1]);
-	outMatrixTSwA = mxGetPr(plhs[2]);
+	outMatrixRe = mxGetDoubles(plhs[0]);
+	outMatrixIm = mxGetDoubles(plhs[1]);
+	outMatrixTSwA = mxGetDoubles(plhs[2]);
 	/* Compute the resonance driving terms from the hamiltonian driving terms */
 	
 	    

--- a/atmat/atphysics/Radiation/findmpoleraddiffmatrix.c
+++ b/atmat/atphysics/Radiation/findmpoleraddiffmatrix.c
@@ -15,6 +15,11 @@
 #include "atlalib.c"
 #include <math.h>
 
+/* Get ready for R2018a C matrix API */
+#ifndef mxGetDoubles
+#define mxGetDoubles mxGetPr
+typedef double mxDouble;
+#endif
 
 /* Fourth order-symplectic integrator constants */
 
@@ -473,7 +478,8 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	double *BDIFF;
 	mxArray  *mxtemp;
 
-	double *orb, *orb0;
+    mxDouble *orb0;
+	double *orb;
 	double *pt1, *pt2, *PR1, *PR2;
 
 
@@ -484,7 +490,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     
 	/* ALLOCATE memory for the output array */
 	plhs[0] = mxCreateDoubleMatrix(6,6,mxREAL);
-	BDIFF = mxGetPr(plhs[0]);
+	BDIFF = mxGetDoubles(plhs[0]);
 
 
 	/* If the ELEMENT sructure does not have fields PolynomA and PolynomB
@@ -495,7 +501,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 
 
-	orb0 = mxGetPr(prhs[1]);
+	orb0 = mxGetDoubles(prhs[1]);
 	/* make local copy of the input closed orbit vector */
 	orb = (double*)mxCalloc(6,sizeof(double));
 	for(m=0;m<6;m++)
@@ -509,8 +515,8 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	if(le == 0)
 		return;
 	
-	A = mxGetPr(mxGetField(prhs[0],0,"PolynomA"));
-	B = mxGetPr(mxGetField(prhs[0],0,"PolynomB"));
+	A = mxGetDoubles(mxGetField(prhs[0],0,"PolynomA"));
+	B = mxGetDoubles(mxGetField(prhs[0],0,"PolynomB"));
 
 	
     mxtemp = mxGetField(prhs[0],0,"Energy");
@@ -558,25 +564,25 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	/* Optional felds */
     mxtemp = mxGetField(prhs[0],0,"T1");
     if(mxtemp)
-        pt1 = mxGetPr(mxtemp);
+        pt1 = mxGetDoubles(mxtemp);
     else
         pt1 = NULL;
     
     mxtemp = mxGetField(prhs[0],0,"T2");
     if(mxtemp)
-        pt2 = mxGetPr(mxtemp);
+        pt2 = mxGetDoubles(mxtemp);
     else
         pt2 = NULL;
     
     mxtemp = mxGetField(prhs[0],0,"R1");
     if(mxtemp)
-        PR1 = mxGetPr(mxtemp);
+        PR1 = mxGetDoubles(mxtemp);
     else
         PR1 = NULL;
     
     mxtemp = mxGetField(prhs[0],0,"R2");
     if(mxtemp)
-        PR2 = mxGetPr(mxtemp);
+        PR2 = mxGetDoubles(mxtemp);
     else
         PR2 = NULL;
     

--- a/atmat/atphysics/nafflib/nafflib.c
+++ b/atmat/atphysics/nafflib/nafflib.c
@@ -121,7 +121,6 @@ double *amplitude_out, double *phase_out, int win, int nfreq, int debug)
 /*  MATLAB TO C-CALL LINKING FUNCTION  */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-    double	 *scalar_in;
     double   *nu, *amplitude, *phase;
     unsigned int  i, m, n, m2, n2, numfreq;
     int win = 0;
@@ -142,9 +141,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             mexErrMsgTxt("CALCNAFF requires that Window be a scalar.");
         }
         
-        /* assign pointer */
-        scalar_in   = mxGetPr(WIN_IN);
-        win = (int )*scalar_in;
+        win = mxGetScalar(WIN_IN);
     }
     
     if (nrhs >= 4){ /* user fequency number */
@@ -156,9 +153,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         {
             mexErrMsgTxt("CALCNAFF requires that frequency number be a scalar.");
         }
-           /* assign pointer for maximum number of frequency */
-        scalar_in   = mxGetPr(NFREQ_IN);
-        nfreq = (int )*scalar_in;
+
+        nfreq = (int )mxGetScalar(NFREQ_IN);
     }
     
     if (nrhs >= 5){ /* debugging flag */
@@ -171,9 +167,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             mexErrMsgTxt("CALCNAFF requires that dubbing flag be a scalar.");
         }
         
-            /* assign pointer for debugging flag */
-        scalar_in   = mxGetPr(DEBUG_IN);
-        debug = (int )*scalar_in;
+        debug = (int )mxGetScalar(DEBUG_IN);
         
     }
         
@@ -204,19 +198,19 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     phase = (double *) mxMalloc(nfreq*sizeof(double));
     
     /* call subroutine that calls routine for all NAFF computation */
-    numfreq = call_naff(mxGetPr(Y_IN),mxGetPr(YP_IN),(int )max(m,n), nu, amplitude, phase,  win, nfreq, debug);
+    numfreq = call_naff(mxGetDoubles(Y_IN),mxGetDoubles(YP_IN),(int )max(m,n),
+            nu, amplitude, phase,  win, nfreq, debug);
     
-    NU_OUT = mxCreateDoubleMatrix(numfreq, 1, mxREAL);
-    memcpy(mxGetPr(NU_OUT), nu, numfreq*sizeof(double));
+    memcpy(mxGetDoubles(NU_OUT), nu, numfreq*sizeof(double));
     
     if (nlhs >= 2){ /* amplitudes */
         AMPLITUDE_OUT = mxCreateDoubleMatrix(numfreq, 1, mxREAL);
-        memcpy(mxGetPr(AMPLITUDE_OUT), amplitude, numfreq*sizeof(double));
+        memcpy(mxGetDoubles(AMPLITUDE_OUT), amplitude, numfreq*sizeof(double));
     }
     
     if (nlhs >= 3){ /* phases */
         PHASE_OUT = mxCreateDoubleMatrix(numfreq, 1, mxREAL);
-        memcpy(mxGetPr(PHASE_OUT), phase, numfreq*sizeof(double));
+        memcpy(mxGetDoubles(PHASE_OUT), phase, numfreq*sizeof(double));
     }
     
     /* free dynamically memory allocation */

--- a/atmat/atphysics/nafflib/nafflib.c
+++ b/atmat/atphysics/nafflib/nafflib.c
@@ -17,7 +17,14 @@
 #include "modnaff.h"
 #include "complexe.h"
 /* #include <sys/ddi.h> */
- 
+
+/* Get ready for R2018a C matrix API */
+#ifndef mxGetDoubles
+#define mxGetDoubles mxGetPr
+#define mxSetDoubles mxSetPr
+typedef double mxDouble;
+#endif
+
 /* Input Arguments */
 #define	Y_IN    prhs[0]
 #define	YP_IN   prhs[1]
@@ -201,6 +208,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     numfreq = call_naff(mxGetDoubles(Y_IN),mxGetDoubles(YP_IN),(int )max(m,n),
             nu, amplitude, phase,  win, nfreq, debug);
     
+    NU_OUT = mxCreateDoubleMatrix(numfreq, 1, mxREAL);
     memcpy(mxGetDoubles(NU_OUT), nu, numfreq*sizeof(double));
     
     if (nlhs >= 2){ /* amplitudes */


### PR DESCRIPTION
As reported by @carmignani  in #52, Matlab R2018a introduces a new C API where:

1) The representation of complex variables is changed (interleaved real and imaginary parts instead of separate real and imaginary arrays (no problem for AT : no complex data accessible in integrators)
2) Data access should be done with specialized macros (`mxGetDoubles`, `mxGetInt32s`...) instead of `mxGetPr`

This new API is accessed when using the `-R2018a` flag in the `mex` command. This not the default yet but it will come in the future. The proposed modifications apply the new API when the -R2018a flag is used and keep the old one otherwise, as for the previous Matlab versions.

While doing this, all integrators have been converted to the Python-compatible `trackFunction` instead of `passFunction`