### PR TITLE
Remove dependencies

### DIFF
--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -4,5 +4,4 @@
 from .lattice import *
 from .tracking import *
 from .physics import *
-from .plot import *
 from .load import *

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -4,4 +4,5 @@
 from .lattice import *
 from .tracking import *
 from .physics import *
+from .plot import *
 from .load import *

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -4,8 +4,7 @@ Helper functions for working with AT lattices.
 A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
 """
-print('lattice start')
-from .utils import *
+
 from .elements import *
+from .utils import *
 from .lattice_object import *
-print('lattice end')

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -4,7 +4,8 @@ Helper functions for working with AT lattices.
 A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
 """
-
+print('lattice start')
 from .utils import *
 from .elements import *
 from .lattice_object import *
+print('lattice end')

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -101,6 +101,7 @@ class Element(object):
             if not k.startswith('_'):
                 yield k, getattr(self, k)
 
+
 class LongElement(Element):
     """pyAT long element"""
     REQUIRED_ATTRIBUTES = Element.REQUIRED_ATTRIBUTES + ['Length']

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1,4 +1,15 @@
-"""Lattice object"""
+"""Lattice object
+
+The methods implemented in this module are internal to the 'lattice' package.
+This is necessary to ensure that the 'lattice' package is independent
+from other AT packages.
+
+Other Lattice methods are implemented in other AT packages and are available
+as soon as the package is imported. The 'tracking' and 'physics' packages are
+automatically imported.
+
+As an example, see the at.physics.orbit module
+"""
 import sys
 import copy
 import numpy
@@ -22,7 +33,10 @@ class Lattice(list):
         energy      Particle energy
         periodicity Number of super-periods to describe the full ring
 
-        """
+    To reduce the inter-package dependencies, some methods of the
+    lattice object are defined in other AT packages, in the module where
+    the underlying function is implemented.
+    """
     _1st_attributes = ('name', 'energy', 'periodicity')
 
     def __init__(self, elems=None, name=None, energy=None, periodicity=None,
@@ -133,7 +147,8 @@ class Lattice(list):
         return Lattice(itertools.chain(self, elems), **vars(self))
 
     def __mul__(self, times):
-        return Lattice(itertools.chain(*itertools.repeat(self, times)), **vars(self))
+        return Lattice(itertools.chain(*itertools.repeat(self, times)),
+                       **vars(self))
 
     def iterator(self, key):
         """Iterates over the indices selected by a slice or an array"""

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -8,9 +8,6 @@ from warnings import warn
 from scipy.constants import physical_constants as cst
 from at.lattice import elements, get_s_pos, get_elements, uint32_refpts
 from at.lattice import AtError, AtWarning
-from at.physics import find_orbit4, find_orbit6, find_sync_orbit, find_m44
-from at.physics import find_m66, linopt, ohmi_envelope, get_mcf
-from at.plot import plot_beta, plot_trajectory
 
 __all__ = ['Lattice']
 
@@ -356,46 +353,6 @@ class Lattice(list):
         # noinspection PyAttributeOutsideInit
         self._radiation = False
 
-    def linopt(self, *args, **kwargs):
-        """See at.physics.linopt():
-        """
-        if self._radiation:
-            raise AtError('linopt needs no radiation in the lattice')
-        return linopt(self, *args, **kwargs)
-
-    def get_mcf(self, *args, **kwargs):
-        """See at.physics.get_mcf():
-        """
-        if self._radiation:
-            raise AtError('get_mcf needs no radiation in the lattice')
-        return get_mcf(self, *args, **kwargs)
-
-    def ohmi_envelope(self, *args, **kwargs):
-        """See at.physics.ohmi_envelope():
-        """
-        if not self._radiation:
-            raise AtError('ohmi_envelope needs radiation in the lattice')
-        return ohmi_envelope(self, *args, **kwargs)
-
 
 Lattice.get_elements = get_elements
 Lattice.get_s_pos = get_s_pos
-Lattice.find_orbit4 = find_orbit4
-Lattice.find_sync_orbit = find_sync_orbit
-Lattice.find_orbit6 = find_orbit6
-Lattice.find_m44 = find_m44
-Lattice.find_m66 = find_m66
-Lattice.plot_beta = plot_beta
-Lattice.plot_trajectory = plot_trajectory
-
-if sys.version_info < (3, 0):
-    # noinspection PyUnresolvedReferences
-    Lattice.linopt.__func__.__doc__ += linopt.__doc__
-    # noinspection PyUnresolvedReferences
-    Lattice.get_mcf.__func__.__doc__ += get_mcf.__doc__
-    # noinspection PyUnresolvedReferences
-    Lattice.ohmi_envelope.__func__.__doc__ += ohmi_envelope.__doc__
-else:
-    Lattice.linopt.__doc__ += linopt.__doc__
-    Lattice.get_mcf.__doc__ += get_mcf.__doc__
-    Lattice.ohmi_envelope.__doc__ += ohmi_envelope.__doc__

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -6,8 +6,8 @@ import math
 import itertools
 from warnings import warn
 from scipy.constants import physical_constants as cst
-from at.lattice import elements, get_s_pos, get_elements, uint32_refpts
 from at.lattice import AtError, AtWarning
+from at.lattice import elements, get_s_pos, get_elements, uint32_refpts
 
 __all__ = ['Lattice']
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -16,8 +16,14 @@ refpts can be:
 """
 import numpy
 import itertools
+import functools
 from fnmatch import fnmatch
 from at.lattice import elements
+
+__all__ = ['AtError', 'AtWarning', 'check_radiation', 'uint32_refpts',
+           'bool_refpts', 'checkattr', 'checktype', 'get_cells', 'get_elements',
+           'refpts_iterator', 'get_s_pos', 'set_shift', 'set_tilt', 'tilt_elem',
+           'shift_elem']
 
 
 class AtError(Exception):
@@ -28,6 +34,21 @@ class AtWarning(UserWarning):
     pass
 
 
+def check_radiation(rad):
+    def radiation_decorator(func):
+        @functools.wraps(func)
+        def wrapper(ring, *args, **kwargs):
+            try:
+                if ring.radiation is not rad:
+                    message = '{0} needs radiation {1}'.format(func.__name__, 'ON' if rad else 'OFF')
+                    raise AtError(message)
+            except AttributeError:
+                pass
+            return func(ring, *args, **kwargs)
+        return wrapper
+    return radiation_decorator
+
+
 def uint32_refpts(refpts, n_elements):
     """
     Return a uint32 numpy array with contents as the indices of the selected
@@ -36,7 +57,7 @@ def uint32_refpts(refpts, n_elements):
     refs = numpy.asarray(refpts).reshape(-1)
     if (refpts is None) or (refs.size is 0):
         return numpy.array([], dtype=numpy.uint32)
-    elif (refs.size > n_elements+1):
+    elif refs.size > n_elements+1:
         raise ValueError('too many reftps given')
     elif numpy.issubdtype(refs.dtype, numpy.bool_):
         return numpy.flatnonzero(refs).astype(numpy.uint32)

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -45,12 +45,10 @@ def check_radiation(rad):
     def radiation_decorator(func):
         @functools.wraps(func)
         def wrapper(ring, *args, **kwargs):
-            try:
-                if ring.radiation is not rad:
-                    raise AtError('{0} needs radiation {1}'.format(
-                        func.__name__, 'ON' if rad else 'OFF'))
-            except AttributeError:
-                pass
+            ringrad = getattr(ring, 'radiation', rad)
+            if ringrad is not rad:
+                raise AtError('{0} needs radiation {1}'.format(
+                    func.__name__, 'ON' if rad else 'OFF'))
             return func(ring, *args, **kwargs)
         return wrapper
     return radiation_decorator
@@ -76,13 +74,13 @@ def uint32_refpts(refpts, n_elements):
     # Check ascending
     if refs.size > 1:
         prev = refs[0]
-        for next in refs[1:]:
-            if next < prev:
+        for nxt in refs[1:]:
+            if nxt < prev:
                 raise ValueError('refpts should be given in ascending order')
-            elif next == prev:
+            elif nxt == prev:
                 raise ValueError('refpts contains duplicates or index(es) out'
                                  ' of range')
-            prev = next
+            prev = nxt
 
     return refs
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -35,13 +35,20 @@ class AtWarning(UserWarning):
 
 
 def check_radiation(rad):
+    """Function to be used as a decorator for optics functions
+
+    If ring is a Lattice object, raises an exception
+        if ring.radiation is not rad
+
+    If ring is any other sequence, no test is performed
+    """
     def radiation_decorator(func):
         @functools.wraps(func)
         def wrapper(ring, *args, **kwargs):
             try:
                 if ring.radiation is not rad:
-                    message = '{0} needs radiation {1}'.format(func.__name__, 'ON' if rad else 'OFF')
-                    raise AtError(message)
+                    raise AtError('{0} needs radiation {1}'.format(
+                        func.__name__, 'ON' if rad else 'OFF'))
             except AttributeError:
                 pass
             return func(ring, *args, **kwargs)

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -2,6 +2,5 @@
 Import of AT lattice from different formats:
 - .mat files
 """
-print('load start')
-from at.load.matfile import *
-print('load end')
+
+from .matfile import *

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -2,4 +2,6 @@
 Import of AT lattice from different formats:
 - .mat files
 """
+print('load start')
 from at.load.matfile import *
+print('load end')

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -2,12 +2,10 @@
 Accelerator physics functions
 """
 
-print('physics start')
 from .orbit import *
+from .amat import *
 from .matrix import *
 from .linear import *
 # noinspection PyUnresolvedReferences
 from .diffmatrix import find_mpole_raddiff_matrix
-from .amat import *
 from .radiation import *
-print('physics end')

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -2,6 +2,7 @@
 Accelerator physics functions
 """
 
+print('physics start')
 from .orbit import *
 from .matrix import *
 from .linear import *
@@ -9,3 +10,4 @@ from .linear import *
 from .diffmatrix import find_mpole_raddiff_matrix
 from .amat import *
 from .radiation import *
+print('physics end')

--- a/pyat/at/physics/amat.py
+++ b/pyat/at/physics/amat.py
@@ -3,15 +3,34 @@ from collections import namedtuple
 import numpy
 from scipy.linalg import block_diag, eig, inv, det
 from math import pi
-from ..physics import jmat
+
+__all__ = ['amat', 'jmat', 'get_tunes_damp']
 
 _i2 = numpy.array([[-1.j, -1.], [1., 1.j]])
+
+# Prepare symplectic identity matrix
+_j2 = numpy.array([[0., 1.], [-1., 0.]])
+_jm = [_j2, block_diag(_j2, _j2), block_diag(_j2, _j2, _j2)]
+
 _vxyz = [_i2, block_diag(_i2, _i2), block_diag(_i2, _i2, _i2)]
 _submat = [slice(0, 2), slice(2, 4), slice(6, 3, -1)]
 
 _Data1 = namedtuple('R66Data', ('tunes', 'damping_rates', 'mode_matrices'))
 _Data2 = namedtuple('R66Data', ('tunes', 'damping_rates', 'mode_matrices',
                                 'mode_emittances'))
+
+
+def jmat(ind):
+    """
+    Return the antisymetric block diagonal matrix [[0, 1][-1, 0]]
+
+    INPUT
+        ind     1, 2 or 3. Matrix dimension
+
+    OUTPUT
+        jm      block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
+    """
+    return _jm[ind - 1]
 
 
 def amat(tt):

--- a/pyat/at/physics/amat.py
+++ b/pyat/at/physics/amat.py
@@ -4,7 +4,7 @@ import numpy
 from scipy.linalg import block_diag, eig, inv, det
 from math import pi
 
-__all__ = ['amat', 'jmat', 'get_tunes_damp']
+__all__ = ['amat', 'jmat', 'get_tunes_damp', 'get_mode_matrices']
 
 _i2 = numpy.array([[-1.j, -1.], [1., 1.j]])
 

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -3,7 +3,8 @@ Coupled or non-coupled 4x4 linear motion
 """
 import numpy
 from math import sqrt, atan2, pi
-from at.lattice import Lattice, uint32_refpts, get_s_pos, AtError
+from at.lattice import AtError
+from at.lattice import Lattice, uint32_refpts, get_s_pos
 from at.tracking import lattice_pass
 from at.physics import find_orbit4, find_m44, jmat
 

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -3,9 +3,9 @@ Coupled or non-coupled 4x4 linear motion
 """
 import numpy
 from math import sqrt, atan2, pi
-from ..lattice import Lattice, uint32_refpts, get_s_pos, AtError
-from ..tracking import lattice_pass
-from ..physics import find_orbit4, find_m44, jmat
+from at.lattice import Lattice, uint32_refpts, get_s_pos, AtError
+from at.tracking import lattice_pass
+from at.physics import find_orbit4, find_m44, jmat
 
 __all__ = ['get_twiss', 'linopt', 'get_mcf']
 

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -174,6 +174,7 @@ def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
     return twiss0, tune, chrom, twiss
 
 
+# noinspection PyPep8Naming
 @check_radiation(False)
 def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
            keep_lattice=False, ddp=DDP, coupled=True):
@@ -247,6 +248,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
 
     """
 
+    # noinspection PyShadowingNames
     def analyze(r44):
         t44 = r44.reshape((4, 4))
         mm = t44[:2, :2]

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -3,8 +3,7 @@ Coupled or non-coupled 4x4 linear motion
 """
 import numpy
 from math import sqrt, atan2, pi
-from at.lattice import AtError
-from at.lattice import Lattice, uint32_refpts, get_s_pos
+from at.lattice import Lattice, check_radiation, uint32_refpts, get_s_pos
 from at.tracking import lattice_pass
 from at.physics import find_orbit4, find_m44, jmat
 
@@ -59,6 +58,7 @@ def _closure(m22):
     return alpha, beta, tune
 
 
+@check_radiation(False)
 def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
               keep_lattice=False, ddp=DDP):
     """
@@ -174,6 +174,7 @@ def get_twiss(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
     return twiss0, tune, chrom, twiss
 
 
+@check_radiation(False)
 def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
            keep_lattice=False, ddp=DDP, coupled=True):
     """
@@ -258,12 +259,6 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
         cc = (numpy.dot(mm, C) + numpy.dot(G, m)).dot(
             _jmt.dot(msb.T.dot(_jmt.T)))
         return msa, msb, gamma, cc
-
-    try:
-        if ring._radiation:
-            raise AtError('linopt needs no radiation in the lattice')
-    except AttributeError:
-        pass
 
     uintrefs = uint32_refpts([] if refpts is None else refpts, len(ring))
 
@@ -363,6 +358,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
     return lindata0, tune, chrom, lindata
 
 
+@check_radiation(False)
 def get_mcf(ring, dp=0.0, ddp=DDP, keep_lattice=False):
     """Compute momentum compaction factor
 
@@ -375,12 +371,6 @@ def get_mcf(ring, dp=0.0, ddp=DDP, keep_lattice=False):
                         Defaults to False
         ddp=1.0E-8      momentum deviation used for differentiation
     """
-    try:
-        if ring._radiation:
-            raise AtError('get_mcf needs no radiation in the lattice')
-    except AttributeError:
-        pass
-
     fp_a, _ = find_orbit4(ring, dp=dp - 0.5 * ddp, keep_lattice=keep_lattice)
     fp_b, _ = find_orbit4(ring, dp=dp + 0.5 * ddp, keep_lattice=True)
     fp = numpy.stack((fp_a, fp_b),

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -5,33 +5,14 @@ A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 
 import numpy
-from scipy.linalg import block_diag
 from at.lattice import Lattice, uint32_refpts
 from at.tracking import lattice_pass, element_pass
-from at.physics import find_orbit4, find_orbit6
+from at.physics import find_orbit4, find_orbit6, jmat
 
-__all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'jmat']
+__all__ = ['find_m44', 'find_m66', 'find_elem_m66']
 
 XYDEFSTEP = 6.055454452393343e-006  # Optimal delta?
 DPSTEP = 6.055454452393343e-006  # Optimal delta?
-
-# Prepare symplectic identity matrix
-_j2 = numpy.array([[0., 1.], [-1., 0.]])
-_jm = [_j2, block_diag(_j2, _j2), block_diag(_j2, _j2, _j2)]
-
-
-def jmat(ind):
-    """
-    Return the antisymetric block diagonal matrix [[0, 1][-1, 0]]
-
-    INPUT
-        ind     1, 2 or 3. Matrix dimension
-
-    OUTPUT
-        jm      block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
-    """
-    return _jm[ind - 1]
-
 
 _jmt = jmat(2)
 

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -6,9 +6,9 @@ A collection of functions to compute 4x4 and 6x6 transfer matrices
 
 import numpy
 from scipy.linalg import block_diag
-from at.lattice import uint32_refpts
-from at.physics import find_orbit4, find_orbit6
+from at.lattice import Lattice, uint32_refpts
 from at.tracking import lattice_pass, element_pass
+from at.physics import find_orbit4, find_orbit6
 
 __all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'jmat']
 
@@ -202,3 +202,7 @@ def find_elem_m66(elem, orbit=None, **kwargs):
     element_pass(elem, in_mat)
     m66 = (in_mat[:, :6] - in_mat[:, 6:]) / scaling.reshape((1, 6))
     return m66
+
+
+Lattice.find_m44 = find_m44
+Lattice.find_m66 = find_m66

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,8 +4,9 @@ Closed orbit related functions
 
 import numpy
 import scipy.constants as constants
-from ..lattice import AtWarning, AtError, get_s_pos, RFCavity, uint32_refpts
-from ..tracking import lattice_pass
+from at.lattice import AtWarning, AtError
+from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
+from at.tracking import lattice_pass
 import warnings
 
 __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6']
@@ -276,7 +277,7 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
 
     # Get evolution period
     l0 = get_s_pos(ring, len(ring))
-    cavities = [elem for elem in ring if isinstance(elem, RFCavity)]
+    cavities = [elem for elem in ring if isinstance(elem, elements.RFCavity)]
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
@@ -320,3 +321,7 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
         lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs, keep_lattice=keeplattice), axis=(1, 3)).T
 
     return ref_in, all_points
+
+Lattice.find_orbit4 = find_orbit4
+Lattice.find_sync_orbit = find_sync_orbit
+Lattice.find_orbit6 = find_orbit6

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,7 +4,7 @@ Closed orbit related functions
 
 import numpy
 import scipy.constants as constants
-from at.lattice import AtWarning, AtError
+from at.lattice import AtWarning, AtError, check_radiation
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
 import warnings
@@ -16,6 +16,7 @@ MAX_ITERATIONS = 20
 CONVERGENCE = 1e-12
 
 
+@check_radiation(False)
 def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     """findorbit4 finds the closed orbit in the 4-d transverse phase
     space by numerically solving for a fixed point of the one turn
@@ -128,6 +129,7 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     return ref_in, all_points
 
 
+@check_radiation(False)
 def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     """find_sync_orbit finds the closed orbit, synchronous with the RF cavity
     and momentum deviation dP (first 5 components of the phase space vector)

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -21,10 +21,10 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     space by numerically solving for a fixed point of the one turn
     map M calculated with lattice_pass.
 
-        (X, PX, Y, PY, dP2, CT2 ) = M (X, PX, Y, PY, dP1, CT1)
+        (X, PX, Y, PY, dP, CT2 ) = M (X, PX, Y, PY, dP, CT1)
 
-    under the CONSTANT MOMENTUM constraint, dP2 = dP1 = dP and
-    there is NO constraint on the 6-th coordinate CT
+    under the CONSTANT MOMENTUM constraint dP and with NO constraint
+    on the 6-th coordinate CT
 
     IMPORTANT!!! findorbit4 imposes a constraint on dP and relaxes
     the constraint on the revolution frequency. A physical storage
@@ -134,9 +134,9 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     % by numerically solving  for a fixed point
     % of the one turn map M calculated with lattice_pass
 
-        (X, PX, Y, PY, dP2, CT2 ) = M (X, PX, Y, PY, dP1, CT1)
+        (X, PX, Y, PY, dP, CT2 ) = M (X, PX, Y, PY, dP, CT1)
 
-    under constraints CT2 - CT1 =  dCT = c/Frev - c/Frev0 and dP2 = dP1, where
+    under the constraint dCT = CT2 - CT1 = C/Frev - C/Frev0, where
     Frev0 = Frf0/HarmNumber is the design revolution frequency
     Frev  = (Frf0 + dFrf)/HarmNumber is the imposed revolution frequency
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -39,18 +39,8 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     1.  change the longitudinal momentum dP (cavities , magnets with radiation)
     2.  have any time dependence (localized impedance, fast kickers etc)
 
-    cod = find_orbit4(ring, dP)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the ring (x,px,y,py)
-
-    cod ,orbit = find_orbit4(ring, dP, refpts)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the ring (x,px,y,py)
-        orbit:  6xNrefs array - orbit at each location specified in refpts
-
-    ... = find_orbit4(ring,...,guess=initial_orbit)
-        sets the initial search to initial_orbit
-
     PARAMETERS
-        ring            lattice description
+        ring            Sequence of AT elements
         dp              momentum deviation. Defaults to 0
         refpts          elements at which data is returned. It can be:
                         1) an integer in the range [-len(ring), len(ring)-1]
@@ -62,6 +52,21 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
                            len(ring)+1, where selected elements are True.
                         Defaults to None, if refpts is None an empty array is
                         returned for orbit.
+
+    OUTPUT
+        orbit0          ((6,) closed orbit vector at the entrance of the
+                        1-st element (x,px,y,py)
+        orbit           (6, Nrefs) closed orbit vector at each location
+                        specified in refpts
+
+    KEYWORDS
+        keep_lattice    Assume no lattice change since the previous tracking.
+                        Default: False
+        guess           (6,) initial value for the closed orbit. It may help
+                        convergence. Default: (0, 0, 0, 0, 0, 0)
+        convergence     Convergence criterion. Default: 1.e-12
+        max_iterations  Maximum number of iterations. Default: 20
+        step_size       Step size. Default: 1.e-6
 
     See also find_sync_orbit, find_orbit6.
     """
@@ -78,14 +83,12 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     # f(r_n) - r_n is denoted b
     # f'(r_n) is the 4x4 jacobian, denoted j4
 
+    keep_lattice = kwargs.pop('keep_lattice', False)
     convergence = kwargs.pop('convergence', CONVERGENCE)
     max_iterations = kwargs.pop('max_iterations', MAX_ITERATIONS)
     step_size = kwargs.pop('step_size', STEP_SIZE)
-    if guess is None:
-        ref_in = numpy.zeros((6,), order='F')
-        ref_in[4] = dp
-    else:
-        ref_in = guess
+    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
+    ref_in[4] = dp
 
     delta_matrix = numpy.zeros((6, 5), order='F')
     for i in range(4):
@@ -93,10 +96,9 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
     id4 = numpy.asfortranarray(numpy.identity(4))
     change = 1
     itercount = 0
-    keeplattice = False
     while (change > convergence) and itercount < max_iterations:
         in_mat = ref_in.reshape((6, 1)) + delta_matrix
-        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keeplattice)
+        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
         # the reference particle after one turn
         ref_out = in_mat[:, 4]
         # 4x4 jacobian matrix from numerical differentiation:
@@ -110,14 +112,18 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
         change = numpy.linalg.norm(r_next - ref_in)
         itercount += 1
         ref_in = r_next
-        keeplattice = True
+        keep_lattice = True
 
     if itercount == max_iterations:
-        warnings.warn(AtWarning('Maximum number of iterations reached. Possible non-convergence'))
+        warnings.warn(AtWarning('Maximum number of iterations reached.'
+                                'Possible non-convergence'))
 
     uint32refs = uint32_refpts(refpts, len(ring))
-    all_points = numpy.empty((0, 6), dtype=float) if (len(uint32refs) == 0) else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs, keep_lattice=keeplattice), axis=(1, 3)).T
+    # bug in numpy < 1.13
+    all_points = numpy.empty((0, 6), dtype=float) if len(
+        uint32refs) == 0 else numpy.squeeze(
+        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
+                     keep_lattice=keep_lattice), axis=(1, 3)).T
 
     return ref_in, all_points
 
@@ -130,7 +136,7 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
 
         (X, PX, Y, PY, dP2, CT2 ) = M (X, PX, Y, PY, dP1, CT1)
 
-    under constraints CT2 - CT1 =  dCT = C(1/Frev - 1/Frev0) and dP2 = dP1 , where
+    under constraints CT2 - CT1 =  dCT = c/Frev - c/Frev0 and dP2 = dP1, where
     Frev0 = Frf0/HarmNumber is the design revolution frequency
     Frev  = (Frf0 + dFrf)/HarmNumber is the imposed revolution frequency
 
@@ -144,19 +150,9 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     1.  change the longitudinal momentum dP (cavities , magnets with radiation)
     2.  have any time dependence (localized impedance, fast kickers etc).
 
-    cod = find_sync_orbit(ring, dct)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the ring (x,px,y,py,delta)
-
-    cod ,orbit = find_sync_orbit(ring, dct, refpts)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the ring (x,px,y,py,delta)
-        orbit:  6xNrefs array - orbit at each location specified in refpts
-
-    ... = find_sync_orbit(ring,...,guess=initial_orbit)
-        sets the initial search to initial_orbit
-
     PARAMETERS
-        ring            lattice description
-        dct              ? Defaults to 0
+        ring            Sequence of AT elements
+        dct             Path lehgth deviation. Default: 0
         refpts          elements at which data is returned. It can be:
                         1) an integer in the range [-len(ring), len(ring)-1]
                            selecting the element according to python indexing
@@ -168,8 +164,24 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
                         Defaults to None, if refpts is None an empty array is
                         returned for orbit.
 
+    OUTPUT
+        orbit0          ((6,) closed orbit vector at the entrance of the
+                        1-st element (x,px,y,py)
+        orbit           (6, Nrefs) closed orbit vector at each location
+                        specified in refpts
+
+    KEYWORDS
+        keep_lattice    Assume no lattice change since the previous tracking.
+                        Default: False
+        guess           Initial value for the closed orbit. It may help
+                        convergence. Default: (0, 0, 0, 0)
+        convergence     Convergence criterion. Default: 1.e-12
+        max_iterations  Maximum number of iterations. Default: 20
+        step_size       Step size. Default: 1.e-6
+
     See also find_orbit4, find_orbit6.
     """
+    keep_lattice = kwargs.pop('keep_lattice', False)
     convergence = kwargs.pop('convergence', CONVERGENCE)
     max_iterations = kwargs.pop('max_iterations', MAX_ITERATIONS)
     step_size = kwargs.pop('step_size', STEP_SIZE)
@@ -186,10 +198,9 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     idx = numpy.array([0, 1, 2, 3, 5])
     change = 1
     itercount = 0
-    keeplattice = False
     while (change > convergence) and itercount < max_iterations:
         in_mat = ref_in.reshape((6, 1)) + delta_matrix
-        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keeplattice)
+        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
         # the reference particle after one turn
         ref_out = in_mat[:, -1]
         # 5x5 jacobian matrix from numerical differentiation:
@@ -203,14 +214,18 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
         change = numpy.linalg.norm(r_next - ref_in)
         itercount += 1
         ref_in = r_next
-        keeplattice = True
+        keep_lattice = True
 
     if itercount == max_iterations:
-        warnings.warn(AtWarning('Maximum number of iterations reached. Possible non-convergence'))
+        warnings.warn(AtWarning('Maximum number of iterations reached. '
+                                'Possible non-convergence'))
 
     uint32refs = uint32_refpts(refpts, len(ring))
-    all_points = numpy.empty((0, 6), dtype=float) if (len(uint32refs) == 0) else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs, keep_lattice=keeplattice), axis=(1, 3)).T
+    # bug in numpy < 1.13
+    all_points = numpy.empty((0, 6), dtype=float) if len(
+        uint32refs) == 0 else numpy.squeeze(
+        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
+                     keep_lattice=keep_lattice), axis=(1, 3)).T
 
     return ref_in, all_points
 
@@ -238,25 +253,13 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
         adequate energy compensation.
         In the simplest case of a single cavity, it must have
         'Voltage' field set so that Voltage > Erad - energy loss per turn
-    4.  find_orbit6 starts the search from [0,,0, 0, 0, 0, 0], unless
-        the third argument is specified: find_orbit6(ring,...,guess=initial_orbit)
-        There exist a family of solutions that correspond to different RF buckets
+    4.  There is a family of solutions that correspond to different RF buckets
         They differ in the 6-th coordinate by C*Nb/Frf. Nb = 1 .. HarmNum-1
     5.  The value of the 6-th coordinate found at the cavity gives
         the equilibrium RF phase. If there is no radiation the phase is 0;
 
-    cod = find_orbit6(ring)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the RING (x,px,y,py,delta,ct)
-
-    cod, orbit = find_orbit6(ring, refpts)
-        cod:    6x1 vector - fixed point at the entrance of the 1-st element of the RING (x,px,y,py,delta)
-        orbit:  6xNrefs array - orbit at each location specified in refpts
-
-    ... = find_orbit6(ring,...,guess=initial_orbit)
-        sets the initial search to initial_orbit
-
     PARAMETERS
-        ring            lattice description
+        ring            Sequence of AT elements
         refpts          elements at which data is returned. It can be:
                         1) an integer in the range [-len(ring), len(ring)-1]
                            selecting the element according to python indexing
@@ -268,8 +271,24 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
                         Defaults to None, if refpts is None an empty array is
                         returned for orbit.
 
+    OUTPUT
+        orbit0          ((6,) closed orbit vector at the entrance of the
+                        1-st element (x,px,y,py)
+        orbit           (6, Nrefs) closed orbit vector at each location
+                        specified in refpts
+
+    KEYWORDS
+        keep_lattice    Assume no lattice change since the previous tracking.
+                        Default: False
+        guess           Initial value for the closed orbit. It may help
+                        convergence. Default: (0, 0, 0, 0)
+        convergence     Convergence criterion. Default: 1.e-12
+        max_iterations  Maximum number of iterations. Default: 20
+        step_size       Step size. Default: 1.e-6
+
     See also find_orbit4, find_sync_orbit.
     """
+    keep_lattice = kwargs.pop('keep_lattice', False)
     convergence = kwargs.pop('convergence', CONVERGENCE)
     max_iterations = kwargs.pop('max_iterations', MAX_ITERATIONS)
     step_size = kwargs.pop('step_size', STEP_SIZE)
@@ -281,7 +300,9 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
+    # noinspection PyUnresolvedReferences
     f_rf = cavities[0].Frequency
+    # noinspection PyUnresolvedReferences
     harm_number = cavities[0].HarmNumber
 
     theta = numpy.zeros((6,))
@@ -294,10 +315,9 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
     id6 = numpy.asfortranarray(numpy.identity(6))
     change = 1
     itercount = 0
-    keeplattice = False
     while (change > convergence) and itercount < max_iterations:
         in_mat = ref_in.reshape((6, 1)) + delta_matrix
-        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keeplattice)
+        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
         # the reference particle after one turn
         ref_out = in_mat[:, 6]
         # 6x6 jacobian matrix from numerical differentiation:
@@ -311,16 +331,21 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
         change = numpy.linalg.norm(r_next - ref_in)
         itercount += 1
         ref_in = r_next
-        keeplattice = True
+        keep_lattice = True
 
     if itercount == max_iterations:
-        warnings.warn(AtWarning('Maximum number of iterations reached. Possible non-convergence'))
+        warnings.warn(AtWarning('Maximum number of iterations reached. '
+                                'Possible non-convergence'))
 
     uint32refs = uint32_refpts(refpts, len(ring))
-    all_points = numpy.empty((0, 6), dtype=float) if (len(uint32refs) == 0) else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs, keep_lattice=keeplattice), axis=(1, 3)).T
+    # bug in numpy < 1.13
+    all_points = numpy.empty((0, 6), dtype=float) if len(
+        uint32refs) == 0 else numpy.squeeze(
+        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
+                     keep_lattice=keep_lattice), axis=(1, 3)).T
 
     return ref_in, all_points
+
 
 Lattice.find_orbit4 = find_orbit4
 Lattice.find_sync_orbit = find_sync_orbit

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -302,9 +302,7 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
-    # noinspection PyUnresolvedReferences
     f_rf = cavities[0].Frequency
-    # noinspection PyUnresolvedReferences
     harm_number = cavities[0].HarmNumber
 
     theta = numpy.zeros((6,))

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -3,8 +3,7 @@ Radiation and equilibrium emittances
 """
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
-from at.lattice import AtError
-from at.lattice import Lattice, uint32_refpts
+from at.lattice import Lattice, check_radiation, uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
 # noinspection PyUnresolvedReferences
@@ -23,6 +22,7 @@ ENVELOPE_DTYPE = [('r66', numpy.float64, (6, 6)),
                   ('emitXYZ', numpy.float64, (3,))]
 
 
+@check_radiation(True)
 def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     """
     Calculate the equilibrium beam envelope in a
@@ -111,10 +111,6 @@ def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
         sigmatrix = m.dot(rr).dot(m.T) + cumb
         m44, emit2, emit3 = process(sigmatrix)
         return sigmatrix, m44, m, orbit6, emit2, emit3
-
-    # noinspection PyProtectedMember
-    if not ring._radiation:
-        raise AtError('ohmi_envelope needs radiation in the lattice')
 
     nelems = len(ring)
     uint32refs = uint32_refpts(refpts, nelems)

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -9,7 +9,7 @@ from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
 # noinspection PyUnresolvedReferences
 from at.physics import find_mpole_raddiff_matrix
 
-__all__ = ['ohmi_envelope']
+__all__ = []
 
 _submat = [slice(0, 2), slice(2, 4), slice(6, 3, -1)]
 
@@ -22,7 +22,7 @@ ENVELOPE_DTYPE = [('r66', numpy.float64, (6, 6)),
                   ('emitXYZ', numpy.float64, (3,))]
 
 
-def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
+def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     """
     Calculate the equilibrium beam envelope in a
     circular accelerator using Ohmi's beam envelope formalism [1]
@@ -163,4 +163,4 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     return data0, r66data, data
 
 
-Lattice.ohmi_envelope = ohmi_envelope
+Lattice.ohmi_envelope = _ohmi_envelope

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -3,7 +3,8 @@ Radiation and equilibrium emittances
 """
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
-from at.lattice import Lattice, AtError, uint32_refpts
+from at.lattice import AtError
+from at.lattice import Lattice, uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
 # noinspection PyUnresolvedReferences
@@ -111,6 +112,7 @@ def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
         m44, emit2, emit3 = process(sigmatrix)
         return sigmatrix, m44, m, orbit6, emit2, emit3
 
+    # noinspection PyProtectedMember
     if not ring._radiation:
         raise AtError('ohmi_envelope needs radiation in the lattice')
 

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -3,7 +3,7 @@ Radiation and equilibrium emittances
 """
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
-from at.lattice import uint32_refpts
+from at.lattice import Lattice, AtError, uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
 # noinspection PyUnresolvedReferences
@@ -111,6 +111,9 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
         m44, emit2, emit3 = process(sigmatrix)
         return sigmatrix, m44, m, orbit6, emit2, emit3
 
+    if not ring._radiation:
+        raise AtError('ohmi_envelope needs radiation in the lattice')
+
     nelems = len(ring)
     uint32refs = uint32_refpts(refpts, nelems)
     allrefs = uint32_refpts(range(nelems + 1), nelems)
@@ -158,3 +161,6 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
             dtype=ENVELOPE_DTYPE)
 
     return data0, r66data, data
+
+
+Lattice.ohmi_envelope = ohmi_envelope

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -9,7 +9,7 @@ from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
 # noinspection PyUnresolvedReferences
 from at.physics import find_mpole_raddiff_matrix
 
-__all__ = []
+__all__ = ['ohmi_envelope']
 
 _submat = [slice(0, 2), slice(2, 4), slice(6, 3, -1)]
 
@@ -23,7 +23,7 @@ ENVELOPE_DTYPE = [('r66', numpy.float64, (6, 6)),
 
 
 @check_radiation(True)
-def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
+def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     """
     Calculate the equilibrium beam envelope in a
     circular accelerator using Ohmi's beam envelope formalism [1]
@@ -161,4 +161,4 @@ def _ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
     return data0, r66data, data
 
 
-Lattice.ohmi_envelope = _ohmi_envelope
+Lattice.ohmi_envelope = ohmi_envelope

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -6,7 +6,6 @@ from scipy.linalg import inv, det, solve_sylvester
 from at.lattice import Lattice, check_radiation, uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
-# noinspection PyUnresolvedReferences
 from at.physics import find_mpole_raddiff_matrix
 
 __all__ = ['ohmi_envelope']

--- a/pyat/at/plot/__init__.py
+++ b/pyat/at/plot/__init__.py
@@ -1,4 +1,11 @@
 """AT plotting functions"""
-from .synopt import *
-from .generic import *
-from .specific import *
+print('plot start')
+try:
+    import matplotlib
+    from .synopt import *
+    from .generic import *
+    from .specific import *
+except (ImportError, RuntimeError) as exc:
+    print(exc)
+    print('Plotting is disabled')
+print('plot end')

--- a/pyat/at/plot/__init__.py
+++ b/pyat/at/plot/__init__.py
@@ -1,6 +1,6 @@
 """AT plotting functions"""
-print('plot start')
 try:
+    # noinspection PyPackageRequirements
     import matplotlib
     from .synopt import *
     from .generic import *
@@ -8,4 +8,3 @@ try:
 except (ImportError, RuntimeError) as exc:
     print(exc)
     print('Plotting is disabled')
-print('plot end')

--- a/pyat/at/plot/generic.py
+++ b/pyat/at/plot/generic.py
@@ -1,143 +1,136 @@
 """AT generic plotting function"""
 from itertools import chain, repeat
+# noinspection PyPackageRequirements
+import matplotlib.pyplot as plt
 from at.plot import plot_synopt
 
 SLICES = 400
 
-try:
-    # noinspection PyPackageRequirements
-    import matplotlib.pyplot as plt
-except (ImportError, RuntimeError) as exc:
-    print(exc)
-    print('Plotting is disabled')
+__all__ = ['baseplot']
 
-    # noinspection PyUnusedLocal
-    def baseplot(ring, plot_function, *args, **kwargs):
-        raise ImportError('Matplotlib is not available: plotting is disabled')
-else:
-    def baseplot(ring, plot_function, *args, **kwargs):
-        """
-        baseplot divides the region of interest of ring into small elements,
-        calls the specified function to get the plot data and calls matplotlib
-        functions to generate the plot.
-        By default it creates a new figure for the plot, but if provided with
-        axes objects it can be used as part of a GUI
+def baseplot(ring, plot_function, *args, **kwargs):
+    """
+    baseplot divides the region of interest of ring into small elements,
+    calls the specified function to get the plot data and calls matplotlib
+    functions to generate the plot.
+    By default it creates a new figure for the plot, but if provided with
+    axes objects it can be used as part of a GUI
 
-        PARAMETERS
-            ring            Lattice object
-            plot_function   specific data generating function to be called
+    PARAMETERS
+        ring            Lattice object
+        plot_function   specific data generating function to be called
 
-            All other positional parameters are sent to the plotting function
+        All other positional parameters are sent to the plotting function
 
-            plot_function is called as:
+        plot_function is called as:
 
-            title, left, right = plot_function(ring, refpts, *args, **kwargs)
+        title, left, right = plot_function(ring, refpts, *args, **kwargs)
 
-            and should return 2 or 3 output:
+        and should return 2 or 3 output:
 
-            title   plot title or None
-            left    tuple returning the data for the main (left) axis
-               left[0]   y-axis label
-               left[1]   xdata: (N,) array (s coordinate)
-               left[2]   ydata: iterable of (N,) or (N,M) arrays. Lines from a
-                         (N, M) array share the same style and label
-               left[3]   labels: (optional) iterable of strings as long as ydata
-            right   tuple returning the data for the secondary (right) axis
-                    (optional)
+        title   plot title or None
+        left    tuple returning the data for the main (left) axis
+           left[0]   y-axis label
+           left[1]   xdata: (N,) array (s coordinate)
+           left[2]   ydata: iterable of (N,) or (N,M) arrays. Lines from a
+                     (N, M) array share the same style and label
+           left[3]   labels: (optional) iterable of strings as long as ydata
+        right   tuple returning the data for the secondary (right) axis
+                (optional)
 
-        KEYWORDS
-            s_range         lattice range of interest, default: unchanged,
-                            initially set to the full cell.
-            axes=None       axes for plotting as (primary_axes, secondary_axes)
-                            Default: create new axes
-            slices=400      Number of slices
-            legend=True     Show a legend on the plot
-            block=False     if True, block until the figure is closed
-            dipole={}       Dictionary of properties overloading the default
-                            properties of dipole representation.
-                            See 'plot_synopt' for details
-            quadrupole={}   Same definition as for dipole
-            sextupole={}    Same definition as for dipole
-            multipole={}    Same definition as for dipole
-            monitor={}      Same definition as for dipole
+    KEYWORDS
+        s_range         lattice range of interest, default: unchanged,
+                        initially set to the full cell.
+        axes=None       axes for plotting as (primary_axes, secondary_axes)
+                        Default: create new axes
+        slices=400      Number of slices
+        legend=True     Show a legend on the plot
+        block=False     if True, block until the figure is closed
+        dipole={}       Dictionary of properties overloading the default
+                        properties of dipole representation.
+                        See 'plot_synopt' for details
+        quadrupole={}   Same definition as for dipole
+        sextupole={}    Same definition as for dipole
+        multipole={}    Same definition as for dipole
+        monitor={}      Same definition as for dipole
 
-            All other keywords are sent to the plotting function
+        All other keywords are sent to the plotting function
 
-        RETURN
-            left_axes       Main (left) axes
-            right_axes      Secondary (right) axes or None
-            synopt_axes     Synoptic axes
-        """
+    RETURN
+        left_axes       Main (left) axes
+        right_axes      Secondary (right) axes or None
+        synopt_axes     Synoptic axes
+    """
 
-        def plot1(ax, yaxis_label, x, y, labels=()):
-            lines = []
-            for y1, prop, label in zip(y, props, chain(labels, repeat(None))):
-                ll = ax.plot(x, y1, **prop)
-                if label is not None:
-                    ll[0].set_label(label)
-                lines += ll
-            ax.set_ylabel(yaxis_label)
-            return lines
+    def plot1(ax, yaxis_label, x, y, labels=()):
+        lines = []
+        for y1, prop, label in zip(y, props, chain(labels, repeat(None))):
+            ll = ax.plot(x, y1, **prop)
+            if label is not None:
+                ll[0].set_label(label)
+            lines += ll
+        ax.set_ylabel(yaxis_label)
+        return lines
 
-        def labeled(line):
-            return not line.properties()['label'].startswith('_')
+    def labeled(line):
+        return not line.properties()['label'].startswith('_')
 
-        # extract baseplot arguments
-        slices = kwargs.pop('slices', SLICES)
-        axes = kwargs.pop('axes', None)
-        legend = kwargs.pop('legend', True)
-        block = kwargs.pop('block', False)
-        if 's_range' in kwargs:
-            ring.s_range = kwargs.pop('s_range')
+    # extract baseplot arguments
+    slices = kwargs.pop('slices', SLICES)
+    axes = kwargs.pop('axes', None)
+    legend = kwargs.pop('legend', True)
+    block = kwargs.pop('block', False)
+    if 's_range' in kwargs:
+        ring.s_range = kwargs.pop('s_range')
 
-        # extract synopt arguments
-        synkeys = ['dipole', 'quadrupole', 'sextupole', 'multipole', 'monitor']
-        kwkeys = list(kwargs.keys())
-        synargs = dict((k, kwargs.pop(k)) for k in kwkeys if k in synkeys)
+    # extract synopt arguments
+    synkeys = ['dipole', 'quadrupole', 'sextupole', 'multipole', 'monitor']
+    kwkeys = list(kwargs.keys())
+    synargs = dict((k, kwargs.pop(k)) for k in kwkeys if k in synkeys)
 
-        # get color cycle
-        cycle_props = plt.rcParams['axes.prop_cycle']
+    # get color cycle
+    cycle_props = plt.rcParams['axes.prop_cycle']
 
-        # slice the ring
-        rg = ring.slice(slices=slices)
+    # slice the ring
+    rg = ring.slice(slices=slices)
 
-        # get the data for the plot
-        pout = plot_function(rg, rg.i_range, *args, **kwargs)
-        title = pout[0]
-        plots = pout[1:]
+    # get the data for the plot
+    pout = plot_function(rg, rg.i_range, *args, **kwargs)
+    title = pout[0]
+    plots = pout[1:]
 
-        # prepare the axes
-        if axes is None:
-            # Create new axes
-            nplots = len(plots)
-            fig = plt.figure()
-            axleft = fig.add_subplot(111, xlim=rg.s_range, xlabel='s [m]',
-                                     facecolor=[1.0, 1.0, 1.0, 0.0],
-                                     title=title)
-            axright = axleft.twinx() if (nplots >= 2) else None
-            axleft.set_title(ring.name, fontdict={'fontsize': 'medium'},
-                             loc='left')
-            axsyn = plot_synopt(ring, axes=axleft, **synargs)
+    # prepare the axes
+    if axes is None:
+        # Create new axes
+        nplots = len(plots)
+        fig = plt.figure()
+        axleft = fig.add_subplot(111, xlim=rg.s_range, xlabel='s [m]',
+                                 facecolor=[1.0, 1.0, 1.0, 0.0],
+                                 title=title)
+        axright = axleft.twinx() if (nplots >= 2) else None
+        axleft.set_title(ring.name, fontdict={'fontsize': 'medium'},
+                         loc='left')
+        axsyn = plot_synopt(ring, axes=axleft, **synargs)
+    else:
+        # Use existing axes
+        axleft, axright = axes
+        axsyn = None
+        nplots = 1 if axright is None else len(plots)
+
+    props = iter(cycle_props())
+
+    # left plot
+    lines1 = plot1(axleft, *plots[0])
+    # right plot
+    lines2 = [] if (nplots < 2) else plot1(axright, *plots[1])
+    if legend:
+        if nplots < 2:
+            axleft.legend(handles=[l for l in lines1 if labeled(l)])
+        elif axleft.get_shared_x_axes().joined(axleft, axright):
+            axleft.legend(
+                handles=[l for l in lines1 + lines2 if labeled(l)])
         else:
-            # Use existing axes
-            axleft, axright = axes
-            axsyn = None
-            nplots = 1 if axright is None else len(plots)
-
-        props = iter(cycle_props())
-
-        # left plot
-        lines1 = plot1(axleft, *plots[0])
-        # right plot
-        lines2 = [] if (nplots < 2) else plot1(axright, *plots[1])
-        if legend:
-            if nplots < 2:
-                axleft.legend(handles=[l for l in lines1 if labeled(l)])
-            elif axleft.get_shared_x_axes().joined(axleft, axright):
-                axleft.legend(
-                    handles=[l for l in lines1 + lines2 if labeled(l)])
-            else:
-                axleft.legend(handles=[l for l in lines1 if labeled(l)])
-                axright.legend(handles=[l for l in lines2 if labeled(l)])
-        plt.show(block)
-        return axleft, axright, axsyn
+            axleft.legend(handles=[l for l in lines1 if labeled(l)])
+            axright.legend(handles=[l for l in lines2 if labeled(l)])
+    plt.show(block)
+    return axleft, axright, axsyn

--- a/pyat/at/plot/specific.py
+++ b/pyat/at/plot/specific.py
@@ -1,5 +1,5 @@
 """AT plotting functions"""
-from at.lattice import Lattice, get_s_pos
+from at.lattice import Lattice
 from at.tracking import lattice_pass
 from at.physics import linopt
 from at.plot import baseplot
@@ -158,7 +158,7 @@ def plot_trajectory(ring, r_in, nturns=1, **kwargs):
     # noinspection PyShadowingNames
     def pldata_trajectory(ring, refpts, r_in, nturns=1, **kwargs):
         r_out = lattice_pass(ring, r_in, refpts=refpts, nturns=nturns, **kwargs)
-        s_pos = get_s_pos(ring, refpts)
+        s_pos = ring.get_s_pos(refpts)
         particles = range(r_out.shape[1])
         xx = [r_out[0, i, :, :] for i in particles]
         zz = [r_out[2, i, :, :] for i in particles]
@@ -168,6 +168,7 @@ def plot_trajectory(ring, r_in, nturns=1, **kwargs):
         return 'Trajectory', left
 
     return baseplot(ring, pldata_trajectory, r_in, nturns=nturns, **kwargs)
+
 
 Lattice.plot_beta = plot_beta
 Lattice.plot_trajectory = plot_trajectory

--- a/pyat/at/plot/specific.py
+++ b/pyat/at/plot/specific.py
@@ -1,10 +1,8 @@
 """AT plotting functions"""
-
-from at.plot import baseplot
-from at.lattice import get_s_pos
-from at.physics import linopt
+from at.lattice import Lattice, get_s_pos
 from at.tracking import lattice_pass
-
+from at.physics import linopt
+from at.plot import baseplot
 
 # --------- Example 1 --------
 
@@ -170,3 +168,6 @@ def plot_trajectory(ring, r_in, nturns=1, **kwargs):
         return 'Trajectory', left
 
     return baseplot(ring, pldata_trajectory, r_in, nturns=nturns, **kwargs)
+
+Lattice.plot_beta = plot_beta
+Lattice.plot_trajectory = plot_trajectory

--- a/pyat/at/plot/synopt.py
+++ b/pyat/at/plot/synopt.py
@@ -1,5 +1,14 @@
 """Plot a lattice synoptic"""
 import numpy
+# noinspection PyPackageRequirements
+import matplotlib.pyplot as plt
+# noinspection PyPackageRequirements
+from matplotlib.patches import Polygon
+# noinspection PyPackageRequirements
+from matplotlib.collections import PatchCollection
+from at.lattice import elements as elts
+
+__all__ = ['plot_synopt']
 
 # Default properties for element representation
 DIPOLE = dict(label='Dipoles', facecolor=(0.5, 0.5, 1.0))
@@ -8,144 +17,128 @@ SEXTUPOLE = dict(label='Sextupoles', facecolor=(0.5, 1.0, 0.5))
 MULTIPOLE = dict(label='Multipoles', facecolor=(0.25, 0.75, 0.25))
 MONITOR = dict(label='Monitors', linestyle=None, marker=10, color='k')
 
-try:
-    # noinspection PyPackageRequirements
-    import matplotlib.pyplot as plt
-    # noinspection PyPackageRequirements
-    from matplotlib.patches import Polygon
-    # noinspection PyPackageRequirements
-    from matplotlib.collections import PatchCollection
-    from at.lattice import elements as elts
-except (ImportError, RuntimeError) as exc:
-    print(exc)
-    print('Plotting is disabled')
 
-    # noinspection PyUnusedLocal
-    def plot_synopt(ring, axes=None, **kwargs):
-        raise ImportError('Matplotlib is not available: plotting is disabled')
-else:
+# noinspection PyDefaultArgument
+def plot_synopt(ring, axes=None, dipole={}, quadrupole={}, sextupole={},
+                multipole={}, monitor={}):
+    """Plot a synoptic of a lattice
 
-    # noinspection PyDefaultArgument
-    def plot_synopt(ring, axes=None, dipole={}, quadrupole={}, sextupole={},
-                    multipole={}, monitor={}):
-        """Plot a synoptic of a lattice
+    PARAMETERS
+        ring            Lattice object
 
-        PARAMETERS
-            ring            Lattice object
+    KEYWORDS
+        s_range=None    plot range, defaults to the full ring
+        axes=None       axes for plotting the synoptic. If None, a new
+                        figure will be created. Otherwise, a new axes object
+                        sharing the same x-axis as the given one is created.
+        dipole={}       Dictionary of properties overloading the default
+                        properties. If None, dipoles will not be shown.
+        quadrupole={}   Same definition as for dipole
+        sextupole={}    Same definition as for dipole
+        multipole={}    Same definition as for dipole
+        monitor={}      Same definition as for dipole
 
-        KEYWORDS
-            s_range=None    plot range, defaults to the full ring
-            axes=None       axes for plotting the synoptic. If None, a new
-                            figure will be created. Otherwise, a new axes object
-                            sharing the same x-axis as the given one is created.
-            dipole={}       Dictionary of properties overloading the default
-                            properties. If None, dipoles will not be shown.
-            quadrupole={}   Same definition as for dipole
-            sextupole={}    Same definition as for dipole
-            multipole={}    Same definition as for dipole
-            monitor={}      Same definition as for dipole
+    RETURN
+        synopt_axes     Synoptic axes
+     """
 
-        RETURN
-            synopt_axes     Synoptic axes
-         """
+    class Dipole(Polygon):
+        xx = numpy.array([0, 0, 1, 1], dtype=float)
+        yy = numpy.array([0, 1, 1, 0], dtype=float)
 
-        class Dipole(Polygon):
-            xx = numpy.array([0, 0, 1, 1], dtype=float)
-            yy = numpy.array([0, 1, 1, 0], dtype=float)
+        def __init__(self, s, length, **kwargs):
+            xy = numpy.stack((self.xx * length + s, self.yy), axis=1)
+            super(Dipole, self).__init__(xy, closed=False, **kwargs)
 
-            def __init__(self, s, length, **kwargs):
-                xy = numpy.stack((self.xx * length + s, self.yy), axis=1)
-                super(Dipole, self).__init__(xy, closed=False, **kwargs)
+    class Quadrupole(Polygon):
+        xx = numpy.array([0, 0, 0.5, 1, 1])
+        yy = {True: numpy.array([0, 1, 1.4, 1, 0]),
+              False: numpy.array([0, 1, 0.6, 1, 0])}
 
-        class Quadrupole(Polygon):
-            xx = numpy.array([0, 0, 0.5, 1, 1])
-            yy = {True: numpy.array([0, 1, 1.4, 1, 0]),
-                  False: numpy.array([0, 1, 0.6, 1, 0])}
+        def __init__(self, s, length, foc, **kwargs):
+            xy = numpy.stack((self.xx * length + s, self.yy[foc]), axis=1)
+            super(Quadrupole, self).__init__(xy, closed=False, **kwargs)
 
-            def __init__(self, s, length, foc, **kwargs):
-                xy = numpy.stack((self.xx * length + s, self.yy[foc]), axis=1)
-                super(Quadrupole, self).__init__(xy, closed=False, **kwargs)
+    class Sextupole(Polygon):
+        xx = numpy.array([0, 0, 0.33, 0.66, 1, 1])
+        yy = {True: numpy.array([0, 0.8, 1, 1, 0.8, 0]),
+              False: numpy.array([0, 0.8, 0.6, 0.6, 0.8, 0])}
 
-        class Sextupole(Polygon):
-            xx = numpy.array([0, 0, 0.33, 0.66, 1, 1])
-            yy = {True: numpy.array([0, 0.8, 1, 1, 0.8, 0]),
-                  False: numpy.array([0, 0.8, 0.6, 0.6, 0.8, 0])}
+        def __init__(self, s, length, foc, **kwargs):
+            xy = numpy.stack((self.xx * length + s, self.yy[foc]), axis=1)
+            super(Sextupole, self).__init__(xy, closed=False, **kwargs)
 
-            def __init__(self, s, length, foc, **kwargs):
-                xy = numpy.stack((self.xx * length + s, self.yy[foc]), axis=1)
-                super(Sextupole, self).__init__(xy, closed=False, **kwargs)
+    class Multipole(Polygon):
+        xx = numpy.array([0, 0, 1, 1], dtype=float)
+        yy = numpy.array([0, 0.8, 0.8, 0])
 
-        class Multipole(Polygon):
-            xx = numpy.array([0, 0, 1, 1], dtype=float)
-            yy = numpy.array([0, 0.8, 0.8, 0])
+        def __init__(self, s, length, **kwargs):
+            xy = numpy.stack((self.xx * length + s, self.yy), axis=1)
+            super(Multipole, self).__init__(xy, closed=False, **kwargs)
 
-            def __init__(self, s, length, **kwargs):
-                xy = numpy.stack((self.xx * length + s, self.yy), axis=1)
-                super(Multipole, self).__init__(xy, closed=False, **kwargs)
+    class Monitor(Polygon):
+        xx = numpy.array([0.0, 0.0])
+        yy = numpy.array([0.0, 1.2])
 
-        class Monitor(Polygon):
-            xx = numpy.array([0.0, 0.0])
-            yy = numpy.array([0.0, 1.2])
+        def __init__(self, s, **kwargs):
+            xy = numpy.stack((self.xx + s, self.yy), axis=1)
+            super(Monitor, self).__init__(xy, closed=False, **kwargs)
 
-            def __init__(self, s, **kwargs):
-                xy = numpy.stack((self.xx + s, self.yy), axis=1)
-                super(Monitor, self).__init__(xy, closed=False, **kwargs)
+    def ismultipole(elem):
+        return isinstance(elem, elts.Multipole) and not isinstance(elem, (
+            elts.Dipole, elts.Quadrupole, elts.Sextupole))
 
-        def ismultipole(elem):
-            return isinstance(elem, elts.Multipole) and not isinstance(elem, (
-                elts.Dipole, elts.Quadrupole, elts.Sextupole))
+    if axes is None:
+        fig = plt.figure()
+        axsyn = fig.add_subplot(111, xlim=ring.s_range)
+    else:
+        axsyn = axes.twinx()
+    axsyn.set_axis_off()         # Set axis invisible
+    axsyn.set_ylim((0.0, 20.0))  # Initial scaling of elements
+    axsyn.set_zorder(-0.2)       # Put synoptic in the background
 
-        if axes is None:
-            fig = plt.figure()
-            axsyn = fig.add_subplot(111, xlim=ring.s_range)
-        else:
-            axsyn = axes.twinx()
-        axsyn.set_axis_off()         # Set axis invisible
-        axsyn.set_ylim((0.0, 20.0))  # Initial scaling of elements
-        axsyn.set_zorder(-0.2)       # Put synoptic in the background
+    s_pos = ring.get_s_pos(range(len(ring)))
 
-        s_pos = ring.get_s_pos(range(len(ring)))
+    if dipole is not None:
+        props = DIPOLE.copy()
+        props.update(dipole)
+        dipoles = PatchCollection(
+            (Dipole(s, el.Length) for s, el in zip(s_pos, ring)
+             if isinstance(el, elts.Dipole)), **props)
+        axsyn.add_collection(dipoles)
 
-        if dipole is not None:
-            props = DIPOLE.copy()
-            props.update(dipole)
-            dipoles = PatchCollection(
-                (Dipole(s, el.Length) for s, el in zip(s_pos, ring)
-                 if isinstance(el, elts.Dipole)), **props)
-            axsyn.add_collection(dipoles)
+    if quadrupole is not None:
+        props = QUADRUPOLE.copy()
+        props.update(quadrupole)
+        quadrupoles = PatchCollection(
+            (Quadrupole(s, el.Length, el.PolynomB[1] >= 0.0)
+             for s, el in zip(s_pos, ring)
+             if isinstance(el, elts.Quadrupole)), **props)
+        axsyn.add_collection(quadrupoles)
 
-        if quadrupole is not None:
-            props = QUADRUPOLE.copy()
-            props.update(quadrupole)
-            quadrupoles = PatchCollection(
-                (Quadrupole(s, el.Length, el.PolynomB[1] >= 0.0)
-                 for s, el in zip(s_pos, ring)
-                 if isinstance(el, elts.Quadrupole)), **props)
-            axsyn.add_collection(quadrupoles)
+    if sextupole is not None:
+        props = SEXTUPOLE.copy()
+        props.update(sextupole)
+        sextupoles = PatchCollection(
+            (Sextupole(s, el.Length, el.PolynomB[2] >= 0.0)
+             for s, el in zip(s_pos, ring)
+             if isinstance(el, elts.Sextupole)), **props)
+        axsyn.add_collection(sextupoles)
 
-        if sextupole is not None:
-            props = SEXTUPOLE.copy()
-            props.update(sextupole)
-            sextupoles = PatchCollection(
-                (Sextupole(s, el.Length, el.PolynomB[2] >= 0.0)
-                 for s, el in zip(s_pos, ring)
-                 if isinstance(el, elts.Sextupole)), **props)
-            axsyn.add_collection(sextupoles)
+    if multipole is not None:
+        props = MULTIPOLE.copy()
+        props.update(multipole)
+        multipoles = PatchCollection(
+            (Multipole(s, el.Length) for s, el in zip(s_pos, ring)
+             if ismultipole(el)), **props)
+        axsyn.add_collection(multipoles)
 
-        if multipole is not None:
-            props = MULTIPOLE.copy()
-            props.update(multipole)
-            multipoles = PatchCollection(
-                (Multipole(s, el.Length) for s, el in zip(s_pos, ring)
-                 if ismultipole(el)), **props)
-            axsyn.add_collection(multipoles)
+    if monitor is not None:
+        props = MONITOR.copy()
+        props.update(monitor)
+        s = s_pos[[isinstance(el, elts.Monitor) for el in ring]]
+        y = numpy.zeros(s.shape)
+        # noinspection PyUnusedLocal
+        monitors = axsyn.plot(s, y, **props)
 
-        if monitor is not None:
-            props = MONITOR.copy()
-            props.update(monitor)
-            s = s_pos[[isinstance(el, elts.Monitor) for el in ring]]
-            y = numpy.zeros(s.shape)
-            # noinspection PyUnusedLocal
-            monitors = axsyn.plot(s, y, **props)
-
-        return axsyn
+    return axsyn

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -2,7 +2,9 @@
 Tracking functions
 """
 
+print('tracking init')
 from .patpass import patpass
 from .track import *
 # noinspection PyUnresolvedReferences
 from .atpass import atpass, elempass
+print('tracking end')

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -2,9 +2,7 @@
 Tracking functions
 """
 
-print('tracking init')
-from .patpass import patpass
-from .track import *
 # noinspection PyUnresolvedReferences
 from .atpass import atpass, elempass
-print('tracking end')
+from .patpass import patpass
+from .track import *

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -2,7 +2,6 @@
 Simple parallelisation of atpass() using multiprocessing.
 """
 import multiprocessing
-# noinspection PyUnresolvedReferences
 from at.tracking import atpass
 from at.lattice import uint32_refpts
 import numpy
@@ -16,20 +15,20 @@ def _atpass_one(args):
     return atpass(ring, rin, turns, refpts)
 
 
-def _patpass(ring, rin, nturns, refpts, pool_size):
+def _patpass(ring, r_in, nturns, refpts, pool_size):
     pool = multiprocessing.Pool(pool_size)
-    args = [(ring, rin[:, i], nturns, refpts) for i in range(rin.shape[1])]
+    args = [(ring, r_in[:, i], nturns, refpts) for i in range(r_in.shape[1])]
     results = pool.map(_atpass_one, args)
     return numpy.concatenate(results, axis=1)
 
 
-def patpass(ring, rin, nturns, refpts=None, reuse=True, pool_size=None):
+def patpass(ring, r_in, nturns, refpts=None, reuse=True, pool_size=None):
     """
     Simple parallel implementation of atpass().  If more than one particle
     is supplied, use multiprocessing to run each particle in a separate
     process.
 
-    Args:
+    INPUT:
         ring            lattice description
         r_in:           6xN array: input coordinates of N particles
         nturns:         number of passes through the lattice line
@@ -51,4 +50,4 @@ def patpass(ring, rin, nturns, refpts=None, reuse=True, pool_size=None):
     refs = uint32_refpts(refpts, len(ring))
     if pool_size is None:
         pool_size = multiprocessing.cpu_count()
-    return _patpass(ring, rin, nturns, refs, pool_size)
+    return _patpass(ring, r_in, nturns, refs, pool_size)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -3,8 +3,8 @@ Simple parallelisation of atpass() using multiprocessing.
 """
 import multiprocessing
 # noinspection PyUnresolvedReferences
-from .atpass import atpass
-from ..lattice import uint32_refpts
+from at.tracking import atpass
+from at.lattice import uint32_refpts
 import numpy
 
 

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
 import numpy
-# noinspection PyUnresolvedReferences
 from at.tracking import atpass, elempass
 from at.lattice import uint32_refpts
 
@@ -11,7 +9,7 @@ DIMENSION_ERROR = 'Input to lattice_pass() must be a 6xN array.'
 
 
 def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
-    """lattice_pass tracks particles through each element of the iterable lattice
+    """lattice_pass tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the
     lattice[i].PassMethod field.
 
@@ -23,7 +21,7 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
      * lattice_pass(lattice, r_in, refpts=0) is a copy of r_in since the
        reference point 0 is the entrance of the first element
 
-    Args:
+    PARAMETERS
         lattice:    iterable of AT elements
         r_in:       6xN array: input coordinates of N particles
         nturns:     number of passes through the lattice line
@@ -41,8 +39,9 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
                     If True, assume that the lattice has not changed since
                     that previous call.
 
-    Returns:
-        6xAxBxC array containing output coordinates of A particles at B selected indices for C turns.
+    OUTPUT
+        (6, A, B, C) array containing output coordinates of A particles
+        at B selected indices for C turns.
     """
     assert r_in.shape[0] == 6 and r_in.ndim in (1, 2), DIMENSION_ERROR
     r_in = numpy.asfortranarray(r_in)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 import numpy
 # noinspection PyUnresolvedReferences
-from .atpass import atpass, elempass
-from ..lattice import uint32_refpts
+from at.tracking import atpass, elempass
+from at.lattice import uint32_refpts
 
 
 __all__ = ['lattice_pass', 'element_pass']

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -1,8 +1,7 @@
 import at
 import numpy
 import pytest
-from at import physics, atpass
-from at.lattice import AtWarning
+from at import AtWarning, physics, atpass
 
 
 DP = 1e-5
@@ -224,12 +223,9 @@ def test_linopt_no_refpts(dba_lattice):
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
-@pytest.mark.parametrize('ring_test', (False, True))
-def test_ohmi_envelope(hmba_lattice, refpts, ring_test):
+def test_ohmi_envelope(hmba_lattice, refpts):
     hmba_lattice.radiation_on()
-    if ring_test:
-        hmba_lattice = hmba_lattice[:]
-    emit0, beamdata, emit = physics.ohmi_envelope(hmba_lattice, refpts)
+    emit0, beamdata, emit = hmba_lattice.ohmi_envelope(refpts)
     expected_beamdata = [([0.38156302, 0.85437641, 1.0906073e-4]),
                          ([1.0044543e-5, 6.6238162e-6, 9.6533473e-6]),
                          ([[[6.9000153, -2.6064253e-5, 1.643376e-25,

--- a/pyat/test_matlab/test_cmp_physics.py
+++ b/pyat/test_matlab/test_cmp_physics.py
@@ -135,7 +135,7 @@ def test_ohmi_envelope(engine, ml_lattice, py_lattice, refpts):
 
     # Python call
     py_lattice.radiation_on()
-    py_emit0, py_beamdata, py_emit = physics.ohmi_envelope(py_lattice, refpts)
+    py_emit0, py_beamdata, py_emit = py_lattice.ohmi_envelope(refpts)
     # Matlab call
     ml_emit = engine.pyproxy('atx', ml_lattice, 0.0, _ml_refs(refpts, nelems))
     ml_emit0, ml_params = engine.pyproxy('atx', ml_lattice, 0.0,


### PR DESCRIPTION
Here is a solution to the dependency loop problem:
The `Lattice` object does not depend any more on the `at.physics` package.
To do this, all methods relying on the `at.physics` package are not defined any more in the `lattice_object` module. Instead, they are defined in the module where the underlying physical function is implemented. And similarly for the `at.plot` package. 
So the import order is now set to:
```
from .lattice import *
from .tracking import *
from .physics import *
from .plot import *
from .load import *
```
where no package depends on the following ones. This is shown on the following debug output obtained with a printout at the beginning and end of each of the sub-packages `__init__` module:

**Branch master:**
```
lattice start
  physics start
    tracking start
    tracking end
  physics end
  plot start
  plot end
lattice end
load start
load end
```
**Branch remove_dependencies:**
```
lattice start
lattice end
tracking start
tracking end
physics start
physics end
plot start
plot end
load start
load end
```
The `import` statements have also been rearranged inside the sub-packages so that there is also no loop within the sub-packages.

As side effects, `import at` is faster (0.701s instead of 0.797s in average on my machine) and the handling of the optional Matplotlib package is simpler.

I also set a decorator to check the `Lattice.radiation` status on `linopt`, `get_mcf`…

Finally I have 2 questions:

1.  I set `_ohmi_envelope` as a private function, so that it should be called only as a `Lattice` method. If you think it should stay accessible as a standard function, it’s easy set it public again,

3.  at.plot is still imported in `at/__init__.py`. Removing it would have 2 advantages
- Faster import for applications not using graphics (0.465s instead of 0.701s)
- The message about non-availability of Matplotlib appears when import `at.plot` is explicitly executed, rather than at the initial `import at`

And 1 drawback: the necessity to explicitly `import at.plot` to have access to the graphics commands
What is your preference ?

Sorry for the many changes in `lattice.orbit`: I try to cut the lines at 80 characters and review the doc strings when I touch a file…