### PR TITLE
Small change in ringpara

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
@@ -76,7 +76,8 @@ for ii=1:len
           Kp = THERING{dpindex(ii)}.PolynomB(2);
       end
       if Kk~=Kp && (Kk~=0 && Kp~=0)
-          warning('Values in K and PolynomB(2) are different. Using larger absolute value'); 
+          Kk=0;
+          warning('Values in K and PolynomB(2) are different and both not zero. Using PolynomB(2).'); 
       end
       Ks=[Kk,Kp];
       [~,i]=max(abs(Ks));


### PR DESCRIPTION
In case K and PolynomB(2) are both present in a dipole and they are different, ringpara was using the one with larger absolute value. I think this decision is questionable and I propose to use PolynomB(2) in that case. The warning is still there, but the message is changed.