### PR TITLE
Touschek lifetime modifications

### DIFF
--- a/atmat/atphysics/TouschekPiwinski/TouschekPiwinskiLifeTime.m
+++ b/atmat/atphysics/TouschekPiwinski/TouschekPiwinskiLifeTime.m
@@ -34,7 +34,8 @@ function [Tl,contributionsTL]=TouschekPiwinskiLifeTime(r,dpp,Ib,varargin)
 %
 % created 31-10-2012
 % updated 22-01-2013 corrected and compared with elegant
-% updates 08-11-2018 add: PhysConstant, default 'integral',
+% updates 08-11-2018 add: PhysConstant, default 'integral', contributionTL
+%                         given for positive and negative side
 
 %ensure a column lattice
 r=reshape(r,numel(r),1);

--- a/atmat/atphysics/TouschekPiwinski/TouschekPiwinskiLifeTime.m
+++ b/atmat/atphysics/TouschekPiwinski/TouschekPiwinskiLifeTime.m
@@ -7,17 +7,20 @@ function [Tl,contributionsTL]=TouschekPiwinskiLifeTime(r,dpp,Ib,varargin)
 %  or
 % TouschekPiwinskiLifeTime(
 %  latticeATring,
-%  momentumaperturecolumnvector,  % column array (size of r or positions)
+%  momentumaperturecolumnvector,  column array (size of r or positions)
+%                                 it can be length(r)x2, for positive and
+%                                 negative aperture
 %  current per bunch in A,                 % scalar
 %  positions where to evaluate,  %(default all elements with length>0 )  column array
 %  emittancex, %(default atx modemittance(1))   scalar
-%  emittancey, %(default 10 pm)		       scalar
-%  integration method,  % (default quad, may be: 'integral', 'quad', 'trapz', 'elegantLike', 'Approximate')
-%  energy sperad,	% scalar
+%  emittancey, %(default is emittancex/2)		       scalar
+%  integration method,  % (default 'integral', may be: 'integral', 'quad', 'trapz')
+%  energy spread,	% scalar
 %  bunch length,        % scalar
 %			   )
 %
-%  contributionsTL 1/T contribution at each element
+%  contributionsTL 1/T contribution at each element 
+%                  if dpp has positive and negative apertures, then contributionTL is a 2 columns vector      
 %
 %  Tl  Lifetime in seconds 1/Tl=sum(contributionsTL.*L)/sum(L);
 %
@@ -31,59 +34,56 @@ function [Tl,contributionsTL]=TouschekPiwinskiLifeTime(r,dpp,Ib,varargin)
 %
 % created 31-10-2012
 % updated 22-01-2013 corrected and compared with elegant
+% updates 08-11-2018 add: PhysConstant, default 'integral',
 
 %ensure a column lattice
 r=reshape(r,numel(r),1);
 
-e0 = 1.60217646e-19; %Coulomb
-r0 = 2.817940327e-15; %m %  classical electron radius
-spl=299792458; % speed of ligth
+e0 = PhysConstant.atomic_unit_of_charge.value; %1.60217646e-19; %Coulomb
+r0 = PhysConstant.classical_electron_radius.value; %2.817940327e-15; %m %  classical electron radius
+spl = PhysConstant.speed_of_light_in_vacuum.value; %299792458; % speed of ligth
 
 naddvar=length(varargin);
 if naddvar>=1
     positions=varargin{1};
 else
-    %    positions=1:length(r);
-    
     % positions default= non zero length elements
     positions=findcells(r,'Length');
     L=getcellstruct(r,'Length',positions);
     positions=positions(L>0);
     size(positions);
 end
-
 % get optics
 [lo,pa]=atx(r,0,positions);
 
 emitx=pa.modemittance(1);
 emity=emitx./2;
-integrationmethod='quad';
+integrationmethod='integral';
 sigp=pa.espread; % relative momentum spread
 sigs=pa.blength; % bunch length
 
 if naddvar==2
     positions=varargin{1};
     emitx=varargin{2};
-    
-    disp(['set defaults: ey=ex/2'])
-    disp([' integration method is quad,'])
-    disp([' energy sperad, bunch length from ATX'])
+    disp('set defaults: ey=ex/2')
+    disp(' integration method is integral,')
+    disp(' energy sperad, bunch length from ATX')
     
 elseif naddvar==3
     positions=varargin{1};
     emitx=varargin{2};
     emity=varargin{3};
-    disp(['set defaults: '])
-    disp([' integration method is quad,'])
-    disp([' energy sperad, bunch length from ATX'])
+    disp('set defaults: ')
+    disp(' integration method is integral,')
+    disp(' energy sperad, bunch length from ATX')
     
 elseif naddvar==4
     positions=varargin{1};
     emitx=varargin{2};
     emity=varargin{3};
     integrationmethod=varargin{4};
-    disp(['set defaults: '])
-    disp([' energy sperad, bunch length from ATX'])
+    disp('set defaults: ')
+    disp(' energy sperad, bunch length from ATX')
     
 elseif naddvar==5
     positions=varargin{1};
@@ -91,8 +91,8 @@ elseif naddvar==5
     emity=varargin{3};
     integrationmethod=varargin{4};
     sigp=varargin{5};
-    disp(['set defaults: '])
-    disp(['bunch length from ATX'])
+    disp('set defaults: ')
+    disp('bunch length from ATX')
     
 elseif naddvar==6
     positions=varargin{1};
@@ -103,10 +103,10 @@ elseif naddvar==6
     sigs=varargin{6};
     
 else
-    disp(['set defaults: ey=ex/2'])
-    disp([' integration method is quad,'])
-    disp([' energy sperad, bunch length, x emittance from ATX'])
-    disp([' evaluation at all points with non zero length'])
+    disp('set defaults: ey=ex/2')
+    disp(' integration method is integral,')
+    disp(' energy spread, bunch length, x emittance from ATX')
+    disp(' evaluation at all points with non zero length')
 end
 
 % if dpp is a scalar assume constant momentum aperture.
@@ -116,123 +116,91 @@ end
 
 dppinput=dpp;
 Tlcol=zeros(1,size(dppinput,2));
+Circumference=findspos(r,length(r)+1);
+
+E0=atenergy(r);
+Nb = Ib/(spl/Circumference)/e0; %Number of particle per bunch.
+mass_el_ev=PhysConstant.electron_mass_energy_equivalent_in_MeV.value*1e6;
+relgamma = E0/mass_el_ev;%0.510998928e6;
+relbeta=sqrt(1-1./relgamma.^2);
+
+aaa=cat(1,lo.alpha);
+bbb=cat(1,lo.beta);
+ddd=cat(2,lo.Dispersion)';
+
+bx=bbb(:,1); % betax
+by=bbb(:,2); % betay
+Dx=ddd(:,1);
+Dy=ddd(:,3);
+
+ax=aaa(:,1);
+ay=aaa(:,2);
+Dpx=ddd(:,2);
+Dpy=ddd(:,4);
+
+sigxb=sqrt(emitx.*bx);
+sigyb=sqrt(emity.*by);
+
+sigx=sqrt(emitx.*bx+sigp.^2.*Dx.^2);
+sigy=sqrt(emity.*by+sigp.^2.*Dy.^2); %%%  was mistaken! it was Dx!!!!!!
+
+Dtx=Dx.*ax+Dpx.*bx;%  % alpha=-b'/2
+Dty=Dy.*ay+Dpy.*by;%
+
+%     sigtx=sqrt(sigx.^2+sigp.^2.*Dtx.^2);
+%     sigty=sqrt(sigy.^2+sigp.^2.*Dty.^2);
+% sigtx2=sigx.^2+sigp.^2.*Dtx.^2;
+%     sigty2=sigy.^2+sigp.^2.*Dty.^2;
+
+sigp2=sigp.^2;
+Dx2=Dx.^2;
+Dy2=Dy.^2;
+Dtx2=Dtx.^2;
+Dty2=Dty.^2;
+sigxb2=sigxb.^2;
+sigyb2=sigyb.^2;
+
+sighinv2=1./(sigp2) +(Dx2+Dtx2)./(sigxb2) + (Dy2+Dty2)./(sigyb2);
+sigh=sqrt(1./sighinv2);
+
+B1=1./(2.*(relbeta.^2).*(relgamma.^2)).*( (bx.^2./(sigxb.^2)).*(1-(sigh.^2.*Dtx.^2./(sigxb.^2))) + (by.^2./(sigyb.^2)).*(1-(sigh.^2.*Dty.^2./(sigyb.^2))));
+B2sq=1./(4.*(relbeta.^4).*(relgamma.^4)).*((bx.^2./(sigxb.^2)).*(1-(sigh.^2.*Dtx.^2./(sigxb.^2)))-(by.^2./(sigyb.^2)).*(1-(sigh.^2.*Dty.^2./(sigyb.^2)))).^2+(sigh.^4.*bx.^2.*by.^2.*Dtx.^2.*Dty.^2)./((relbeta.^4).*(relgamma.^4).*sigxb.^4.*sigyb.^4);
+B2=sqrt(B2sq);
+contributionsTL=zeros(size(dppinput));
 
 for dppcolnum=1:size(dppinput,2)
-    
     dpp=dppinput(:,dppcolnum);
-    
-    
-    Circumference=findspos(r,length(r)+1);
-    
-    E0=r{1}.('Energy');%
-    
-    Nb = Ib/(spl/Circumference)/e0; %Number of particle per bunch.
-    
-    relgamma = E0/0.510998928e6;
-    relbeta=sqrt(1-1./relgamma.^2);
-    
-    aaa=cat(1,lo.alpha);
-    bbb=cat(1,lo.beta);
-    ddd=cat(2,lo.Dispersion)';
-    
-    bx=bbb(:,1); % betax
-    by=bbb(:,2); % betay
-    Dx=ddd(:,1);
-    Dy=ddd(:,3);
-    
-    ax=aaa(:,1);
-    ay=aaa(:,2);
-    Dpx=ddd(:,2);
-    Dpy=ddd(:,4);
-    
-    
-    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%
     %%%%%%%% From here calculation takes place.
     %%%%%%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
-    
-    sigxb=sqrt(emitx.*bx);
-    sigyb=sqrt(emity.*by);
-    
-    sigx=sqrt(emitx.*bx+sigp.^2.*Dx.^2);
-    sigy=sqrt(emity.*by+sigp.^2.*Dy.^2); %%%  was mistaken! it was Dx!!!!!!
-    
-    
-    Dtx=Dx.*ax+Dpx.*bx;%  % alpha=-b'/2
-    Dty=Dy.*ay+Dpy.*by;%
-    
-    sigtx=sqrt(sigx.^2+sigp.^2.*Dtx.^2);
-    sigty=sqrt(sigy.^2+sigp.^2.*Dty.^2);
-    
-    sigtx2=sigx.^2+sigp.^2.*Dtx.^2;
-    sigty2=sigy.^2+sigp.^2.*Dty.^2;
-    
-    sigp2=sigp.^2;
-    Dx2=Dx.^2;
-    Dy2=Dy.^2;
-    Dtx2=Dtx.^2;
-    Dty2=Dty.^2;
-    sigxb2=sigxb.^2;
-    sigyb2=sigyb.^2;
-    
-    
-    sighinv2=1./(sigp2) +(Dx2+Dtx2)./(sigxb2) + (Dy2+Dty2)./(sigyb2);
-    
-    sigh=sqrt(1./sighinv2);
-    
     um=relbeta.^2*dpp.^2;
-    
-    B1=1./(2.*(relbeta.^2).*(relgamma.^2)).*( (bx.^2./(sigxb.^2)).*(1-(sigh.^2.*Dtx.^2./(sigxb.^2))) + (by.^2./(sigyb.^2)).*(1-(sigh.^2.*Dty.^2./(sigyb.^2))));
-    
-    B2sq=1./(4.*(relbeta.^4).*(relgamma.^4)).*((bx.^2./(sigxb.^2)).*(1-(sigh.^2.*Dtx.^2./(sigxb.^2)))-(by.^2./(sigyb.^2)).*(1-(sigh.^2.*Dty.^2./(sigyb.^2)))).^2+(sigh.^4.*bx.^2.*by.^2.*Dtx.^2.*Dty.^2)./((relbeta.^4).*(relgamma.^4).*sigxb.^4.*sigyb.^4);
-    
-    B2=sqrt(B2sq);
-    
-    em=bx.^2.*sigx.^2./(relbeta.^2.*relgamma.^2.*sigxb.^2.*sigtx2).*um;
+    %  em=bx.^2.*sigx.^2./(relbeta.^2.*relgamma.^2.*sigxb.^2.*sigtx2).*um;
     
     val=zeros(size(B1));
-    
     km=atan(sqrt(um));
-    
     FpiWfact=sqrt(pi.*(B1.^2-B2.^2)).*um;
     
     for ii=1:length(positions)
-        
         % choose integration method
         switch integrationmethod
-            
             case 'infiniteintegral'
-                
                 val(ii)= integral(@(u)TLT_IntPiw(u,um(ii),B1(ii),B2(ii)),um(ii),Inf); %,...um(ii)*1e4
                 
             case 'integral'
-                
                 val(ii) = integral(@(k)TLT_IntPiw_k(k,km(ii),B1(ii),B2(ii)),km(ii),pi/2); %,...,'Waypoints',evalpoints um(ii)*1e4
                 
             case 'quad'
-                
                 val(ii)= quad(@(k)TLT_IntPiw_k(k,km(ii),B1(ii),B2(ii)),km(ii),pi/2); %,...,'Waypoints',evalpoints um(ii)*1e4
+                
             case 'trapz'
-                
-                
                 k=linspace(km(ii),pi/2,10000);
                 val(ii)= trapz(k,TLT_IntPiw_k(k,km(ii),B1(ii),B2(ii))); %,...,'Waypoints',evalpoints um(ii)*1e4
                 
-            case 'elegantLike'
-                
-                val(ii)=IntegrateLikeElegant(km(ii),B1(ii),B2(ii));
-                
-            case 'Approximate'
-                
-                val(ii)=integral(@(e)Cfun(e,em(ii)),em(ii),Inf);
-                
             otherwise % use default method quad (backward compatible)
-                
-                
-                val(ii)=quad(@(k)TLT_IntPiw_k(k,km(ii),B1(ii),B2(ii)),km(ii),pi/2); %,...,'Waypoints',evalpoints um(ii)*1e4
+                val(ii)=integral(@(k)TLT_IntPiw_k(k,km(ii),B1(ii),B2(ii)),km(ii),pi/2); %,...,'Waypoints',evalpoints um(ii)*1e4
                 
         end
     end
@@ -244,38 +212,24 @@ for dppcolnum=1:size(dppinput,2)
             frontfact=(r0.^2.*spl.*Nb)./(8.*pi.*(relgamma.^2).*sigs.*sqrt(...
                 (sigx.^2).*(sigy.^2)-sigp.^4.*Dx.^2.*Dy.^2).*um).*FpiWfact;
             
-        case {'integral' 'quad' } %'elegantLike'
-            
+        case {'integral' 'quad' }
             frontfact=(r0.^2.*spl.*Nb)./(8.*pi.*(relgamma.^2).*sigs.*sqrt(...
                 (sigx.^2).*(sigy.^2)-sigp.^4.*Dx.^2.*Dy.^2).*um).*2.*FpiWfact;
-        case {'trapz' 'elegantLike'}
-            
+        case {'trapz'}
             frontfact=(r0.^2.*spl.*Nb.*sigh.*bx.*by)./(4.*sqrt(pi).*(relbeta.^2).*(relgamma.^4).*sigxb.^2.*sigyb.^2.*sigs.*sigp);
             
-        case 'Approximate'
-            
-            frontfact=(r0.^2.*spl.*Nb.*bx)./(...
-                8.*pi.*(relbeta.^3).*(relgamma.^3).*...
-                sigxb.*sigyb.*sigs.*sqrt(sigtx2).*dpp.^2 ...
-                ).*em;
-            
         otherwise
-            
             frontfact=(r0.^2.*spl.*Nb)./(8.*pi.*(relgamma.^2).*sigs.*sqrt(...
                 (sigx.^2).*(sigy.^2)-sigp.^4.*Dx.^2.*Dy.^2).*um).*2.*FpiWfact;
             
     end
-    contributionsTL=frontfact.*val;
-    
+    contributionsTL(:,dppcolnum)=frontfact.*val;
     
     L=getcellstruct(r,'Length',positions);
-    Tlcol(dppcolnum)=1/(1/sum(L)*sum(contributionsTL.*L));
+    Tlcol(dppcolnum)=1/(1/sum(L)*sum(contributionsTL(:,dppcolnum).*L));
     
 end
 
 Tl=length(Tlcol)/(sum(1./Tlcol));
 
 return
-
-
-


### PR DESCRIPTION
I did some changes to this function:
- options "elegantlike" and "Approximate" are removed, because they were not working; 
- the energy is found with the function atenergy instead of looking in the energy field of element number 1;
- the physical constants are from the PhysConstant class;
- the default integration method is 'integral' and not 'quad';
- ContributionTL output has now two columns in case the dpp input has two columns;
- many quantities were computed but not used, now it should be faster.