### PR TITLE
Add "pip install scipy" to install instructions

### DIFF
--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -26,6 +26,7 @@ It is easiest to do this using a virtualenv:
 * ``virtualenv --no-site-packages venv``
 * ``source venv/bin/activate  # or venv\Scripts\activate on Windows``
 * ``pip install numpy``
+* ``pip install scipy``
 * ``pip install pytest``
 * ``python setup.py install  # install into the virtualenv``
 


### PR DESCRIPTION
Add missing pip install command to pyat README