### PR TITLE
Update to refpts docstrings and handling

### DIFF
--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -35,7 +35,7 @@ def uint32_refpts(refpts, n_elements):
     elif (refs.size > n_elements+1):
         raise ValueError('too many reftps given')
     elif numpy.issubdtype(refs.dtype, numpy.bool_):
-        refs = numpy.flatnonzero(refs)
+        return numpy.flatnonzero(refs)
 
     # Handle negative indices
     refs = numpy.array([i if (i == n_elements) else i % n_elements for i in refs],

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -35,7 +35,7 @@ def uint32_refpts(refpts, n_elements):
     elif (refs.size > n_elements+1):
         raise ValueError('too many reftps given')
     elif numpy.issubdtype(refs.dtype, numpy.bool_):
-        return numpy.flatnonzero(refs)
+        return numpy.flatnonzero(refs).astype(numpy.uint32)
 
     # Handle negative indices
     refs = numpy.array([i if (i == n_elements) else i % n_elements for i in refs],

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -5,12 +5,14 @@ A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
 
 The refpts allow functions to select points in the lattice, returned values are
-given at the entrance of each element specified in refpts.
-refpts can be: an integer in the range [-len(ring), len(ring)-1] selecting the
-element according to python indexing rules. As a special case, len(ring) is
-allowed and refers to the end of the last element, an ordered list of such
-integers without duplicates, a numpy array of booleans of maximum length
-len(ring)+1, where selected elements are True.
+given at the entrance of each element specified in refpts;
+refpts can be:
+    - an integer in the range [-len(ring), len(ring)-1] selecting the element
+        according to python indexing rules. As a special case, len(ring) is
+        allowed and refers to the end of the last element,
+    - an ordered list of such integers without duplicates,
+    - a numpy array of booleans of maximum length len(ring)+1, where selected
+        elements are True.
 """
 import numpy
 import itertools

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -66,11 +66,14 @@ def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None, keep_latti
     PARAMETERS
         ring            lattice description
         dp              momentum deviation. Defaults to 0
-        refpts          elements at which data is returned. It can be
-                        1) an integer (0 indicating the first element)
-                        2) a list of integers
-                        3) a numpy array of booleans as long as ring where
-                           selected elements are true
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
                         Defaults to None
 
     KEYWORDS
@@ -166,11 +169,14 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None, keep_lattice=
     PARAMETERS
         ring            lattice description
         dp              momentum deviation. Defaults to 0
-        refpts          Optional: elements at which data is returned. It can be
-                        1) an integer (0 indicating the first element)
-                        2) a list of integers
-                        3) a numpy array of booleans as long as ring where
-                           selected elements are true
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
                         Defaults to None
 
     KEYWORDS

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -90,7 +90,8 @@ def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None, keep_latti
         tune            [tune_h, tune_v], fractional part of the linear tunes
         chrom           [ksi_h , ksi_v], vector of chromaticities ksi = d(nu)/(dP/P).
                         Only computed if 'get_chrom' is True
-        twiss           linear optics at the points refered to by refpts
+        twiss           linear optics at the points refered to by refpts, if
+                        refpts is None an empty twiss structure is returned.
 
         twiss is a structured array with fields:
         idx             element index in the ring                           (nrefs,)
@@ -194,7 +195,8 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None, keep_lattice=
         tune            [tune_A, tune_B], linear tunes for the two normal modes of linear motion [1]
         chrom           [ksi_A , ksi_B], vector of chromaticities ksi = d(nu)/(dP/P).
                         Only computed if 'get_chrom' is True
-        lindata         linear optics at the points refered to by refpts
+        lindata         linear optics at the points refered to by refpts, if
+                        refpts is None an empty lindata structure is returned.
 
         lindata is a structured array with fields:
         idx             element index in the ring                           (nrefs,)

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -55,6 +55,19 @@ def find_m44(ring, dp=0.0, refpts=None, orbit=None, keep_lattice=False, **kwargs
         Unless an input orbit is introduced, find_m44 assumes that the lattice is a ring and first
         finds the closed orbit.
 
+    PARAMETERS
+        ring            lattice description
+        dp              momentum deviation. Defaults to 0
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
+
     KEYWORDS
         keep_lattice=False  When True, assume no lattice change since the previous tracking.
         full=False          When True, matrices are full 1-turn matrices at the entrance of each
@@ -107,6 +120,19 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
         m66:    full one-turn 6-by-6 matrix at the entrance of the first element
         t:      6x6 transfer matrices between the entrance of the first element and each element indexed by refpts:
                 (nrefs, 6, 6) array.
+
+    PARAMETERS
+        ring            lattice description
+        dp              momentum deviation. Defaults to 0
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
 
     KEYWORDS
         keep_lattice=False  When True, assume no lattice change since the previous tracking.

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -66,7 +66,8 @@ def find_m44(ring, dp=0.0, refpts=None, orbit=None, keep_lattice=False, **kwargs
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, if refpts is None an empty array is
+                        returned for mstack.
 
     KEYWORDS
         keep_lattice=False  When True, assume no lattice change since the previous tracking.
@@ -132,7 +133,8 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, if refpts is None an empty array is
+                        returned for mstack.
 
     KEYWORDS
         keep_lattice=False  When True, assume no lattice change since the previous tracking.

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -48,6 +48,19 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     ... = find_orbit4(ring,...,guess=initial_orbit)
         sets the initial search to initial_orbit
 
+    PARAMETERS
+        ring            lattice description
+        dp              momentum deviation. Defaults to 0
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
+
     See also find_sync_orbit, find_orbit6.
     """
     # We seek
@@ -139,6 +152,19 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     ... = find_sync_orbit(ring,...,guess=initial_orbit)
         sets the initial search to initial_orbit
 
+    PARAMETERS
+        ring            lattice description
+        dct              ? Defaults to 0
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
+
     See also find_orbit4, find_orbit6.
     """
     convergence = kwargs.pop('convergence', CONVERGENCE)
@@ -225,6 +251,18 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
 
     ... = find_orbit6(ring,...,guess=initial_orbit)
         sets the initial search to initial_orbit
+
+    PARAMETERS
+        ring            lattice description
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
 
     See also find_orbit4, find_sync_orbit.
     """

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -59,7 +59,8 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, if refpts is None an empty array is
+                        returned for orbit.
 
     See also find_sync_orbit, find_orbit6.
     """
@@ -163,7 +164,8 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, if refpts is None an empty array is
+                        returned for orbit.
 
     See also find_orbit4, find_orbit6.
     """
@@ -262,7 +264,8 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, if refpts is None an empty array is
+                        returned for orbit.
 
     See also find_orbit4, find_sync_orbit.
     """

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -50,7 +50,8 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     OUTPUT
         emit0               emittance data at the start/end of the ring
         beamdata            beam parameters at the start of the ring
-        emit                emittance data at the points refered to by refpts
+        emit                emittance data at the points refered to by refpts,
+                            if refpts is None an empty structure is returned.
 
         emit is a structured array with fields:
         R66                 (6, 6) equilibrium envelope matrix R

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -32,11 +32,15 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
 
     PARAMETERS
         ring                at.Lattice object
-        refpts              elements at which data is returned. It can be
-                            1) an integer (0 indicating the first element)
-                            2) a list of integers
-                            3) a numpy array of booleans as long as ring where selected elements are true
-                            Defaults to None
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
 
     KEYWORDS
         orbit=None          Avoids looking for the colsed orbit if is already known ((6,) array)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -41,7 +41,8 @@ def patpass(ring, rin, nturns, refpts=None, reuse=True, pool_size=None):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, meaning no refpts, equivelent to
+                        passing an empty array for calculation purposes.
     """
     if not reuse:
         raise ValueError('patpass does not support altering lattices')

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -28,6 +28,20 @@ def patpass(ring, rin, nturns, refpts=None, reuse=True, pool_size=None):
     Simple parallel implementation of atpass().  If more than one particle
     is supplied, use multiprocessing to run each particle in a separate
     process.
+
+    Args:
+        ring            lattice description
+        r_in:           6xN array: input coordinates of N particles
+        nturns:         number of passes through the lattice line
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
     """
     if not reuse:
         raise ValueError('patpass does not support altering lattices')

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -35,7 +35,8 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
                            len(ring)+1, where selected elements are True.
-                        Defaults to None
+                        Defaults to None, meaning no refpts, equivelent to
+                        passing an empty array for calculation purposes.
         keep_lattice: use elements persisted from a previous call to at.atpass.
                     If True, assume that the lattice has not changed since
                     that previous call.

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -27,8 +27,15 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
         lattice:    iterable of AT elements
         r_in:       6xN array: input coordinates of N particles
         nturns:     number of passes through the lattice line
-        refpts:     indices of elements at which to return coordinates (see
-                    lattice/utils.py)
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Defaults to None
         keep_lattice: use elements persisted from a previous call to at.atpass.
                     If True, assume that the lattice has not changed since
                     that previous call.

--- a/pyat/test/test_lattice.py
+++ b/pyat/test/test_lattice.py
@@ -3,20 +3,44 @@ from at import lattice, elements
 import pytest
 
 
-def test_uint32_refpts_handles_array_as_input():
-    expected = numpy.array([1, 2, 3], dtype=numpy.uint32)
-    requested = numpy.array([1, 2, 3], dtype=numpy.uint32)
-    numpy.testing.assert_equal(lattice.uint32_refpts(requested, 5),
-                               expected)
-    requested = numpy.array([1, 2, 3], dtype=numpy.float64)
-    numpy.testing.assert_equal(lattice.uint32_refpts(requested, 5),
-                               expected)
+@pytest.mark.parametrize('ref_in, expected', (
+    [2, numpy.array([2], dtype=numpy.uint32)],
+    [-1, numpy.array([4], dtype=numpy.uint32)],
+    [7, numpy.array([2], dtype=numpy.uint32)],
+    [[1, 2, 3], numpy.array([1, 2, 3], dtype=numpy.uint32)],
+    [[0, 1, 2, 3, 4, 5], numpy.array([0, 1, 2, 3, 4, 5], dtype=numpy.uint32)],
+    [[0, 6, 2, -2, 4, 5], numpy.array([0, 1, 2, 3, 4, 5], dtype=numpy.uint32)],
+))
+def test_uint32_refpts_converts_numerical_inputs_correctly(ref_in, expected):
+    numpy.testing.assert_equal(lattice.uint32_refpts(ref_in, 5), expected)
+    ref_in2 = numpy.asarray(ref_in).astype(numpy.float64)
+    numpy.testing.assert_equal(lattice.uint32_refpts(ref_in2, 5), expected)
+    ref_in2 = numpy.asarray(ref_in).astype(numpy.int64)
+    numpy.testing.assert_equal(lattice.uint32_refpts(ref_in2, 5), expected)
 
 
-@pytest.mark.parametrize('input', ([-1, 0], [0, 0], [2, 1], [0, 1, 2, 3]))
-def test_uint32_refpts_throws_ValueError_if_input_invalid(input):
+@pytest.mark.parametrize('ref_in, expected', (
+    [None, numpy.array([], dtype=numpy.uint32)],
+    [[], numpy.array([], dtype=numpy.uint32)],
+    [True, numpy.array([0], dtype=numpy.uint32)],
+    [False, numpy.array([], dtype=numpy.uint32)],
+    [[True, False, True], numpy.array([0, 2], dtype=numpy.uint32)],
+    [[False, False, False, False, False, False], numpy.array([], dtype=numpy.uint32)],
+    [[True, True, True, True, True, True], numpy.array([0, 1, 2, 3, 4, 5], dtype=numpy.uint32)]
+))
+def test_uint32_refpts_converts_other_input_types_correctly(ref_in, expected):
+    numpy.testing.assert_equal(lattice.uint32_refpts(ref_in, 5), expected)
+
+
+# too long, misordered, duplicate, -ve indexing misordered, -ve indexing
+# duplicate, wrap-around indexing misordered, wrap-around indexing duplicate,
+# -ve indexing and wrap-around indexing duplicate, -ve indexing and wrap-around
+# indexing misordered
+@pytest.mark.parametrize('ref_in', ([0, 1, 2, 3], [2, 1], [0, 0], [-1, 0],
+                                    [0, -2], [3, 0], [1, 3], [-1, 3], [3, -2]))
+def test_uint32_refpts_throws_ValueError_correctly(ref_in):
     with pytest.raises(ValueError):
-        r = lattice.uint32_refpts(input, 2)
+        r = lattice.uint32_refpts(ref_in, 2)
 
 
 def test_get_s_pos_returns_zero_for_empty_lattice():


### PR DESCRIPTION
The changes discussed on #94.
Minor notes:

- I may have put a little more checking logic into `uint32_refpts` and `bool_refpts` than you may want @lfarv; so let me know if you think any of it is overly complex or doesn't provide a meaningful benefit. I tried to make it as thorough as possible within the bounds we agreed, whilst keeping it simple.
- On that note, negative and wrap-around indexing remain available to the user; however, in their current forms, I am worried about one type of use case. Since when mixing indexing formats the `refpts`  must be provided in an unintuitive order. e.g. the intuitively ordered `[-1, 0, 2, 3, 5, 6]` would raise `ValueError('refpts should be given in ascending order')` and instead would have to be ordered like: `[0, 6, 2, 3, -1, 5]`.
- In some places, when I was adding the new refpts explanation, I also added a few other things to the docstrings; I did not fully complete the docstrings though. So, whilst better than before, they do not necessarily give a full explanation; this is because I intend to look at improving docstrings across pyat in the future.