### PR TITLE
Check the "at.Element" attributes when set

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -113,6 +113,8 @@ class LongElement(Element):
 
     def __init__(self, family_name, length, *args, **kwargs):
         kwargs.setdefault('Length', length)
+        # Ancestor may be either Element of ThinMultipole
+        # noinspection PyArgumentList
         super(LongElement, self).__init__(family_name, *args, **kwargs)
 
     def _part(self, fr, sumfr):

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -198,10 +198,8 @@ def test_quad(rin):
 
 def test_quad_incorrect_array(rin):
     q = elements.Quadrupole('quad', 0.4, k=1)
-    q.PolynomB = 'a'
-    lattice = [q]
-    with pytest.raises(RuntimeError):
-        atpass(lattice, rin, 1)
+    with pytest.raises(ValueError):
+        q.PolynomB = 'a'
 
 
 def test_rfcavity(rin):

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -28,6 +28,22 @@ def test_base_element_methods():
     assert id(e.copy()) != id(e)
 
 
+def test_argument_checks():
+    q = elements.Quadrupole('quad', 1.0, 0.5)
+    # Test type
+    with pytest.raises(ValueError):
+        q.Length = 'a'
+    # Test shape
+    with pytest.raises(ValueError):
+        q.T1 = [0.0, 0.0]
+    # Test coherence of polynoms
+    with pytest.raises(ValueError):
+        q.MaxOrder = 2
+    with pytest.raises(ValueError):
+        q.PolynomA = [0.0]
+    with pytest.raises(ValueError):
+        q.PolynomB = [0.0]
+
 def test_divide_splits_attributes_correctly():
     pre = elements.Drift('drift', 1, KickAngle=0.5)
     post = pre.divide([0.2, 0.5, 0.3])

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -138,28 +138,28 @@ def test_get_s_pos_returns_zero_for_empty_lattice():
 
 
 def test_get_s_pos_returns_length_for_lattice_with_one_element():
-    e = elements.Element('e', 0.1)
+    e = elements.LongElement('e', 0.1)
     assert get_s_pos([e], [1]) == numpy.array([0.1])
 
 
 def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_and_refpts_None():
-    e = elements.Element('e', 0.1)
-    f = elements.Element('e', 2.1)
+    e = elements.LongElement('e', 0.1)
+    f = elements.LongElement('e', 2.1)
     print(get_s_pos([e, f], None))
     numpy.testing.assert_equal(get_s_pos([e, f], None),
                                numpy.array([0, 0.1, 2.2]))
 
 
 def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_using_int_refpts():
-    e = elements.Element('e', 0.1)
-    f = elements.Element('e', 2.1)
+    e = elements.LongElement('e', 0.1)
+    f = elements.LongElement('e', 2.1)
     lat = [e, f]
     numpy.testing.assert_equal(get_s_pos(lat, range(len(lat) + 1)),
                                numpy.array([0, 0.1, 2.2]))
 
 def test_get_s_pos_returns_all_points_for_lattice_with_two_elements_using_bool_refpts():
-    e = elements.Element('e', 0.1)
-    f = elements.Element('e', 2.1)
+    e = elements.LongElement('e', 0.1)
+    f = elements.LongElement('e', 2.1)
     lat = [e, f]
     numpy.testing.assert_equal(get_s_pos(lat, numpy.ones(3, dtype=bool)),
                                numpy.array([0, 0.1, 2.2]))


### PR DESCRIPTION
The type and shape of `Element` attributes are checked at the creation of the element, but not when an attribute is set later. This allows things like:

`elem.FamName = [0, 0]`
or
`elem.PolynomB = ‘abcd’`

Here we move the checks to the `setattr` function, which secures completely  the `Element`.
In addition, we also prevent modifying `MaxOrder`, `PolynomA` or `PolynomB` in an inconsistent way.