### PR TITLE
Remove RingParam

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,30 +8,39 @@ different research institutes.
 The latest release can be found [on Github](https://github.com/atcollab/at/releases).
 
 Installation process:
+---------------------
 
 1. Install git on your computer.
 
 2. Download the latest version of AT:
-    `$ git clone https://github.com/atcollab/at.git`
+    ```
+    $ git clone https://github.com/atcollab/at.git
+    ```
 
-3. Insert recursively the directories at_installation/atmat and at_installation/atintegrators
-in the Matlab path. This can be done by:
+3. Insert recursively the directories `at_installation/atmat` and
+`at_installation/atintegrators` in the Matlab path. This can be done by:
     - Using the GUI:
         Open the "Set Path" window, press "Add with subfolders", select
-        at_installation/atmat; repeat the operation for
-        at_installation/atintegrators.
-    - Using the startup.m file:
-        Insert a line addpath(genpath(at_installation/atmat) and a similar one
-        for atintegrators.
+        `at_installation/atmat`; repeat the operation for
+        `at_installation/atintegrators`.
+    - Using the `startup.m` file:
+        Insert a line `addpath(genpath(at_installation/atmat)` and a similar
+        one for atintegrators.
     - Temporarily modifying the path by running:
-        `>> cd  at_installation/atmat`
-        `>> atpath`
+        ```
+        >> cd  at_installation/atmat
+        >> atpath
+        ```
 
 4. Compile all mexfunctions:
-    `>> atmexall`
+    ```
+    >> atmexall
+    ```
 
 5. Update helpfiles:
-    `>> atupdateContents`
+    ```
+    >> atupdateContents
+    ```
     You can now use `athelp` to list all main functions.
 
 6. Update html doc - not yet documented.

--- a/machine_data/readme.txt
+++ b/machine_data/readme.txt
@@ -1,12 +1,18 @@
-This director contains example lattice files using the creation
+This directory contains example lattice files using the creation
 functions rather than the older style relying on global variables.
 Each one can be called by writing e.g.
 ring=FODO;
 
 
-FODO.m     FODO lattice from AT2.0 Primer document
-soleil.m   soleil lattice 
-thomx.m        ThomX lattice
-esrf.m      esrf lattice 
+FODO.m                      FODO lattice from AT2.0 Primer document
+soleil.m                    soleil lattice
+thomx.m                     ThomX lattice
+esrf.m                      esrf lattice
 australian_synchrotron.m    Australian synchrotron lattice
-dba.m         dba lattice with creation functions
+dba.m                       dba lattice with creation functions
+
+These scripts can also be used to create .mat files, from which the lattices
+can be loaded in pyAT, e.g.
+
+    >>> RING = esrf()
+    >>> save('esrf.mat', 'RING')

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -57,13 +57,13 @@ class Element(object):
 
     def __str__(self):
         first3 = ['FamName', 'Length', 'PassMethod']
-        attrs = dict((k, getattr(self, k)) for k in self)
+        attrs = dict((k, v) for k, v in vars(self).items())
         keywords = ['\t{0} : {1!s}'.format(k, attrs.pop(k)) for k in first3]
         keywords += ['\t{0} : {1!s}'.format(k, v) for k, v in attrs.items()]
         return '\n'.join((self.__class__.__name__ + ':', '\n'.join(keywords)))
 
     def __repr__(self):
-        attrs = dict((k, getattr(self, k)) for k in self)
+        attrs = dict((k, v) for k, v in vars(self).items())
         arguments = [attrs.pop(k, getattr(self, k)) for k in
                      self.REQUIRED_ATTRIBUTES]
         defelem = self.__class__(*arguments)
@@ -462,3 +462,14 @@ class Corrector(LongElement):
         super(Corrector, self).__init__(family_name,
                                         Length=kwargs.pop('Length', length),
                                         KickAngle=kick_angle, **kwargs)
+
+
+class _RingParam(Element):
+    """Private class for Matlab RingParam element"""
+    REQUIRED_ATTRIBUTES = Element.REQUIRED_ATTRIBUTES + ['Energy']
+    _conversions = dict(Element._conversions, Energy=float, Periodicity=int)
+
+    def __init__(self, family_name, energy, **kwargs):
+        kwargs.setdefault('Periodicity', 1)
+        kwargs.setdefault('PassMethod', 'IdentityPass')
+        super(_RingParam, self).__init__(family_name, Energy=energy, **kwargs)

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -469,14 +469,3 @@ class Corrector(LongElement):
         super(Corrector, self).__init__(family_name,
                                         Length=kwargs.pop('Length', length),
                                         KickAngle=kick_angle, **kwargs)
-
-
-class _RingParam(Element):
-    """Private class for Matlab RingParam element"""
-    REQUIRED_ATTRIBUTES = Element.REQUIRED_ATTRIBUTES + ['Energy']
-    _conversions = dict(Element._conversions, Energy=float, Periodicity=int)
-
-    def __init__(self, family_name, energy, **kwargs):
-        kwargs.setdefault('Periodicity', 1)
-        kwargs.setdefault('PassMethod', 'IdentityPass')
-        super(_RingParam, self).__init__(family_name, Energy=energy, **kwargs)

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -7,6 +7,7 @@ responsibility to ensure that the appropriate attributes are present.
 """
 import numpy
 import copy
+from inspect import getmembers, isdatadescriptor
 
 
 def _array(value, shape=(-1,), dtype=numpy.float64):
@@ -25,6 +26,7 @@ def _nop(value):
 
 class Element(object):
     """Base of pyat elements"""
+
     REQUIRED_ATTRIBUTES = ['FamName']
     _conversions = dict(R1=_array66, R2=_array66, T1=lambda v: _array(v, (6,)),
                         T2=lambda v: _array(v, (6,)),
@@ -32,7 +34,7 @@ class Element(object):
                         EApertures=lambda v: _array(v, (2,)),
                         Energy=float,
                         )
-    
+
     _entrance_fields = ['T1', 'R1']
     _exit_fields = ['T2', 'R2']
 
@@ -52,13 +54,13 @@ class Element(object):
 
     def __str__(self):
         first3 = ['FamName', 'Length', 'PassMethod']
-        attrs = dict((k, v) for k, v in vars(self).items())
+        attrs = dict(self.items())
         keywords = ['\t{0} : {1!s}'.format(k, attrs.pop(k)) for k in first3]
         keywords += ['\t{0} : {1!s}'.format(k, v) for k, v in attrs.items()]
         return '\n'.join((self.__class__.__name__ + ':', '\n'.join(keywords)))
 
     def __repr__(self):
-        attrs = dict((k, v) for k, v in vars(self).items())
+        attrs = dict(self.items())
         arguments = [attrs.pop(k, getattr(self, k)) for k in
                      self.REQUIRED_ATTRIBUTES]
         defelem = self.__class__(*arguments)
@@ -89,6 +91,15 @@ class Element(object):
         """Return a shallow copy of the element"""
         return copy.copy(self)
 
+    def items(self):
+        """Iterates through the data members including slots and properties"""
+        # Get attributes
+        for k, v in vars(self).items():
+            yield k, v
+        # Get slots and properties
+        for k, v in getmembers(self.__class__, isdatadescriptor):
+            if not k.startswith('_'):
+                yield k, getattr(self, k)
 
 class LongElement(Element):
     """pyAT long element"""
@@ -116,6 +127,7 @@ class LongElement(Element):
         >>> Drift('dr', 0.5).divide([0.2, 0.6, 0.2])
         [Drift('dr', 0.1), Drift('dr', 0.3), Drift('dr', 0.1)]
         """
+
         def popattr(element, attr):
             val = getattr(element, attr)
             delattr(element, attr)
@@ -205,11 +217,11 @@ class Drift(LongElement):
         lg = [0.0 if el is None else el.Length for el in elements]
         fr = numpy.asarray(frac, dtype=float)
         lg = 0.5 * numpy.asarray(lg, dtype=float) / self.Length
-        drfrac = numpy.hstack((fr-lg, 1.0)) - numpy.hstack((0.0, fr+lg))
+        drfrac = numpy.hstack((fr - lg, 1.0)) - numpy.hstack((0.0, fr + lg))
         long_elems = (drfrac != 0.0)
         drifts = numpy.ndarray((len(drfrac),), dtype='O')
         drifts[long_elems] = self.divide(drfrac[long_elems])
-        line = [None]*(len(drifts)+len(elements))
+        line = [None] * (len(drifts) + len(elements))
         line[::2] = drifts
         line[1::2] = elements
         return [el for el in line if el is not None]
@@ -314,7 +326,7 @@ class Dipole(Multipole):
         kwargs.setdefault('ExitAngle', 0.0)
         kwargs.setdefault('PassMethod', 'BendLinearPass')
         super(Dipole, self).__init__(family_name, length, [], poly_b, **kwargs)
-    
+
     def _part(self, fr, sumfr):
         pp = super(Dipole, self)._part(fr, sumfr)
         pp.BendingAngle = fr / sumfr * self.BendingAngle

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -440,17 +440,6 @@ class RFCavity(LongElement):
         return pp
 
 
-class RingParam(Element):
-    """pyAT RingParam element"""
-    REQUIRED_ATTRIBUTES = Element.REQUIRED_ATTRIBUTES + ['Energy']
-    _conversions = dict(Element._conversions, Energy=float, Periodicity=int)
-
-    def __init__(self, family_name, energy, **kwargs):
-        kwargs.setdefault('Periodicity', 1)
-        kwargs.setdefault('PassMethod', 'IdentityPass')
-        super(RingParam, self).__init__(family_name, Energy=energy, **kwargs)
-
-
 class M66(Element):
     """Linear (6, 6) transfer matrix"""
     REQUIRED_ATTRIBUTES = Element.REQUIRED_ATTRIBUTES

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -50,11 +50,6 @@ class Element(object):
                         family_name, key, exc),)
                 raise
 
-    def __iter__(self):
-        """Implement iter(self)"""
-        for k in vars(self):
-            yield k
-
     def __str__(self):
         first3 = ['FamName', 'Length', 'PassMethod']
         attrs = dict((k, v) for k, v in vars(self).items())
@@ -129,9 +124,9 @@ class LongElement(Element):
         frac = numpy.asarray(frac, dtype=float)
         el = self.copy()
         # Remove entrance and exit attributes
-        fin = dict(popattr(el, key) for key in self if
+        fin = dict(popattr(el, key) for key in vars(self) if
                    key in self._entrance_fields)
-        fout = dict(popattr(el, key) for key in self if
+        fout = dict(popattr(el, key) for key in vars(self) if
                     key in self._exit_fields)
         # Split element
         element_list = [el._part(f, numpy.sum(frac)) for f in frac]

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -2,8 +2,9 @@
 Import of AT lattice from different formats:
 - .mat files
 """
-from .utils import *
-from .matfile import load_mat
+from at.load.utils import *
+from at.load.utils import _isparam
+from at.load.matfile import load_mat
 
 
 __all__ = ['load_mat']

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -2,8 +2,4 @@
 Import of AT lattice from different formats:
 - .mat files
 """
-from at.load.utils import *
-from at.load.matfile import load_mat
-
-
-__all__ = ['load_mat']
+from at.load.matfile import *

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -3,7 +3,6 @@ Import of AT lattice from different formats:
 - .mat files
 """
 from at.load.utils import *
-from at.load.utils import _isparam
 from at.load.matfile import load_mat
 
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -95,7 +95,7 @@ def _scanner(elems, **kwargs):
         if len(params) > 1:
             warn(AtWarning(
                 'More than 1 RingParam element, the 1st one is used'))
-        attributes.update((_translate.get(key, key.lower()),attr)
+        attributes.update((_translate.get(key, key.lower()), attr)
                           for key, attr in vars(params[0]).items()
                           if key not in _ignore)
     else:

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -1,9 +1,13 @@
 """
 Load lattices from Matlab files.
 """
+from warnings import warn
 import scipy.io
 import numpy
 from . import element_from_dict
+from at.lattice import elements, Lattice, AtWarning
+
+TWO_PI_ERROR = 1.E-4
 
 
 def _load_element(index, element_array, check=True, quiet=False):
@@ -21,7 +25,83 @@ def _load_element(index, element_array, check=True, quiet=False):
     return element_from_dict(kwargs, index=index, check=check, quiet=quiet)
 
 
-def load_mat(filename, key=None, check=True, quiet=False):
+def _scanner(elems, **kwargs):
+    """Extract the lattice attributes from an element list
+
+    If a RingParam element is found, its energy will be used, energies
+    defined in other elements are ignored. All its user-defined
+    attributes will also be set as Lattice attributes.
+
+    Otherwise, necessary values will be guessed from other elements.
+    """
+    _translate = {'Energy': 'energy', 'Periodicity': 'periodicity',
+                  'FamName': 'name'}
+    _ignore = {'PassMethod', 'Length'}
+
+    attributes = {}
+    params = []
+    rf_energies = []
+    el_energies = []
+    thetas = []
+
+    radiate = False
+    for elem in elems:
+        if isinstance(elem, elements.RingParam):
+            params.append(elem)
+        if hasattr(elem, 'Energy'):
+            if isinstance(elem, elements.RFCavity):
+                rf_energies.append(elem.Energy)
+            el_energies.append(elem.Energy)
+        if isinstance(elem, elements.Dipole):
+            # noinspection PyUnresolvedReferences
+            thetas.append(elem.BendingAngle)
+        if elem.PassMethod.endswith(
+                'RadPass') or elem.PassMethod.endswith('CavityPass'):
+            radiate = True
+    attributes['_radiation'] = radiate
+
+    if params:
+        # At least one RingParam element, use the 1st one
+        if len(params) > 1:
+            warn(AtWarning(
+                'More than 1 RingParam element, the 1st one is used'))
+        attributes.update((_translate.get(key, key.lower()),
+                           getattr(params[0], key))
+                          for key in params[0]
+                          if key not in _ignore)
+    else:
+        # No RingParam element, try to guess
+        attributes['name'] = ''
+        if 'energy' not in kwargs:
+            # Guess energy from the Energy attribute of the elements
+            energies = rf_energies if rf_energies else el_energies
+            if energies:
+                energy = max(energies)
+                if min(energies) < energy:
+                    warn(AtWarning('Inconsistent energy values, '
+                                   '"energy" set to {0}'.format(energy)))
+                attributes['energy'] = energy
+        if 'periodicity' not in kwargs:
+            # Guess periodicity from the bending angles of the lattice
+            try:
+                nbp = 2.0 * numpy.pi / sum(thetas)
+            except ZeroDivisionError:
+                warn(AtWarning('No bending in the cell, '
+                               'set "Periodicity" to 1'))
+                attributes['periodicity'] = 1
+            else:
+                periodicity = int(round(nbp))
+                if abs(periodicity - nbp) > TWO_PI_ERROR:
+                    warn(AtWarning(
+                        'Non-integer number of cells: '
+                        '{0} -> {1}'.format(nbp, periodicity)))
+                attributes['periodicity'] = periodicity
+
+    return attributes
+
+
+def load_mat(filename, key=None, check=True, quiet=False, keep_all=False,
+             **kwargs):
     """Load a matlab at structure into a Python at list
 
     PARAMETERS
@@ -32,14 +112,35 @@ def load_mat(filename, key=None, check=True, quiet=False):
 
     KEYWORDS
         check=True      if False, skip the coherence tests
+        quiet=False     If True, suppress the warning for non-standard classes
+        keep_all=False  if True, keep RingParam elements as Markers
+        name            Name of the lattice
+                        (default: taken from the lattice, or '')
+        energy          Energy of the lattice
+                        (default: taken from the elements)
+        periodicity     Number of periods
+                        (default: taken from the elements, or 1)
 
     OUTPUT
         list    pyat ring
     """
+    def substitute(elem):
+        if isinstance(elem, elements.RingParam):
+            params = vars(elem).copy()
+            name = params.pop('FamName')
+            return elements.Marker(name, **params)
+        else:
+            return elem
+
     m = scipy.io.loadmat(filename)
     if key is None:
         matvars = [varname for varname in m if not varname.startswith('__')]
         key = matvars[0] if (len(matvars) == 1) else 'RING'
     element_arrays = m[key].flat
-    return [_load_element(i, elem[0][0], check=check, quiet=quiet) for
-            (i, elem) in enumerate(element_arrays)]
+    elem_list = [_load_element(i, elem[0][0], check=check, quiet=quiet) for
+                 (i, elem) in enumerate(element_arrays)]
+    attrs = _scanner(elem_list, **kwargs)
+    attrs.update(kwargs)
+    if not keep_all:
+        elem_list = (substitute(elem) for elem in elem_list)
+    return Lattice(elem_list, **attrs)

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -10,17 +10,6 @@ from at.lattice import elements as elt
 from at.lattice.utils import AtWarning
 
 
-class _RingParam(elt.Element):
-    """Private class for Matlab RingParam element"""
-    REQUIRED_ATTRIBUTES = elt.Element.REQUIRED_ATTRIBUTES + ['Energy']
-    _conversions = dict(elt.Element._conversions, Energy=float, Periodicity=int)
-
-    def __init__(self, family_name, energy, **kwargs):
-        kwargs.setdefault('Periodicity', 1)
-        kwargs.setdefault('PassMethod', 'IdentityPass')
-        super(_RingParam, self).__init__(family_name, Energy=energy, **kwargs)
-
-
 _CLASS_MAP = {'multipole': elt.Multipole,
               'thinmultipole': elt.ThinMultipole,
               'dipole': elt.Dipole, 'bend': elt.Dipole,
@@ -34,7 +23,7 @@ _CLASS_MAP = {'multipole': elt.Multipole,
               'corrector': elt.Corrector,
               'monitor': elt.Monitor, 'bpm': elt.Monitor,
               'marker': elt.Marker,
-              'ringparam': _RingParam}
+              'ringparam': elt._RingParam}
 
 _PASS_MAP = {'CorrectorPass': elt.Corrector, 'BendLinearPass': elt.Dipole,
              'QuadLinearPass': elt.Quadrupole, 'RFCavityPass': elt.RFCavity,
@@ -43,11 +32,6 @@ _PASS_MAP = {'CorrectorPass': elt.Corrector, 'BendLinearPass': elt.Dipole,
              'BndMPoleSymplectic4RadPass': elt.Dipole,
              'DriftPass': elt.Drift,
              'AperturePass': elt.Aperture}
-
-
-def _isparam(elem):
-    """Chack for temporary RingParam elements"""
-    return isinstance(elem, _RingParam)
 
 
 def hasattrs(kwargs, *attributes):
@@ -122,7 +106,7 @@ def find_class(elem_dict, quiet=False):
                               'PhaseLag', 'TimeLag'):
                     return elt.RFCavity
                 elif hasattrs(elem_dict, 'Periodicity'):
-                    return _RingParam
+                    return elt._RingParam
                 elif hasattrs(elem_dict, 'Limits'):
                     return elt.Aperture
                 elif hasattrs(elem_dict, 'M66'):
@@ -195,7 +179,7 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
             elif pass_to_class is not None:
                 if not issubclass(cls, pass_to_class):
                     raise err("is not compatible with Class {0}.", class_name)
-            elif issubclass(cls, (elt.Marker, elt.Monitor, _RingParam)):
+            elif issubclass(cls, (elt.Marker, elt.Monitor, elt._RingParam)):
                 if pass_method != 'IdentityPass':
                     raise err("is not compatible with Class {0}.", class_name)
             elif cls == elt.Drift:

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -30,7 +30,7 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     emit0, beamdata, emit = ohmi_envelope(ring[, refpts])
 
     PARAMETERS
-        ring            lattice description.
+        ring            Lattice object.
         refpts=None     elements at which data is returned. It can be:
                         1) an integer in the range [-len(ring), len(ring)-1]
                            selecting the element according to python indexing
@@ -45,9 +45,6 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
                             already known                           (6,) array)
         keep_lattice=False  Assume no lattice change since the previous
                             tracking
-        energy=None         Energy of the ring; if it is not specified it is:
-                            - lattice.energy if a lattice object is passed,
-                            - otherwise, taken from the elements.
 
     OUTPUT
         emit0               emittance data at the start/end of the ring

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -22,8 +22,7 @@ ENVELOPE_DTYPE = [('r66', numpy.float64, (6, 6)),
                   ('emitXYZ', numpy.float64, (3,))]
 
 
-def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False,
-                  energy=None):
+def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     """
     Calculate the equilibrium beam envelope in a
     circular accelerator using Ohmi's beam envelope formalism [1]
@@ -118,8 +117,7 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False,
     nelems = len(ring)
     uint32refs = uint32_refpts(refpts, nelems)
     allrefs = uint32_refpts(range(nelems + 1), nelems)
-    if energy is None:
-        energy = ring.energy
+    energy = ring.energy
 
     if orbit is None:
         orbit, _ = find_orbit6(ring, keep_lattice=keep_lattice)

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -3,7 +3,6 @@ Radiation and equilibrium emittances
 """
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
-import at
 from at.lattice import uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
@@ -120,7 +119,7 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False,
     uint32refs = uint32_refpts(refpts, nelems)
     allrefs = uint32_refpts(range(nelems + 1), nelems)
     if energy is None:
-        energy = at.get_ring_properties(ring)['energy']
+        energy = ring.energy
 
     if orbit is None:
         orbit, _ = find_orbit6(ring, keep_lattice=keep_lattice)
@@ -128,8 +127,7 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False,
 
     orbs = numpy.squeeze(
         lattice_pass(ring, orbit.copy(order='K'), refpts=allrefs,
-                     keep_lattice=keep_lattice),
-        axis=(1, 3)).T
+                     keep_lattice=keep_lattice), axis=(1, 3)).T
     mring, ms = find_m66(ring, uint32refs, orbit=orbit, keep_lattice=True)
     b0 = numpy.zeros((6, 6))
     bb = [find_mpole_raddiff_matrix(elem, orbit, energy)

--- a/pyat/pyat_examples.rst
+++ b/pyat/pyat_examples.rst
@@ -1,0 +1,57 @@
+pyAT Examples
+=============
+
+Please follow ``at/pyat/README.rst`` for installation instructions.
+In these examples, we use the ring from `hmba.mat` found in ``test_matlab``;
+however, they will also work on the ``err.mat`` ring if you want to be more
+representative of a real accelerator.
+
+Initialisation:
+---------------
+
+- Start Python inside the ``pyat`` directory::
+
+    $ cd pyat
+    $ source venv/bin/activate
+    $ python
+    Python 2.7.3 (default, Nov  9 2013, 21:59:00)
+    [GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>>
+
+- Load a pyAT ring from a .mat file::
+
+    >>> import at
+    >>> ring = at.load.load_mat('test_matlab/hmba.mat')
+
+Basic Use:
+----------
+
+- Viewing the first element in the ring::
+
+    >>> ring[0]
+    RingParam('S28d', 6000000000.0, Periodicity=32)
+
+- Changing the pass method of an element::
+
+    >>> ring[1].PassMethod = "CavityPass"
+
+- Get the s position of the 10th element in the ring::
+
+    >>> at.lattice.get_s_pos(ring, 10)
+    array([3.4295565])
+
+- Creating a lattice object::
+
+    >>> lattice = at.lattice.Lattice(ring)
+
+Calculating Physics Data:
+-------------------------
+
+- Return the linear optics data at the first 5 elements::
+
+    >>> at.physics.linopt(ring, refpts=[0, 1, 2, 3, 4])
+
+- Physics data functions can also be called as methods on the lattice::
+
+    >>> lattice.find_orbit4(refpts=[0, 1, 2, 3, 4])

--- a/pyat/test/conftest.py
+++ b/pyat/test/conftest.py
@@ -40,8 +40,3 @@ def hmba_ring():
     path = os.path.realpath(os.path.join(os.path.dirname(__file__),
                                          '../test_matlab/hmba.mat'))
     return load.load_mat(path)
-
-
-@pytest.fixture(scope='session')
-def hmba_lattice(hmba_ring):
-    return lattice.Lattice(hmba_ring)

--- a/pyat/test/conftest.py
+++ b/pyat/test/conftest.py
@@ -29,14 +29,14 @@ def simple_lattice(simple_ring):
 
 
 @pytest.fixture(scope='session')
-def dba_ring():
+def dba_lattice():
     path = os.path.realpath(os.path.join(os.path.dirname(__file__),
                                          '../test_matlab/dba.mat'))
     return load.load_mat(path)
 
 
 @pytest.fixture(scope='session')
-def hmba_ring():
+def hmba_lattice():
     path = os.path.realpath(os.path.join(os.path.dirname(__file__),
                                          '../test_matlab/hmba.mat'))
     return load.load_mat(path)

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -213,16 +213,6 @@ def test_rfcavity(rin):
     expected = numpy.array([0., 0., 0., 0., 9.990769e-7, 1.e-6]).reshape(6, 1)
     numpy.testing.assert_allclose(rin, expected, atol=1e-12)
 
-
-def test_ringparam(rin):
-    rp = elements.RingParam('ringparam', 1.e+09)
-    assert rp.Length == 0
-    lattice = [rp]
-    rin = numpy.array(numpy.random.rand(*rin.shape), order='F')
-    rin_orig = numpy.array(rin, copy=True, order='F')
-    atpass(lattice, rin, 1)
-    numpy.testing.assert_equal(rin, rin_orig)
-
 @pytest.mark.parametrize("n", (0, 1, 2, 3, 4, 5))
 def test_m66(rin, n):
     m = numpy.random.rand(6, 6)

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -40,28 +40,6 @@ def test_lattice_creation_from_lattice_inherits_attributes():
     assert lat._radiation is True
     assert lat.an_attr == 12
     assert lat.another_attr == 5
-#
-#
-# def test_lattice_gets_attributes_from_RingParam():
-#     rp = elt.RingParam('lattice_name', 3.e+6, Periodicity=32)
-#     l = Lattice([rp])
-#     assert len(l) == 0
-#     assert l.name == 'lattice_name'
-#     assert l.energy == 3.e+6
-#     assert l.periodicity == 32
-#     assert l._radiation is False
-#     assert len(Lattice([rp], keep_all=True)) == 1
-#
-#
-# def test_lattice_gets_attributes_from_elements():
-#     d = elt.Dipole('d1', 1, BendingAngle=numpy.pi, Energy=3.e+6,
-#                         PassMethod='BndMPoleSymplectic4RadPass')
-#     l = Lattice([d])
-#     assert len(l) == 1
-#     assert l.name == ''
-#     assert l.energy == 3.e+6
-#     assert l.periodicity == 2
-#     assert l._radiation is True
 
 
 def test_lattice_energy_is_not_defined_raises_AtError():
@@ -69,33 +47,9 @@ def test_lattice_energy_is_not_defined_raises_AtError():
         Lattice()
 
 
-# def test_no_bending_in_the_cell_warns_correctly():
-#     with pytest.warns(AtWarning):
-#         Lattice([], energy=0)
-
-
 def test_item_is_not_an_AT_element_warns_correctly():
     with pytest.warns(AtWarning):
         Lattice(['a'], energy=0, periodicity=1)
-
-
-# def test__non_integer_number_of_cells_warns_correctly():
-#     d = elt.Dipole('d1', 1, BendingAngle=0.5)
-#     with pytest.warns(AtWarning):
-#         Lattice([d], energy=0)
-#
-#
-# def test_inconsistent_energy_values_warns_correctly():
-#     m1 = elt.Marker('m1', Energy=5)
-#     m2 = elt.Marker('m2', Energy=3)
-#     with pytest.warns(AtWarning):
-#         Lattice([m1, m2], periodicity=1)
-#
-#
-# def test_more_than_one_RingParam_in_ring_raises_warning():
-#     with pytest.warns(AtWarning):
-#         l = Lattice([elt.RingParam('rp1', 3.e+6),
-#                      elt.RingParam('rp2', 12)])
 
 
 def test_lattice_string_ordering():
@@ -146,41 +100,41 @@ def test_delitem(simple_lattice, simple_ring):
     assert simple_lattice[:] == simple_ring
 
 
-def test_copy(hmba_ring):
-    assert id(hmba_ring.copy()) != id(hmba_ring)
-    assert id(hmba_ring.copy()[0]) == id(hmba_ring[0])
+def test_copy(hmba_lattice):
+    assert id(hmba_lattice.copy()) != id(hmba_lattice)
+    assert id(hmba_lattice.copy()[0]) == id(hmba_lattice[0])
 
 
-def test_deepcopy(hmba_ring):
-    assert id(hmba_ring.deepcopy()) != id(hmba_ring)
-    assert id(hmba_ring.deepcopy()[0]) != id(hmba_ring[0])
+def test_deepcopy(hmba_lattice):
+    assert id(hmba_lattice.deepcopy()) != id(hmba_lattice)
+    assert id(hmba_lattice.deepcopy()[0]) != id(hmba_lattice[0])
 
 
-def test_property_values_against_known(hmba_ring):
-    assert hmba_ring.voltage == 6000000
-    assert hmba_ring.harmonic_number == 992
-    assert hmba_ring.radiation == False
-    numpy.testing.assert_almost_equal(hmba_ring.energy_loss,
+def test_property_values_against_known(hmba_lattice):
+    assert hmba_lattice.voltage == 6000000
+    assert hmba_lattice.harmonic_number == 992
+    assert hmba_lattice.radiation == False
+    numpy.testing.assert_almost_equal(hmba_lattice.energy_loss,
                                       2526188.713461808)
 
 
-def test_radiation_change(hmba_ring):
-    rfs = [elem for elem in hmba_ring if isinstance(elem,
+def test_radiation_change(hmba_lattice):
+    rfs = [elem for elem in hmba_lattice if isinstance(elem,
                                                        elements.RFCavity)]
-    dipoles = [elem for elem in hmba_ring if isinstance(elem,
+    dipoles = [elem for elem in hmba_lattice if isinstance(elem,
                                                            elements.Dipole)]
-    quads = [elem for elem in hmba_ring if isinstance(elem,
+    quads = [elem for elem in hmba_lattice if isinstance(elem,
                                                          elements.Quadrupole)]
-    hmba_ring.radiation_on(None, 'pass2', 'auto')
-    assert hmba_ring.radiation == True
+    hmba_lattice.radiation_on(None, 'pass2', 'auto')
+    assert hmba_lattice.radiation == True
     for elem in rfs:
         assert elem.PassMethod == 'IdentityPass'
     for elem in dipoles:
         assert elem.PassMethod == 'pass2'
     for elem in quads:
         assert elem.PassMethod == 'StrMPoleSymplectic4RadPass'
-    hmba_ring.radiation_off(None, 'BndMPoleSymplectic4Pass', 'auto')
-    assert hmba_ring.radiation == False
+    hmba_lattice.radiation_off(None, 'BndMPoleSymplectic4Pass', 'auto')
+    assert hmba_lattice.radiation == False
     for elem in rfs:
         assert elem.PassMethod == 'IdentityPass'
     for elem in dipoles:
@@ -189,17 +143,17 @@ def test_radiation_change(hmba_ring):
         assert elem.PassMethod == 'StrMPoleSymplectic4Pass'
 
 
-def test_radiation_state_errors(hmba_ring):
-    hmba_ring.radiation_on()
+def test_radiation_state_errors(hmba_lattice):
+    hmba_lattice.radiation_on()
     with pytest.raises(AtError):
-        hmba_ring.linopt()
-    hmba_ring.radiation_off()
-    hmba_ring.linopt()
+        hmba_lattice.linopt()
+    hmba_lattice.radiation_off()
+    hmba_lattice.linopt()
     with pytest.raises(AtError):
-        hmba_ring.ohmi_envelope()
-    hmba_ring.radiation_on()
-    hmba_ring.ohmi_envelope()
+        hmba_lattice.ohmi_envelope()
+    hmba_lattice.radiation_on()
+    hmba_lattice.ohmi_envelope()
     with pytest.raises(AtError):
-        hmba_ring.get_mcf()
-    hmba_ring.radiation_off()
-    hmba_ring.get_mcf()
+        hmba_lattice.get_mcf()
+    hmba_lattice.radiation_off()
+    hmba_lattice.get_mcf()

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -2,7 +2,6 @@ import sys
 import numpy
 import pytest
 from at import elements
-from at.load import load_mat
 from at.lattice import Lattice, AtWarning, AtError
 
 
@@ -41,28 +40,28 @@ def test_lattice_creation_from_lattice_inherits_attributes():
     assert lat._radiation is True
     assert lat.an_attr == 12
     assert lat.another_attr == 5
-
-
-def test_lattice_gets_attributes_from_RingParam():
-    rp = elements.RingParam('lattice_name', 3.e+6, Periodicity=32)
-    l = Lattice([rp])
-    assert len(l) == 0
-    assert l.name == 'lattice_name'
-    assert l.energy == 3.e+6
-    assert l.periodicity == 32
-    assert l._radiation is False
-    assert len(Lattice([rp], keep_all=True)) == 1
-
-
-def test_lattice_gets_attributes_from_elements():
-    d = elements.Dipole('d1', 1, BendingAngle=numpy.pi, Energy=3.e+6,
-                        PassMethod='BndMPoleSymplectic4RadPass')
-    l = Lattice([d])
-    assert len(l) == 1
-    assert l.name == ''
-    assert l.energy == 3.e+6
-    assert l.periodicity == 2
-    assert l._radiation is True
+#
+#
+# def test_lattice_gets_attributes_from_RingParam():
+#     rp = elt.RingParam('lattice_name', 3.e+6, Periodicity=32)
+#     l = Lattice([rp])
+#     assert len(l) == 0
+#     assert l.name == 'lattice_name'
+#     assert l.energy == 3.e+6
+#     assert l.periodicity == 32
+#     assert l._radiation is False
+#     assert len(Lattice([rp], keep_all=True)) == 1
+#
+#
+# def test_lattice_gets_attributes_from_elements():
+#     d = elt.Dipole('d1', 1, BendingAngle=numpy.pi, Energy=3.e+6,
+#                         PassMethod='BndMPoleSymplectic4RadPass')
+#     l = Lattice([d])
+#     assert len(l) == 1
+#     assert l.name == ''
+#     assert l.energy == 3.e+6
+#     assert l.periodicity == 2
+#     assert l._radiation is True
 
 
 def test_lattice_energy_is_not_defined_raises_AtError():
@@ -70,9 +69,9 @@ def test_lattice_energy_is_not_defined_raises_AtError():
         Lattice()
 
 
-def test_no_bending_in_the_cell_warns_correctly():
-    with pytest.warns(AtWarning):
-        Lattice([], energy=0)
+# def test_no_bending_in_the_cell_warns_correctly():
+#     with pytest.warns(AtWarning):
+#         Lattice([], energy=0)
 
 
 def test_item_is_not_an_AT_element_warns_correctly():
@@ -80,23 +79,23 @@ def test_item_is_not_an_AT_element_warns_correctly():
         Lattice(['a'], energy=0, periodicity=1)
 
 
-def test__non_integer_number_of_cells_warns_correctly():
-    d = elements.Dipole('d1', 1, BendingAngle=0.5)
-    with pytest.warns(AtWarning):
-        Lattice([d], energy=0)
-
-
-def test_inconsistent_energy_values_warns_correctly():
-    m1 = elements.Marker('m1', Energy=5)
-    m2 = elements.Marker('m2', Energy=3)
-    with pytest.warns(AtWarning):
-        Lattice([m1, m2], periodicity=1)
-
-
-def test_more_than_one_RingParam_in_ring_raises_warning():
-    with pytest.warns(AtWarning):
-        l = Lattice([elements.RingParam('rp1', 3.e+6),
-                     elements.RingParam('rp2', 12)])
+# def test__non_integer_number_of_cells_warns_correctly():
+#     d = elt.Dipole('d1', 1, BendingAngle=0.5)
+#     with pytest.warns(AtWarning):
+#         Lattice([d], energy=0)
+#
+#
+# def test_inconsistent_energy_values_warns_correctly():
+#     m1 = elt.Marker('m1', Energy=5)
+#     m2 = elt.Marker('m2', Energy=3)
+#     with pytest.warns(AtWarning):
+#         Lattice([m1, m2], periodicity=1)
+#
+#
+# def test_more_than_one_RingParam_in_ring_raises_warning():
+#     with pytest.warns(AtWarning):
+#         l = Lattice([elt.RingParam('rp1', 3.e+6),
+#                      elt.RingParam('rp2', 12)])
 
 
 def test_lattice_string_ordering():
@@ -110,11 +109,10 @@ def test_lattice_string_ordering():
                                        "attr1=array(0))], ")
         assert l.__repr__().endswith(", attr2=3)")
     else:
-        assert l.__str__() == ("Lattice(<1 elements>, energy=5, periodicity=1,"
-                               " name='lat', attr2=3)")
-        assert l.__repr__() == ("Lattice([Drift('D0', 1.0, attr1=array(0))],"
-                                " energy=5, periodicity=1, name='lat', "
-                                "attr2=3)")
+        assert l.__str__() == ("Lattice(<1 elements>, "
+                               "name='lat', energy=5, periodicity=1, attr2=3)")
+        assert l.__repr__() == ("Lattice([Drift('D0', 1.0, attr1=array(0))], "
+                                "name='lat', energy=5, periodicity=1, attr2=3)")
 
 
 def test_getitem(simple_lattice, simple_ring):
@@ -148,41 +146,41 @@ def test_delitem(simple_lattice, simple_ring):
     assert simple_lattice[:] == simple_ring
 
 
-def test_copy(hmba_lattice):
-    assert id(hmba_lattice.copy()) != id(hmba_lattice)
-    assert id(hmba_lattice.copy()[0]) == id(hmba_lattice[0])
+def test_copy(hmba_ring):
+    assert id(hmba_ring.copy()) != id(hmba_ring)
+    assert id(hmba_ring.copy()[0]) == id(hmba_ring[0])
 
 
-def test_deepcopy(hmba_lattice):
-    assert id(hmba_lattice.deepcopy()) != id(hmba_lattice)
-    assert id(hmba_lattice.deepcopy()[0]) != id(hmba_lattice[0])
+def test_deepcopy(hmba_ring):
+    assert id(hmba_ring.deepcopy()) != id(hmba_ring)
+    assert id(hmba_ring.deepcopy()[0]) != id(hmba_ring[0])
 
 
-def test_property_values_against_known(hmba_lattice):
-    assert hmba_lattice.voltage == 6000000
-    assert hmba_lattice.harmonic_number == 992
-    assert hmba_lattice.radiation == False
-    numpy.testing.assert_almost_equal(hmba_lattice.energy_loss,
+def test_property_values_against_known(hmba_ring):
+    assert hmba_ring.voltage == 6000000
+    assert hmba_ring.harmonic_number == 992
+    assert hmba_ring.radiation == False
+    numpy.testing.assert_almost_equal(hmba_ring.energy_loss,
                                       2526188.713461808)
 
 
-def test_radiation_change(hmba_lattice):
-    rfs = [elem for elem in hmba_lattice if isinstance(elem,
+def test_radiation_change(hmba_ring):
+    rfs = [elem for elem in hmba_ring if isinstance(elem,
                                                        elements.RFCavity)]
-    dipoles = [elem for elem in hmba_lattice if isinstance(elem,
+    dipoles = [elem for elem in hmba_ring if isinstance(elem,
                                                            elements.Dipole)]
-    quads = [elem for elem in hmba_lattice if isinstance(elem,
+    quads = [elem for elem in hmba_ring if isinstance(elem,
                                                          elements.Quadrupole)]
-    hmba_lattice.radiation_on(None, 'pass2', 'auto')
-    assert hmba_lattice.radiation == True
+    hmba_ring.radiation_on(None, 'pass2', 'auto')
+    assert hmba_ring.radiation == True
     for elem in rfs:
         assert elem.PassMethod == 'IdentityPass'
     for elem in dipoles:
         assert elem.PassMethod == 'pass2'
     for elem in quads:
         assert elem.PassMethod == 'StrMPoleSymplectic4RadPass'
-    hmba_lattice.radiation_off(None, 'BndMPoleSymplectic4Pass', 'auto')
-    assert hmba_lattice.radiation == False
+    hmba_ring.radiation_off(None, 'BndMPoleSymplectic4Pass', 'auto')
+    assert hmba_ring.radiation == False
     for elem in rfs:
         assert elem.PassMethod == 'IdentityPass'
     for elem in dipoles:
@@ -191,17 +189,17 @@ def test_radiation_change(hmba_lattice):
         assert elem.PassMethod == 'StrMPoleSymplectic4Pass'
 
 
-def test_radiation_state_errors(hmba_lattice):
-    hmba_lattice.radiation_on()
+def test_radiation_state_errors(hmba_ring):
+    hmba_ring.radiation_on()
     with pytest.raises(AtError):
-        hmba_lattice.linopt()
-    hmba_lattice.radiation_off()
-    hmba_lattice.linopt()
+        hmba_ring.linopt()
+    hmba_ring.radiation_off()
+    hmba_ring.linopt()
     with pytest.raises(AtError):
-        hmba_lattice.ohmi_envelope()
-    hmba_lattice.radiation_on()
-    hmba_lattice.ohmi_envelope()
+        hmba_ring.ohmi_envelope()
+    hmba_ring.radiation_on()
+    hmba_ring.ohmi_envelope()
     with pytest.raises(AtError):
-        hmba_lattice.get_mcf()
-    hmba_lattice.radiation_off()
-    hmba_lattice.get_mcf()
+        hmba_ring.get_mcf()
+    hmba_ring.radiation_off()
+    hmba_ring.get_mcf()

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -97,36 +97,36 @@ def test_refpts_iterator(simple_ring):
     assert list(refpts_iterator(simple_ring, a)) == [simple_ring[1]]
 
 
-def test_get_elements(hmba_ring):
+def test_get_elements(hmba_lattice):
     # test FamName direct match
-    assert get_elements(hmba_ring, 'BPM_06') == [hmba_ring[65]]
+    assert get_elements(hmba_lattice, 'BPM_06') == [hmba_lattice[65]]
     # test FamName wildcard matching
-    assert get_elements(hmba_ring, 'QD2?') == list(hmba_ring[9, 113])
-    assert get_elements(hmba_ring, 'QD3*') == list(hmba_ring[19, 105])
-    assert get_elements(hmba_ring, 'S*H2B') == list([hmba_ring[55]])
-    assert get_elements(hmba_ring, '*C_1') == list(hmba_ring[59, 60])
-    assert get_elements(hmba_ring, 'DR_2[1-3]') == list(hmba_ring[54, 56, 58])
-    assert get_elements(hmba_ring, 'DR_2[!1-7]') == list(hmba_ring[52, 78, 80])
+    assert get_elements(hmba_lattice, 'QD2?') == list(hmba_lattice[9, 113])
+    assert get_elements(hmba_lattice, 'QD3*') == list(hmba_lattice[19, 105])
+    assert get_elements(hmba_lattice, 'S*H2B') == list([hmba_lattice[55]])
+    assert get_elements(hmba_lattice, '*C_1') == list(hmba_lattice[59, 60])
+    assert get_elements(hmba_lattice, 'DR_2[1-3]') == list(hmba_lattice[54, 56, 58])
+    assert get_elements(hmba_lattice, 'DR_2[!1-7]') == list(hmba_lattice[52, 78, 80])
     # test element instance
     marker = elements.Marker('M1')
-    assert get_elements(hmba_ring, marker) == list(hmba_ring[1, 12, 61,
+    assert get_elements(hmba_lattice, marker) == list(hmba_lattice[1, 12, 61,
                                                               67, 73])
     # test element type
-    assert get_elements(hmba_ring, elements.RFCavity) == [hmba_ring[0]]
+    assert get_elements(hmba_lattice, elements.RFCavity) == [hmba_lattice[0]]
     # test invalid key raises TypeError
     with pytest.raises(TypeError):
-        get_elements(hmba_ring, None)
+        get_elements(hmba_lattice, None)
     # test quiet suppresses print statement correctly
     if sys.version_info < (3, 0):
         capturedOutput = BytesIO()
     else:
         capturedOutput = StringIO()
     sys.stdout = capturedOutput
-    get_elements(hmba_ring, 'BPM_06', quiet=True)
+    get_elements(hmba_lattice, 'BPM_06', quiet=True)
     sys.stdout = sys.__stdout__
     assert capturedOutput.getvalue() == ''
     sys.stdout = capturedOutput
-    get_elements(hmba_ring, 'BPM_06', quiet=False)
+    get_elements(hmba_lattice, 'BPM_06', quiet=False)
     sys.stdout = sys.__stdout__
     assert capturedOutput.getvalue() == ("String 'BPM_06' matched 1 family: "
                                          "BPM_06\nall corresponding elements "

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -97,36 +97,36 @@ def test_refpts_iterator(simple_ring):
     assert list(refpts_iterator(simple_ring, a)) == [simple_ring[1]]
 
 
-def test_get_elements(hmba_lattice):
+def test_get_elements(hmba_ring):
     # test FamName direct match
-    assert get_elements(hmba_lattice, 'BPM_06') == [hmba_lattice[65]]
+    assert get_elements(hmba_ring, 'BPM_06') == [hmba_ring[65]]
     # test FamName wildcard matching
-    assert get_elements(hmba_lattice, 'QD2?') == hmba_lattice[9, 113]
-    assert get_elements(hmba_lattice, 'QD3*') == hmba_lattice[19, 105]
-    assert get_elements(hmba_lattice, 'S*H2B') == [hmba_lattice[55]]
-    assert get_elements(hmba_lattice, '*C_1') == hmba_lattice[59, 60]
-    assert get_elements(hmba_lattice, 'DR_2[1-3]') == hmba_lattice[54, 56, 58]
-    assert get_elements(hmba_lattice, 'DR_2[!1-7]') == hmba_lattice[52, 78, 80]
+    assert get_elements(hmba_ring, 'QD2?') == list(hmba_ring[9, 113])
+    assert get_elements(hmba_ring, 'QD3*') == list(hmba_ring[19, 105])
+    assert get_elements(hmba_ring, 'S*H2B') == list([hmba_ring[55]])
+    assert get_elements(hmba_ring, '*C_1') == list(hmba_ring[59, 60])
+    assert get_elements(hmba_ring, 'DR_2[1-3]') == list(hmba_ring[54, 56, 58])
+    assert get_elements(hmba_ring, 'DR_2[!1-7]') == list(hmba_ring[52, 78, 80])
     # test element instance
     marker = elements.Marker('M1')
-    assert get_elements(hmba_lattice, marker) == hmba_lattice[1, 12, 61,
-                                                              67, 73]
+    assert get_elements(hmba_ring, marker) == list(hmba_ring[1, 12, 61,
+                                                              67, 73])
     # test element type
-    assert get_elements(hmba_lattice, elements.RFCavity) == [hmba_lattice[0]]
+    assert get_elements(hmba_ring, elements.RFCavity) == [hmba_ring[0]]
     # test invalid key raises TypeError
     with pytest.raises(TypeError):
-        get_elements(hmba_lattice, None)
+        get_elements(hmba_ring, None)
     # test quiet suppresses print statement correctly
     if sys.version_info < (3, 0):
         capturedOutput = BytesIO()
     else:
         capturedOutput = StringIO()
     sys.stdout = capturedOutput
-    get_elements(hmba_lattice, 'BPM_06', quiet=True)
+    get_elements(hmba_ring, 'BPM_06', quiet=True)
     sys.stdout = sys.__stdout__
     assert capturedOutput.getvalue() == ''
     sys.stdout = capturedOutput
-    get_elements(hmba_lattice, 'BPM_06', quiet=False)
+    get_elements(hmba_ring, 'BPM_06', quiet=False)
     sys.stdout = sys.__stdout__
     assert capturedOutput.getvalue() == ("String 'BPM_06' matched 1 family: "
                                          "BPM_06\nall corresponding elements "

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -1,8 +1,8 @@
 import at
 import numpy
 import pytest
-from at.load import find_class_name, element_from_dict
-from at.load import CLASS_MAPPING, PASS_MAPPING
+from at.load.utils import find_class_name, element_from_dict
+from at.load.utils import CLASS_MAPPING, PASS_MAPPING
 
 
 def test_invalid_class_warns_correctly():

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -93,11 +93,6 @@ def test_find_Corrector():
     assert find_class_name(elem_kwargs, True) == 'Corrector'
 
 
-def test_find_RingParam():
-    elem_kwargs = {'Periodicity': 1, 'FamName': 'fam'}
-    assert find_class_name(elem_kwargs, True) == 'RingParam'
-
-
 def test_find_M66():
     elem_kwargs = {'M66': numpy.eye(6), 'FamName': 'fam'}
     assert find_class_name(elem_kwargs, True) == 'M66'

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -1,8 +1,8 @@
 import at
 import numpy
 import pytest
-from at import physics, load, atpass, elements
-from at.lattice import AtWarning, AtError
+from at import physics, atpass
+from at.lattice import AtWarning
 
 
 DP = 1e-5
@@ -77,10 +77,10 @@ def test_find_m66(hmba_ring, refpts):
     assert mstack.shape == (stack_size, 6, 6)
 
 
-@pytest.mark.parametrize('index', (20, 1, 2))
+@pytest.mark.parametrize('index', (19, 0, 1))
 def test_find_elem_m66(hmba_ring, index):
     m66 = physics.find_elem_m66(hmba_ring[index])
-    if index is 20:
+    if index is 19:
         expected = numpy.array([[1.0386, 0.180911, 0., 0., 0., 0.],
                                 [0.434959, 1.0386, 0., 0., 0., 0.],
                                 [0., 0., 0.961891, 0.176344, 0., 0.],
@@ -225,11 +225,11 @@ def test_linopt_no_refpts(dba_ring):
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
 @pytest.mark.parametrize('ring_test', (False, True))
-def test_ohmi_envelope(hmba_lattice, refpts, ring_test):
-    hmba_lattice.radiation_on()
+def test_ohmi_envelope(hmba_ring, refpts, ring_test):
+    hmba_ring.radiation_on()
     if ring_test:
-        hmba_lattice = hmba_lattice[:]
-    emit0, beamdata, emit = physics.ohmi_envelope(hmba_lattice, refpts)
+        hmba_ring = hmba_ring[:]
+    emit0, beamdata, emit = physics.ohmi_envelope(hmba_ring, refpts)
     expected_beamdata = [([0.38156302, 0.85437641, 1.0906073e-4]),
                          ([1.0044543e-5, 6.6238162e-6, 9.6533473e-6]),
                          ([[[6.9000153, -2.6064253e-5, 1.643376e-25,

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -12,60 +12,60 @@ M44_MATLAB = numpy.array([[-0.66380202, 2.23414498, 0, 0],
                           [0, 0, -0.0059496965, -0.99921979]])
 
 
-def test_find_orbit4(dba_ring):
-    orbit4, _ = physics.find_orbit4(dba_ring, DP)
+def test_find_orbit4(dba_lattice):
+    orbit4, _ = physics.find_orbit4(dba_lattice, DP)
     expected = numpy.array([1.091636e-7, 1.276747e-15, 0, 0, DP, 0])
     numpy.testing.assert_allclose(orbit4, expected, atol=1e-12)
 
 
-def test_find_orbit4_finds_zeros_if_dp_zero(dba_ring):
-    orbit4, _ = physics.find_orbit4(dba_ring, 0)
+def test_find_orbit4_finds_zeros_if_dp_zero(dba_lattice):
+    orbit4, _ = physics.find_orbit4(dba_lattice, 0)
     expected = numpy.zeros((6,))
     numpy.testing.assert_allclose(orbit4, expected, atol=1e-7)
 
 
-def test_find_orbit4_result_unchanged_by_atpass(dba_ring):
-    orbit, _ = physics.find_orbit4(dba_ring, DP)
+def test_find_orbit4_result_unchanged_by_atpass(dba_lattice):
+    orbit, _ = physics.find_orbit4(dba_lattice, DP)
     orbit_copy = numpy.copy(orbit)
     orbit[4] = DP
-    atpass(dba_ring, orbit, 1)
+    atpass(dba_lattice, orbit, 1)
     numpy.testing.assert_allclose(orbit[:4], orbit_copy[:4], atol=1e-12)
 
 
-def test_find_orbit4_with_two_refpts_with_and_without_guess(dba_ring):
+def test_find_orbit4_with_two_refpts_with_and_without_guess(dba_lattice):
     expected = numpy.array(
         [[8.148212e-6, 1.0993354e-5, 0, 0, DP, 2.963929e-6],
          [3.0422808e-8, 9.1635269e-8, 0, 0, DP, 5.9280346e-6]]
     )
-    _, all_points = physics.find_orbit4(dba_ring, DP, [49, 99])
+    _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99])
     numpy.testing.assert_allclose(all_points, expected, atol=1e-12)
-    _, all_points = physics.find_orbit4(dba_ring, DP, [49, 99],
+    _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99],
                                         numpy.array([0., 0., 0., 0., DP, 0.]))
     numpy.testing.assert_allclose(all_points, expected, atol=1e-12)
 
 
-def test_orbit_maxiter_warnings(hmba_ring):
+def test_orbit_maxiter_warnings(hmba_lattice):
     with pytest.warns(AtWarning):
-        physics.find_orbit4(hmba_ring, max_iterations=1)
+        physics.find_orbit4(hmba_lattice, max_iterations=1)
     with pytest.warns(AtWarning):
-        physics.find_sync_orbit(hmba_ring, max_iterations=1)
+        physics.find_sync_orbit(hmba_lattice, max_iterations=1)
     with pytest.warns(AtWarning):
-        physics.find_orbit6(hmba_ring, max_iterations=1)
+        physics.find_orbit6(hmba_lattice, max_iterations=1)
 
 
 @pytest.mark.parametrize('refpts', ([145], [20], [1, 2, 3]))
-def test_find_m44_returns_same_answer_as_matlab(dba_ring, refpts):
-    m44, mstack = physics.find_m44(dba_ring, dp=DP, refpts=refpts)
+def test_find_m44_returns_same_answer_as_matlab(dba_lattice, refpts):
+    m44, mstack = physics.find_m44(dba_lattice, dp=DP, refpts=refpts)
     numpy.testing.assert_allclose(m44, M44_MATLAB, rtol=1e-5, atol=1e-7)
     assert mstack.shape == (len(refpts), 4, 4)
-    m44, mstack = physics.find_m44(dba_ring, dp=DP, refpts=refpts, full=True)
+    m44, mstack = physics.find_m44(dba_lattice, dp=DP, refpts=refpts, full=True)
     numpy.testing.assert_allclose(m44, M44_MATLAB, rtol=1e-5, atol=1e-7)
     assert mstack.shape == (len(refpts), 4, 4)
 
 
 @pytest.mark.parametrize('refpts', ([145], [20], [1, 2, 3]))
-def test_find_m66(hmba_ring, refpts):
-    m66, mstack = physics.find_m66(hmba_ring, refpts=refpts)
+def test_find_m66(hmba_lattice, refpts):
+    m66, mstack = physics.find_m66(hmba_lattice, refpts=refpts)
     expected = numpy.array([[-0.735654, 4.673766, 0., 0., 2.997161e-3, 0.],
                             [-9.816788e-2, -0.735654, 0., 0., 1.695263e-4, 0.],
                             [0., 0., 0.609804, -2.096051, 0., 0.],
@@ -78,8 +78,8 @@ def test_find_m66(hmba_ring, refpts):
 
 
 @pytest.mark.parametrize('index', (19, 0, 1))
-def test_find_elem_m66(hmba_ring, index):
-    m66 = physics.find_elem_m66(hmba_ring[index])
+def test_find_elem_m66(hmba_lattice, index):
+    m66 = physics.find_elem_m66(hmba_lattice[index])
     if index is 19:
         expected = numpy.array([[1.0386, 0.180911, 0., 0., 0., 0.],
                                 [0.434959, 1.0386, 0., 0., 0., 0.],
@@ -92,32 +92,32 @@ def test_find_elem_m66(hmba_ring, index):
     numpy.testing.assert_allclose(m66, expected, rtol=1e-5, atol=1e-7)
 
 
-def test_find_sync_orbit(dba_ring):
+def test_find_sync_orbit(dba_lattice):
     expected = numpy.array([[1.030844e-5, 1.390795e-5, -2.439041e-30,
                              4.701621e-30, 1.265181e-5, 3.749859e-6],
                             [3.86388e-8, 1.163782e-7, -9.671192e-30,
                              3.567819e-30, 1.265181e-5, 7.5e-6]])
-    _, all_points = physics.find_sync_orbit(dba_ring, DP, [49, 99])
+    _, all_points = physics.find_sync_orbit(dba_lattice, DP, [49, 99])
     numpy.testing.assert_allclose(all_points, expected, rtol=1e-5, atol=1e-7)
 
 
-def test_find_sync_orbit_finds_zeros(dba_ring):
-    sync_orbit = physics.find_sync_orbit(dba_ring)[0]
+def test_find_sync_orbit_finds_zeros(dba_lattice):
+    sync_orbit = physics.find_sync_orbit(dba_lattice)[0]
     numpy.testing.assert_equal(sync_orbit, numpy.zeros(6))
 
 
-def test_find_orbit6(hmba_ring):
-    expected = numpy.zeros((len(hmba_ring), 6))
-    refpts = numpy.ones(len(hmba_ring), dtype=bool)
-    _, all_points = physics.find_orbit6(hmba_ring, refpts)
+def test_find_orbit6(hmba_lattice):
+    expected = numpy.zeros((len(hmba_lattice), 6))
+    refpts = numpy.ones(len(hmba_lattice), dtype=bool)
+    _, all_points = physics.find_orbit6(hmba_lattice, refpts)
     numpy.testing.assert_allclose(all_points, expected, atol=1e-12)
 
-def test_find_orbit6_raises_AtError_if_there_is_no_cavity(dba_ring):
+def test_find_orbit6_raises_AtError_if_there_is_no_cavity(dba_lattice):
     with pytest.raises(at.lattice.utils.AtError):
-        physics.find_orbit6(dba_ring)
+        physics.find_orbit6(dba_lattice)
 
-def test_find_m44_no_refpts(dba_ring):
-    m44 = physics.find_m44(dba_ring, dp=DP)[0]
+def test_find_m44_no_refpts(dba_lattice):
+    m44 = physics.find_m44(dba_lattice, dp=DP)[0]
     expected = numpy.array([[-0.66380, 2.23415, 0., 0.],
                             [-0.25037, -0.66380, 0.,0.],
                             [-1.45698e-31, -1.15008e-30, -0.99922, 0.26217],
@@ -126,8 +126,8 @@ def test_find_m44_no_refpts(dba_ring):
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
-def test_get_twiss(dba_ring, refpts):
-    twiss0, tune, chrom, twiss = physics.get_twiss(dba_ring, DP, refpts,
+def test_get_twiss(dba_lattice, refpts):
+    twiss0, tune, chrom, twiss = physics.get_twiss(dba_lattice, DP, refpts,
                                                    get_chrom=True)
     numpy.testing.assert_allclose(twiss['s_pos'][-1], 56.209377216, atol=1e-9)
     numpy.testing.assert_allclose(twiss['closed_orbit'][0][:5],
@@ -142,15 +142,15 @@ def test_get_twiss(dba_ring, refpts):
                                   atol=1e-7)
 
 
-def test_get_twiss_no_refpts(dba_ring):
-    twiss0, tune, chrom, twiss = physics.get_twiss(dba_ring, DP, get_chrom=True)
+def test_get_twiss_no_refpts(dba_lattice):
+    twiss0, tune, chrom, twiss = physics.get_twiss(dba_lattice, DP, get_chrom=True)
     assert list(twiss) == []
-    assert len(physics.get_twiss(dba_ring, DP, get_chrom=True)) is 4
+    assert len(physics.get_twiss(dba_lattice, DP, get_chrom=True)) is 4
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
-def test_linopt(dba_ring, refpts):
-    lindata0, tune, chrom, lindata = physics.linopt(dba_ring, DP, refpts,
+def test_linopt(dba_lattice, refpts):
+    lindata0, tune, chrom, lindata = physics.linopt(dba_lattice, DP, refpts,
                                                     get_chrom=True)
     numpy.testing.assert_allclose(tune, [0.365529, 0.493713], rtol=1e-5)
     numpy.testing.assert_allclose(chrom, [-0.309037, -0.441859], rtol=1e-5)
@@ -186,8 +186,8 @@ def test_linopt(dba_ring, refpts):
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
-def test_linopt_uncoupled(dba_ring, refpts):
-    lindata0, tune, chrom, lindata = physics.linopt(dba_ring, DP, refpts,
+def test_linopt_uncoupled(dba_lattice, refpts):
+    lindata0, tune, chrom, lindata = physics.linopt(dba_lattice, DP, refpts,
                                                     coupled=False)
     numpy.testing.assert_allclose(tune, [0.365529, 0.493713], rtol=1e-5)
     numpy.testing.assert_allclose(lindata['s_pos'][-1], 56.209377216, atol=1e-9)
@@ -217,19 +217,19 @@ def test_linopt_uncoupled(dba_ring, refpts):
                                   rtol=1e-5, atol=1e-7)
 
 
-def test_linopt_no_refpts(dba_ring):
-    lindata0, tune, chrom, lindata = physics.linopt(dba_ring, DP, get_chrom=True)
+def test_linopt_no_refpts(dba_lattice):
+    lindata0, tune, chrom, lindata = physics.linopt(dba_lattice, DP, get_chrom=True)
     assert list(lindata) == []
-    assert len(physics.linopt(dba_ring, DP, get_chrom=True)) is 4
+    assert len(physics.linopt(dba_lattice, DP, get_chrom=True)) is 4
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
 @pytest.mark.parametrize('ring_test', (False, True))
-def test_ohmi_envelope(hmba_ring, refpts, ring_test):
-    hmba_ring.radiation_on()
+def test_ohmi_envelope(hmba_lattice, refpts, ring_test):
+    hmba_lattice.radiation_on()
     if ring_test:
-        hmba_ring = hmba_ring[:]
-    emit0, beamdata, emit = physics.ohmi_envelope(hmba_ring, refpts)
+        hmba_lattice = hmba_lattice[:]
+    emit0, beamdata, emit = physics.ohmi_envelope(hmba_lattice, refpts)
     expected_beamdata = [([0.38156302, 0.85437641, 1.0906073e-4]),
                          ([1.0044543e-5, 6.6238162e-6, 9.6533473e-6]),
                          ([[[6.9000153, -2.6064253e-5, 1.643376e-25,

--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -4,7 +4,6 @@ between other modules.
 """
 import pytest
 import utils
-from at import Lattice
 from at.load import load_mat
 
 
@@ -35,14 +34,14 @@ def ml_err(engine):
 
 @pytest.fixture(scope='session')
 def py_dba():
-    return Lattice(load_mat(utils.dba_ring, key='RING'), keep_all=True)
+    return load_mat(utils.dba_ring, key='RING', keep_all=True)
 
 
 @pytest.fixture(scope='session')
 def py_hmba():
-    return Lattice(load_mat(utils.hmba_ring, key='RING'), keep_all=True)
+    return load_mat(utils.hmba_ring, key='RING', keep_all=True)
 
 
 @pytest.fixture(scope='session')
 def py_err():
-    return Lattice(load_mat(utils.err_ring, key='RING'), keep_all=True)
+    return load_mat(utils.err_ring, key='RING', keep_all=True)


### PR DESCRIPTION
According to the discussion in #107, I removed the `RingParam` element, moved all the `Lattice` coherence tests to `load_mat`, simplified the `Lattice` initialisation and return `Lattice` objects when indexing a `Lattice`.