### PR TITLE
Update atfastring.m for non-zero length cavities

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
@@ -101,7 +101,7 @@ if ~isempty(cavind)
     freq = THERING{cavind(:,1)}.Frequency;
     v_cav = 0;
     for i = 1:length(cavind)
-        v_cav = v_cav + THERING{cavind(:,1)}.Voltage;
+        v_cav = v_cav + THERING{cavind(:,i)}.Voltage;
     end
 else
     % Default

--- a/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
@@ -99,7 +99,10 @@ sum.etac = sum.gamma^(-2) - sum.compactionFactor;
 cavind = findcells(THERING,'HarmNumber');
 if ~isempty(cavind)
     freq = THERING{cavind(:,1)}.Frequency;
-    v_cav = THERING{cavind(:,1)}.Voltage;
+    v_cav = 0;
+    for i = 1:length(cavind)
+        v_cav = v_cav + THERING{cavind(:,1)}.Voltage;
+    end
 else
     % Default
     freq = 352.202e6;

--- a/atmat/lattice/atfastring.m
+++ b/atmat/lattice/atfastring.m
@@ -29,6 +29,20 @@ function [newring,newringrad] = atfastring(ring0,varargin)
 
 global GLOBVAL
 
+I_cav = findcells(ring0,'Frequency');
+ring_temp = ring0;
+for i = 1:length(I_cav)
+    if ring_temp{I_cav(i)}.Length ~= 0
+        CavElement = ring_temp{I_cav(i)};
+        CavDrift = atdrift('CavDrift',CavElement.Length);
+        ring_temp{I_cav(i)} = CavDrift;
+        CavElement.Length = 0;
+        ring_temp = atinsertelems(ring_temp,I_cav(i),0.5,CavElement);
+    end
+    I_cav(i+1:end) = I_cav(i+1:end)+2;
+end
+ring0 = ring_temp;
+
 [doplot,varargin]=getflag(varargin,'Plot');
 split=getargs(varargin,{[]});
 if nargin < 2

--- a/atmat/lattice/atfastring.m
+++ b/atmat/lattice/atfastring.m
@@ -38,8 +38,8 @@ for i = 1:length(I_cav)
         ring_temp{I_cav(i)} = CavDrift;
         CavElement.Length = 0;
         ring_temp = atinsertelems(ring_temp,I_cav(i),0.5,CavElement);
+        I_cav(i+1:end) = I_cav(i+1:end)+2;
     end
-    I_cav(i+1:end) = I_cav(i+1:end)+2;
 end
 ring0 = ring_temp;
 


### PR DESCRIPTION
atfastring now modified to work with lattices where cavities have non-zero length. See issue: https://github.com/atcollab/at/issues/60