### PR TITLE
Adjustments to the class guessing functions

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atlinopt.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atlinopt.m
@@ -158,7 +158,7 @@ lindata=reshape(ld(isel),size(isel));
     function UP = BetatronPhaseUnwrap(P)
         % unwrap negative jumps in betatron
         %JUMPS = [0; diff(P)] < -1.e-5;
-        JUMPS = diff([0;P]) < -1.e-3;
+        JUMPS = diff([0;P],1,1) < -1.e-3;
         UP = P+cumsum(JUMPS)*2*pi;
     end
 

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -4,4 +4,4 @@
 from .lattice import *
 from .tracking import *
 from .physics import *
-from .load_mat import *
+from .load import *

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -1,0 +1,9 @@
+"""
+Import of AT lattice from different formats:
+- .mat files
+"""
+from .utils import *
+from .matfile import load_mat
+
+
+__all__ = ['load_mat']

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -43,7 +43,7 @@ def load_mat(filename, key=None, check=True, **kwargs):
     """
     m = scipy.io.loadmat(filename)
     if key is None:
-        matvars = [varname for varname in m if not varname.startwith('__')]
+        matvars = [varname for varname in m if not varname.startswith('__')]
         key = matvars[0] if (len(matvars) == 1) else 'RING'
     element_arrays = m[key].flat
     return Lattice([_load_element(i, elem[0][0], check=check) for (i, elem) in

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -1,0 +1,50 @@
+"""
+Load lattices from Matlab files.
+"""
+import scipy.io
+import numpy
+from . import element_from_dict
+from ..lattice import Lattice
+
+
+def _load_element(index, element_array, check=True):
+    """Load what scipy produces into a pyat element object.
+    """
+    kwargs = {}
+    for field_name in element_array.dtype.fields:
+        # Remove any surplus dimensions in arrays.
+        data = numpy.squeeze(element_array[field_name])
+        # Convert strings in arrays back to strings.
+        if data.dtype.type is numpy.unicode_:
+            data = str(data)
+        kwargs[field_name] = data
+
+    return element_from_dict(kwargs, index=index, check=check)
+
+
+def load_mat(filename, key=None, check=True, **kwargs):
+    """Load a matlab at structure into a Python at list
+
+    PARAMETERS
+        filename        name of a '.mat' file
+        varname         name of the Matlab variable containing the lattice.
+                        Default: Matlab variable name if there is only one,
+                        otherwise 'RING'
+
+    KEYWORDS
+        check=True      if False, skip the coherence tests
+        keep_all=False  Keep RingParam elements in the lattice
+        name=''         Name of the lattice
+        energy          Energy of the lattice (default: taken from the elements)
+        periodicity     Number of periods (default: taken from the elements)
+
+    OUTPUT
+        pyat Lattice object
+    """
+    m = scipy.io.loadmat(filename)
+    if key is None:
+        matvars = [varname for varname in m if not varname.startwith('__')]
+        key = matvars[0] if (len(matvars) == 1) else 'RING'
+    element_arrays = m[key].flat
+    return Lattice([_load_element(i, elem[0][0], check=check) for (i, elem) in
+                    enumerate(element_arrays)], **kwargs)

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -22,7 +22,7 @@ def _load_element(index, element_array, check=True):
     return element_from_dict(kwargs, index=index, check=check)
 
 
-def load_mat(filename, key=None, check=True, **kwargs):
+def load_mat(filename, key=None, check=True):
     """Load a matlab at structure into a Python at list
 
     PARAMETERS
@@ -33,10 +33,6 @@ def load_mat(filename, key=None, check=True, **kwargs):
 
     KEYWORDS
         check=True      if False, skip the coherence tests
-        keep_all=False  Keep RingParam elements in the lattice
-        name=''         Name of the lattice
-        energy          Energy of the lattice (default: taken from the elements)
-        periodicity     Number of periods (default: taken from the elements)
 
     OUTPUT
         pyat Lattice object
@@ -46,5 +42,5 @@ def load_mat(filename, key=None, check=True, **kwargs):
         matvars = [varname for varname in m if not varname.startswith('__')]
         key = matvars[0] if (len(matvars) == 1) else 'RING'
     element_arrays = m[key].flat
-    return Lattice([_load_element(i, elem[0][0], check=check) for (i, elem) in
-                    enumerate(element_arrays)], **kwargs)
+    return [_load_element(i, elem[0][0], check=check) for (i, elem) in
+                    enumerate(element_arrays)]

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -1,11 +1,8 @@
 """
-Load lattice from Matlab file.
-
-This is working from a specific file and may not be general.
+Conversion utilities for creating pyat elements
 """
-import scipy.io
-from .lattice import elements
 import numpy
+from at.lattice import elements
 
 CLASS_MAPPING = {'Quad': 'Quadrupole', 'Sext': 'Sextupole', 'Bend': 'Dipole', 'AP': 'Aperture',
                  'RF': 'RFCavity', 'BPM': 'Monitor'}
@@ -169,26 +166,3 @@ def element_from_dict(elem_dict, index=None, check=True):
     elem_args = [elem_dict.pop(attr) for attr in cl.REQUIRED_ATTRIBUTES]
     element = cl(*elem_args, **elem_dict)
     return element
-
-
-def load_element(index, element_array, check=True):
-    """Load what scipy produces into a pyat element object.
-    """
-    kwargs = {}
-    for field_name in element_array.dtype.fields:
-        # Remove any surplus dimensions in arrays.
-        data = numpy.squeeze(element_array[field_name])
-        # Convert strings in arrays back to strings.
-        if data.dtype.type is numpy.unicode_:
-            data = str(data)
-        kwargs[field_name] = data
-
-    return element_from_dict(kwargs, index=index, check=check)
-
-
-def load(filename, key='RING', check=True):
-    """Load a matlab at structure into a Python at list
-    """
-    m = scipy.io.loadmat(filename)
-    element_arrays = m[key].flat
-    return [load_element(i, elem[0][0], check=check) for (i, elem) in enumerate(element_arrays)]

--- a/pyat/at/load_mat.py
+++ b/pyat/at/load_mat.py
@@ -7,10 +7,10 @@ import scipy.io
 from .lattice import elements
 import numpy
 
-CLASS_MAPPING = {'Quad': 'Quadrupole', 'Sext': 'Sextupole', 'AP': 'Aperture',
+CLASS_MAPPING = {'Quad': 'Quadrupole', 'Sext': 'Sextupole', 'Bend': 'Dipole', 'AP': 'Aperture',
                  'RF': 'RFCavity', 'BPM': 'Monitor'}
 
-CLASSES = set(['Marker', 'Monitor', 'Aperture', 'Drift', 'ThinMultipole', 'Multipole', 'Dipole', 'Bend', 'Quadrupole',
+CLASSES = set(['Marker', 'Monitor', 'Aperture', 'Drift', 'ThinMultipole', 'Multipole', 'Dipole', 'Quadrupole',
                'Sextupole', 'Octupole', 'RFCavity', 'RingParam', 'M66', 'Corrector'])
 
 FAMILY_MAPPING = {'ap': 'Aperture', 'rf': 'RFCavity', 'bpm': 'Monitor'}
@@ -165,8 +165,8 @@ def element_from_dict(elem_dict, index=None, check=True):
         sanitise_class(index, class_name, elem_dict)
     cl = getattr(elements, class_name)
     # Remove mandatory attributes from the keyword arguments.
-    args = [elem_dict.pop(attr) for attr in cl.REQUIRED_ATTRIBUTES]
-    element = cl(*args, **elem_dict)
+    elem_args = [elem_dict.pop(attr) for attr in cl.REQUIRED_ATTRIBUTES]
+    element = cl(*elem_args, **elem_dict)
     return element
 
 

--- a/pyat/at/load_mat.py
+++ b/pyat/at/load_mat.py
@@ -10,14 +10,15 @@ import numpy
 CLASS_MAPPING = {'Quad': 'Quadrupole', 'Sext': 'Sextupole', 'AP': 'Aperture',
                  'RF': 'RFCavity', 'BPM': 'Monitor'}
 
-CLASSES = {'Marker', 'Monitor', 'Aperture', 'Drift', 'ThinMultipole', 'Multipole', 'Dipole', 'Bend', 'Quadrupole',
-           'Sextupole', 'Octupole', 'RFCavity', 'RingParam', 'M66', 'Corrector'}
+CLASSES = set(['Marker', 'Monitor', 'Aperture', 'Drift', 'ThinMultipole', 'Multipole', 'Dipole', 'Bend', 'Quadrupole',
+               'Sextupole', 'Octupole', 'RFCavity', 'RingParam', 'M66', 'Corrector'])
 
 FAMILY_MAPPING = {'ap': 'Aperture', 'rf': 'RFCavity', 'bpm': 'Monitor'}
 
 PASSMETHOD_MAPPING = {'CorrectorPass': 'Corrector', 'Matrix66Pass': 'M66',
                       'CavityPass': 'RFCavity', 'RFCavityPass': 'RFCavity',
                       'QuadLinearPass': 'Quadrupole', 'BendLinearPass': 'Dipole',
+                      'BndMPoleSymplectic4Pass': 'Dipole', 'BndMPoleSymplectic4RadPass': 'Dipole',
                       'AperturePass': 'Aperture', 'ThinMPolePass': 'ThinMultipole',
                       'DriftPass': 'Drift'}
 
@@ -85,11 +86,9 @@ def find_class_name(kwargs):
                 return class_from_pass
             else:
                 length = float(kwargs.get('Length', 0.0))
-                if hasattrs(kwargs, 'BendingAngle', 'FullGap', 'FringeInt1', 'FringeInt2',
-                            'gK', 'EntranceAngle', 'ExitAngle'):
+                if hasattrs(kwargs, 'FullGap', 'FringeInt1', 'FringeInt2', 'gK', 'EntranceAngle', 'ExitAngle'):
                     return 'Dipole'
-                elif hasattrs(kwargs, 'Voltage', 'Frequency', 'HarmNumber',
-                              'PhaseLag', 'TimeLag'):
+                elif hasattrs(kwargs, 'Voltage', 'Frequency', 'HarmNumber', 'PhaseLag', 'TimeLag'):
                     return 'RFCavity'
                 elif hasattrs(kwargs, 'Periodicity'):
                     return 'RingParam'
@@ -97,69 +96,73 @@ def find_class_name(kwargs):
                     return 'Aperture'
                 elif hasattrs(kwargs, 'M66'):
                     return 'M66'
-                elif hasattrs(kwargs, 'GCR'):
-                    return 'Monitor'
                 elif hasattrs(kwargs, 'K'):
                     return 'Quadrupole'
                 elif hasattrs(kwargs, 'PolynomB'):
                     loworder = low_order('PolynomB')
-                    # loworder = min(low_order('PolynomB'), low_order('PolynomA'))
                     if loworder == 1:
                         return 'Quadrupole'
                     elif loworder == 2:
                         return 'Sextupole'
                     elif loworder == 3:
                         return 'Octupole'
+                    elif (pass_method in {'StrMPoleSymplectic4Pass', 'StrMPoleSymplectic4RadPass'}) or (length > 0):
+                        return 'Multipole'
                     else:
-                        return 'Multipole' if (pass_method in {'StrMPoleSymplectic4Pass',
-                                                               'StrMPoleSymplectic4RadPass'}) or (
-                                                          length > 0) else 'ThinMultipole'
+                        return 'ThinMultipole'
                 elif hasattrs(kwargs, 'KickAngle'):
                     return 'Corrector'
+                elif length > 0.0:
+                    return 'Drift'
+                elif hasattrs(kwargs, 'GCR'):
+                    return 'Monitor'
                 else:
-                    return 'Marker' if (length == 0.0) else 'Drift'
+                    return 'Marker'
 
 
-def sanitise_class(class_name, kwargs):
-    """Checks that the Class and PassMethod of the element are a valid
-        combination. Some Classes and PassMethods are incompatible and would
-        raise errors during calculation if left, so we raise an error here with
-        a more helpful message.
-
-    Args:
-        class_name:     Proposed class name
-        kwargs (dict):  The dictionary of keyword arguments passed to the
-                        Element constructor.
-
-    Raises:
-        AttributeError: if the PassMethod and Class are incompatible.
-    """
-    pass_method = kwargs.get('PassMethod')
-    if pass_method is not None:
-        pass_to_class = PASSMETHOD_MAPPING.get(pass_method)
-        if (pass_method == 'IdentityPass') and (float(kwargs.get('Length', 0.0)) != 0.0):
-            raise AttributeError(
-                "PassMethod {0} is not compatible with Class {1}.".format(pass_method, class_name))
-        elif pass_to_class is not None:
-            if pass_to_class != class_name:
-                raise AttributeError(
-                    "PassMethod {0} is not compatible with Class {1}.".format(pass_method, class_name))
-        elif class_name in ['Marker', 'Monitor', 'RingParam']:
-            if pass_method != 'IdentityPass':
-                raise AttributeError(
-                    "PassMethod {0} is not compatible with Class {1}.".format(pass_method, class_name))
-        elif class_name == 'Drift':
-            if pass_method != 'DriftPass':
-                raise AttributeError(
-                    "PassMethod {0} is not compatible with Class {1}.".format(pass_method, class_name))
-
-
-def element_from_dict(elem_dict, check=True):
+def element_from_dict(elem_dict, index=None, check=True):
     """return an AT element from a dictinary of attributes
     """
+
+    def sanitise_class(index, class_name, kwargs):
+        """Checks that the Class and PassMethod of the element are a valid
+            combination. Some Classes and PassMethods are incompatible and would
+            raise errors during calculation if left, so we raise an error here with
+            a more helpful message.
+
+        Args:
+            index:          element index
+            class_name:     Proposed class name
+            kwargs (dict):  The dictionary of keyword arguments passed to the
+                            Element constructor.
+
+        Raises:
+            AttributeError: if the PassMethod and Class are incompatible.
+        """
+
+        def error_message(message, *args):
+            location = '' if index is None else 'Error in element {0}: '.format(index)
+            return location + 'PassMethod {0} is not compatible with '.format(pass_method) + message.format(*args)
+
+        pass_method = kwargs.get('PassMethod')
+        if pass_method is not None:
+            pass_to_class = PASSMETHOD_MAPPING.get(pass_method)
+            length = float(kwargs.get('Length', 0.0))
+            if (pass_method == 'IdentityPass') and (length != 0.0):
+                raise AttributeError(error_message("length {0}.", length))
+            elif pass_to_class is not None:
+                if pass_to_class != class_name:
+                    raise AttributeError(error_message("Class {0}.", class_name))
+            elif class_name in ['Marker', 'Monitor', 'RingParam']:
+                if pass_method != 'IdentityPass':
+                    raise AttributeError(error_message("Class {0}.", class_name))
+            elif class_name == 'Drift':
+                if pass_method != 'DriftPass':
+                    raise AttributeError(error_message("Class {0}.", class_name))
+
     class_name = find_class_name(elem_dict)
     if check:
-        sanitise_class(class_name, elem_dict)
+        sanitise_class(index, class_name, elem_dict)
     cl = getattr(elements, class_name)
     # Remove mandatory attributes from the keyword arguments.
     args = [elem_dict.pop(attr) for attr in cl.REQUIRED_ATTRIBUTES]
@@ -167,7 +170,7 @@ def element_from_dict(elem_dict, check=True):
     return element
 
 
-def load_element(element_array, check=True):
+def load_element(index, element_array, check=True):
     """Load what scipy produces into a pyat element object.
     """
     kwargs = {}
@@ -179,18 +182,12 @@ def load_element(element_array, check=True):
             data = str(data)
         kwargs[field_name] = data
 
-    return element_from_dict(kwargs, check=check)
+    return element_from_dict(kwargs, index=index, check=check)
 
 
 def load(filename, key='RING', check=True):
     """Load a matlab at structure into a Python at list
     """
     m = scipy.io.loadmat(filename)
-    py_ring = []
     element_arrays = m[key].flat
-    for i in range(len(element_arrays)):
-        try:
-            py_ring.append(load_element(element_arrays[i][0, 0], check=check))
-        except AttributeError as error_message:
-            raise AttributeError('On element {0}, {1}'.format(i, error_message))
-    return py_ring
+    return [load_element(i, elem[0][0], check=check) for (i, elem) in enumerate(element_arrays)]

--- a/pyat/at/load_mat.py
+++ b/pyat/at/load_mat.py
@@ -72,7 +72,7 @@ def find_class_name(kwargs):
         if class_name in CLASSES:
             return class_name
         else:
-            raise AttributeError("Class {0} does not exist.".format(class_name))
+            raise AttributeError("Class {0} does not exist.\n{1}".format(class_name, kwargs))
     except KeyError:
         fam_name = kwargs.get('FamName')
         if fam_name in CLASSES:
@@ -142,7 +142,8 @@ def element_from_dict(elem_dict, index=None, check=True):
 
         def error_message(message, *args):
             location = '' if index is None else 'Error in element {0}: '.format(index)
-            return location + 'PassMethod {0} is not compatible with '.format(pass_method) + message.format(*args)
+            return ''.join((location, 'PassMethod {0} is not compatible with '.format(pass_method),
+                            message.format(*args), '\n{0}'.format(kwargs)))
 
         pass_method = kwargs.get('PassMethod')
         if pass_method is not None:

--- a/pyat/at/load_mat.py
+++ b/pyat/at/load_mat.py
@@ -152,14 +152,14 @@ def sanitise_class(class_name, kwargs):
             if pass_method != 'DriftPass':
                 raise AttributeError(
                     "PassMethod {0} is not compatible with Class {1}.".format(pass_method, class_name))
-    return class_name
 
 
-def element_from_dict(elem_dict):
+def element_from_dict(elem_dict, check=True):
     """return an AT element from a dictinary of attributes
     """
     class_name = find_class_name(elem_dict)
-    class_name = sanitise_class(class_name, elem_dict)
+    if check:
+        sanitise_class(class_name, elem_dict)
     cl = getattr(elements, class_name)
     # Remove mandatory attributes from the keyword arguments.
     args = [elem_dict.pop(attr) for attr in cl.REQUIRED_ATTRIBUTES]
@@ -167,7 +167,7 @@ def element_from_dict(elem_dict):
     return element
 
 
-def load_element(element_array):
+def load_element(element_array, check=True):
     """Load what scipy produces into a pyat element object.
     """
     kwargs = {}
@@ -179,10 +179,10 @@ def load_element(element_array):
             data = str(data)
         kwargs[field_name] = data
 
-    return element_from_dict(kwargs)
+    return element_from_dict(kwargs, check=check)
 
 
-def load(filename, key='RING'):
+def load(filename, key='RING', check=True):
     """Load a matlab at structure into a Python at list
     """
     m = scipy.io.loadmat(filename)
@@ -190,7 +190,7 @@ def load(filename, key='RING'):
     element_arrays = m[key].flat
     for i in range(len(element_arrays)):
         try:
-            py_ring.append(load_element(element_arrays[i][0, 0]))
+            py_ring.append(load_element(element_arrays[i][0, 0], check=check))
         except AttributeError as error_message:
             raise AttributeError('On element {0}, {1}'.format(i, error_message))
     return py_ring

--- a/pyat/test/test_load_mat.py
+++ b/pyat/test/test_load_mat.py
@@ -142,12 +142,6 @@ def test_find_Marker():
     assert find_class_name(elem_kwargs) == 'Marker'
 
 
-@pytest.mark.parametrize('class_name,pass_method', (('Drift', 'IdentityPass'),))
-def test_sanitise_class_ok(class_name, pass_method):
-    class_name = sanitise_class(class_name, {'PassMethod': pass_method})
-    assert class_name == 'Monitor'
-
-
 @pytest.mark.parametrize('class_name,pass_method', (
 ('Drift', 'CavityPass'), ('Marker', 'Invalid'),
 ('Monitor', 'Invalid'), ('Drift', 'Invalid'), ('RingParam', 'Invalid')))

--- a/pyat/test/test_load_mat.py
+++ b/pyat/test/test_load_mat.py
@@ -66,22 +66,22 @@ def test_find_Monitor():
     assert find_class_name(elem_kwargs) == 'Monitor'
 
 
-def test_find_Bend():
+def test_find_Dipole():
     elem_kwargs = {'FullGap': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'FringeInt1': 0.5, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'FringeInt2': 0.5, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'gK': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'EntranceAngle': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'ExitAngle': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
     elem_kwargs = {'BendingAngle': 0.1, 'PolynomB': [0, 0, 0, 0],
                    'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Bend'
+    assert find_class_name(elem_kwargs) == 'Dipole'
 
 
 def test_find_Corrector():
@@ -102,25 +102,15 @@ def test_find_M66():
 def test_find_Quadrupole():
     elem_kwargs = {'K': -0.5, 'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'Quadrupole'
-    elem_kwargs = {'PolynomB': [0, -0.5, 0, 0], 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Quadrupole'
 
 
 def test_find_Multipole():
     elem_kwargs = {'PolynomB': [0, 0, 0, 0],
                    'PassMethod': 'StrMPoleSymplectic4Pass', 'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'Multipole'
-    elem_kwargs = {'PolynomB': [0, 0, 0, 0, 1], 'PolynomA': [0, 0, 0, 0],
-                   'Length': 0, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Multipole'
 
 
 def test_find_Drift():
-    elem_kwargs = {'PolynomB': [0, 0, 0, 0], 'BendingAngle': 0.0,
-                   'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Drift'
-    elem_kwargs = {'PolynomB': [0, 0, 0, 0], 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Drift'
     elem_kwargs = {'Length': 1.0, 'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'Drift'
 
@@ -128,16 +118,10 @@ def test_find_Drift():
 def test_find_Sextupole():
     elem_kwargs = {'PolynomB': [0, 0, 1, 0], 'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'Sextupole'
-    elem_kwargs = {'PolynomB': [0, 0, 0, 0, 1], 'PolynomA': [0, 1, 0, 0],
-                   'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Sextupole'
 
 
 def test_find_Octupole():
     elem_kwargs = {'PolynomB': [0, 0, 0, 1], 'PolynomA': [0, 0, 0, 0],
-                   'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Octupole'
-    elem_kwargs = {'PolynomB': [0, 0, 0, 0, 1], 'PolynomA': [0, 0, 0, 1],
                    'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'Octupole'
 
@@ -146,11 +130,9 @@ def test_find_ThinMultipole():
     elem_kwargs = {'PolynomB': [0, 0, 0, 0, 1], 'PolynomA': [0, 0, 0, 0],
                    'FamName': 'fam'}
     assert find_class_name(elem_kwargs) == 'ThinMultipole'
-
-
-def test_find_Dipole():
-    elem_kwargs = {'BendingAngle': 0.1, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
+    elem_kwargs = {'PolynomB': [0, 0, 0, 0, 1], 'PolynomA': [0, 0, 0, 0],
+                   'Length': 0, 'FamName': 'fam'}
+    assert find_class_name(elem_kwargs) == 'ThinMultipole'
 
 
 def test_find_Marker():
@@ -160,22 +142,15 @@ def test_find_Marker():
     assert find_class_name(elem_kwargs) == 'Marker'
 
 
-def test_sanitise_class():
-    elem_kwargs = {'PassMethod': 'IdentityPass', 'Class': 'Drift'}
-    sanitise_class(elem_kwargs)
-    assert elem_kwargs['Class'] == 'Monitor'
-    elem_kwargs = {'PassMethod': 'CavityPass', 'Class': 'Drift'}
+@pytest.mark.parametrize('class_name,pass_method', (('Drift', 'IdentityPass'),))
+def test_sanitise_class_ok(class_name, pass_method):
+    class_name = sanitise_class(class_name, {'PassMethod': pass_method})
+    assert class_name == 'Monitor'
+
+
+@pytest.mark.parametrize('class_name,pass_method', (
+('Drift', 'CavityPass'), ('Marker', 'Invalid'),
+('Monitor', 'Invalid'), ('Drift', 'Invalid'), ('RingParam', 'Invalid')))
+def test_sanitise_class_error(class_name, pass_method):
     with pytest.raises(AttributeError):
-        sanitise_class(elem_kwargs)
-    elem_kwargs = {'PassMethod': 'Invalid', 'Class': 'Marker'}
-    with pytest.raises(AttributeError):
-        sanitise_class(elem_kwargs)
-    elem_kwargs = {'PassMethod': 'Invalid', 'Class': 'Monitor'}
-    with pytest.raises(AttributeError):
-        sanitise_class(elem_kwargs)
-    elem_kwargs = {'PassMethod': 'Invalid', 'Class': 'Drift'}
-    with pytest.raises(AttributeError):
-        sanitise_class(elem_kwargs)
-    elem_kwargs = {'PassMethod': 'Invalid', 'Class': 'RingParam'}
-    with pytest.raises(AttributeError):
-        sanitise_class(elem_kwargs)
+        sanitise_class(class_name, {'PassMethod': pass_method})

--- a/pyat/test/test_load_mat.py
+++ b/pyat/test/test_load_mat.py
@@ -1,7 +1,8 @@
 import at
 import numpy
 import pytest
-from at.load_mat import find_class_name, element_from_dict
+from at.load import find_class_name, element_from_dict
+from at.load import CLASSES, CLASS_MAPPING, FAMILY_MAPPING, PASSMETHOD_MAPPING
 
 
 def test_invalid_class_raises_AttributeError():
@@ -12,35 +13,35 @@ def test_invalid_class_raises_AttributeError():
 
 def test_correct_class_names():
     elem_kwargs = {'FamName': 'fam'}
-    for class_name in at.load_mat.CLASSES:
+    for class_name in CLASSES:
         elem_kwargs['Class'] = class_name
         assert find_class_name(elem_kwargs) == class_name
 
 
 def test_class_mapping():
     elem_kwargs = {'FamName': 'fam'}
-    for class_name in at.load_mat.CLASS_MAPPING.keys():
+    for class_name in CLASS_MAPPING.keys():
         elem_kwargs['Class'] = class_name
-        assert find_class_name(elem_kwargs) == at.load_mat.CLASS_MAPPING[class_name]
+        assert find_class_name(elem_kwargs) == CLASS_MAPPING[class_name]
 
 
 def test_family_mapping():
     elem_kwargs = {}
-    for family_name in at.load_mat.CLASSES:
+    for family_name in CLASSES:
         elem_kwargs['FamName'] = family_name
         assert find_class_name(elem_kwargs) == family_name
-    for family_name in at.load_mat.FAMILY_MAPPING.keys():
+    for family_name in FAMILY_MAPPING.keys():
         elem_kwargs['FamName'] = family_name
-        assert find_class_name(elem_kwargs) == at.load_mat.FAMILY_MAPPING[family_name]
+        assert find_class_name(elem_kwargs) == FAMILY_MAPPING[family_name]
         elem_kwargs['FamName'] = family_name.upper()
-        assert find_class_name(elem_kwargs) == at.load_mat.FAMILY_MAPPING[family_name]
+        assert find_class_name(elem_kwargs) == FAMILY_MAPPING[family_name]
 
 
 def test_PassMethod_mapping():
     elem_kwargs = {'FamName': 'fam'}
-    for pass_method in at.load_mat.PASSMETHOD_MAPPING.keys():
+    for pass_method in PASSMETHOD_MAPPING.keys():
         elem_kwargs['PassMethod'] = pass_method
-        assert find_class_name(elem_kwargs) == at.load_mat.PASSMETHOD_MAPPING[pass_method]
+        assert find_class_name(elem_kwargs) == PASSMETHOD_MAPPING[pass_method]
 
 
 def test_find_Aperture():

--- a/pyat/test/test_load_mat.py
+++ b/pyat/test/test_load_mat.py
@@ -1,7 +1,7 @@
 import at
 import numpy
 import pytest
-from at.load_mat import find_class_name, sanitise_class
+from at.load_mat import find_class_name, element_from_dict
 
 
 def test_invalid_class_raises_AttributeError():
@@ -66,21 +66,15 @@ def test_find_Monitor():
     assert find_class_name(elem_kwargs) == 'Monitor'
 
 
-def test_find_Dipole():
-    elem_kwargs = {'FullGap': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'FringeInt1': 0.5, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'FringeInt2': 0.5, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'gK': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'EntranceAngle': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'ExitAngle': 0.05, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs) == 'Dipole'
-    elem_kwargs = {'BendingAngle': 0.1, 'PolynomB': [0, 0, 0, 0],
-                   'FamName': 'fam'}
+@pytest.mark.parametrize('elem_kwargs', (
+        {'FullGap': 0.05, 'FamName': 'fam'},
+        {'FringeInt1': 0.5, 'FamName': 'fam'},
+        {'FringeInt2': 0.5, 'FamName': 'fam'},
+        {'EntranceAngle': 0.05, 'FamName': 'fam'},
+        {'ExitAngle': 0.05, 'FamName': 'fam'},
+        {'PassMethod': 'BndMPoleSymplectic4Pass', 'PolynomB': [0, 0, 0, 0], 'FamName': 'fam'}
+))
+def test_find_Dipole(elem_kwargs):
     assert find_class_name(elem_kwargs) == 'Dipole'
 
 
@@ -142,9 +136,14 @@ def test_find_Marker():
     assert find_class_name(elem_kwargs) == 'Marker'
 
 
-@pytest.mark.parametrize('class_name,pass_method', (
-('Drift', 'IdentityPass'), ('Drift', 'CavityPass'), ('Marker', 'Invalid'),
-('Monitor', 'Invalid'), ('Drift', 'Invalid'), ('RingParam', 'Invalid')))
-def test_sanitise_class_error(class_name, pass_method):
+@pytest.mark.parametrize('elem_kwargs', (
+        {'FamName': '', 'Class': 'Marker', 'PassMethod': 'IdentityPass', 'Length': 1.0},
+        {'FamName': '', 'Class': 'Quadrupole', 'PassMethod': 'CavityPass', 'Length': 1.0},
+        {'FamName': '', 'Class': 'Marker', 'PassMethod': 'Invalid'},
+        {'FamName': '', 'Class': 'Monitor', 'PassMethod': 'Invalid'},
+        {'FamName': '', 'Class': 'RingParam', 'PassMethod': 'Invalid', 'Energy': 3E9},
+        {'FamName': '', 'Class': 'Drift', 'PassMethod': 'IdentityPass', 'Length': 1.0}
+))
+def test_sanitise_class_error(elem_kwargs):
     with pytest.raises(AttributeError):
-        sanitise_class(class_name, {'PassMethod': pass_method})
+        elem = element_from_dict(elem_kwargs)

--- a/pyat/test/test_load_mat.py
+++ b/pyat/test/test_load_mat.py
@@ -143,7 +143,7 @@ def test_find_Marker():
 
 
 @pytest.mark.parametrize('class_name,pass_method', (
-('Drift', 'CavityPass'), ('Marker', 'Invalid'),
+('Drift', 'IdentityPass'), ('Drift', 'CavityPass'), ('Marker', 'Invalid'),
 ('Monitor', 'Invalid'), ('Drift', 'Invalid'), ('RingParam', 'Invalid')))
 def test_sanitise_class_error(class_name, pass_method):
     with pytest.raises(AttributeError):

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -1,7 +1,6 @@
 import numpy
 import pytest
-from at import physics
-from at import load_mat
+from at import physics, load_mat
 from at import atpass
 
 
@@ -17,7 +16,7 @@ M44_MATLAB = numpy.array([[-0.66380202, 2.23414498, 0, 0],
 
 @pytest.fixture
 def ring():
-    ring = load_mat.load(LATTICE_FILE)
+    ring = load_mat(LATTICE_FILE)
     return ring
 
 

--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -4,6 +4,7 @@ between other modules.
 """
 import pytest
 import utils
+from at import Lattice
 from at.load import load_mat
 
 
@@ -22,4 +23,4 @@ def ml_lattice(engine):
 
 @pytest.fixture
 def py_lattice():
-    return load_mat(utils.LATTICE, keep_all=True)
+    return Lattice(load_mat(utils.LATTICE, key='RING'), keep_all=True)

--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -4,7 +4,7 @@ between other modules.
 """
 import pytest
 import utils
-from at import load_mat, Lattice
+from at.load import load_mat
 
 
 @pytest.fixture(scope='session')
@@ -22,4 +22,4 @@ def ml_lattice(engine):
 
 @pytest.fixture
 def py_lattice():
-    return Lattice(load_mat.load(utils.LATTICE), keep_all=True)
+    return load_mat(utils.LATTICE, keep_all=True)


### PR DESCRIPTION
I tested the class guessing function on some lattices. It works almost everywhere. This class guessing function even looks smarter than the Matlab one. The few problems led me to the following modifications:

- Classes `Bend` and `Dipole` are synonyms, the function should return one or the other, but always the same. I choose `Dipole`, but it can be `Bend` if you prefer.
- `BendingAngle` is a non-ambiguous indication of a `Dipole` (test moved up).
- `RFCavityPass` is a non-ambiguous indication of a `Cavity` (added to `PASSMETHOD_MAPPING`).
- `KickAngle` can be used in `Dipoles`, `Quadrupoles`, `Multipoles`. So testing its presence must be done after  `Dipole`s, `Quadrupole`s, `Multipole`s have been identified.
- Pure skew elements (`PolynomB[n] == 0`) could be described by any class using `StrMPoleSymplectic4Pass`. In the usual element designation in a lattice, they are rather correctors than quadrupoles or sextupoles. So I prefer the class `Multipole` rather `Quadrupole`/`Sextupole`. The `Class` is a pure indicator to ease the selection of elements in a long lattice, it has no effect on tracking which is only governed by the `PassMethod` and the other attributes.
- In `sanitise_class`, 1st case (`PassMethod`:`IdentityPass` and `Class`:`Drift`): you cannot turn an element into a `Monitor` its the length is not 0 ! More generally, `IdentityPass` on a ‘long’ element is a problem. For a short element, you can always imagine that it's turned off. Here is what I propose:
1. Long element cannot have `IdentityPass` => `AttributeError`
2. `Class` cannot contradict `PASSMETHOD_MAPPING` (unchanged)
3. `Marker`, `Monitor` and `RingParam` should have `IdentityPass` (I take `Drift` out)
4. `Drift` should have `DriftPass` (new alternative)
Anyway, I am still not satisfied with that. There should be no check on the `Class`. For the tracking, the only point is the compatibility of the `PassMethod` with the available attributes.
- Attribute `Class` is popped out when entering `find_class_name` and then push in again when returning. Since it should not appear in the final element, I prefer keeping it in a local variable.
- I did not see any usage of the attribute `Index`. Did I miss something ?
- I don’t know what the attributes `gK` `GCR` are intended for. Anyway, it ’s not a problem…

Sorry for some small modifications suggested by my syntax checker: they are unimportant, I just tried to turn the indicator to green…

The remaining problems are:

- A `Sextupole` with errors is turned into a `Multipole`: no simple solution
- `Monitor`s are turned into `Marker`s (No way to distinguish, they are identical, Monitor is supposed to indicate  a real hardware element, a Marker is virtual).

Can you run again all your test lattices and see if these modifications are acceptable ?

I had to make quick modifications to `test_load_mat`. May be you should review the whole list…

Otherwise, I split the `load_element` function in 2: the inner function, `element_from_dict` is completely independent from the ‘.mat’ file decoding and can be used to convert elements coming from the Matlab engine: they are also dictionaries, the data type is different (`matlab.double`) but the element instantiation handles it nicely. In principle, the 3 functions `find_class_name`, `sanitise_class` and `element_from_dict` don’t rely at all upon ‘.mat’ file reading, they could be in the lattice package as well.

Finally I see a small ambiguity in having `at.load`, which looks generic, refer specifically to .mat file loading. One could imagine other load functions for different input formats. Could we rather use something like` at.<format>.load` ? It would mean removing `from load_mat import *` from` __init__.py`.