### PR TITLE
Fixed matlab bug in atlinopt

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atlinopt.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atlinopt.m
@@ -158,7 +158,7 @@ lindata=reshape(ld(isel),size(isel));
     function UP = BetatronPhaseUnwrap(P)
         % unwrap negative jumps in betatron
         %JUMPS = [0; diff(P)] < -1.e-5;
-        JUMPS = diff([0;P]) < -1.e-3;
+        JUMPS = diff([0;P],1,1) < -1.e-3;
         UP = P+cumsum(JUMPS)*2*pi;
     end
 


### PR DESCRIPTION
Work around a matlab different behaviour on different architectures concerning empty matrices