### PR TITLE
Default MaxOrder determination

### DIFF
--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -5,7 +5,7 @@ from at import elements
 
 
 def test_data_checks():
-    val = numpy.zeros([6,6])
+    val = numpy.zeros([6, 6])
     assert elements._array(val).shape == (36,)
     assert elements._array66(val).shape == (6, 6)
 
@@ -44,12 +44,92 @@ def test_argument_checks():
     with pytest.raises(ValueError):
         q.PolynomB = [0.0]
 
+
+def test_dipole():
+    d = elements.Dipole('dipole', 1.0, 0.01)
+    assert d.MaxOrder == 0
+    assert len(d.PolynomA) == 2
+    assert d.K == 0.0
+    d = elements.Dipole('dipole', 1.0, 0.01, -0.5)
+    assert d.MaxOrder == 1
+    assert len(d.PolynomA) == 2
+    assert d.K == -0.5
+    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.1, 0.0])
+    assert d.MaxOrder == 1
+    assert len(d.PolynomA) == 3
+    assert d.K == 0.1
+    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005])
+    assert d.MaxOrder == 2
+    assert len(d.PolynomA) == 3
+    assert d.K == 0.0
+    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005], MaxOrder=0)
+    assert d.MaxOrder == 0
+    assert len(d.PolynomA) == 3
+    assert d.K == 0.0
+
+
+def test_quadrupole():
+    q = elements.Quadrupole('quadrupole', 1.0)
+    assert q.MaxOrder == 1
+    assert len(q.PolynomA) == 2
+    assert q.K == 0.0
+    q = elements.Quadrupole('quadrupole', 1.0, -0.5)
+    assert q.MaxOrder == 1
+    assert len(q.PolynomA) == 2
+    assert q.K == -0.5
+    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.0, 0.005])
+    assert q.MaxOrder == 2
+    assert len(q.PolynomA) == 3
+    assert q.K == 0.0
+    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.5, 0.005], MaxOrder=1)
+    assert q.MaxOrder == 1
+    assert len(q.PolynomA) == 3
+    assert q.K == 0.5
+
+
+def test_sextupole():
+    s = elements.Sextupole('sextupole', 1.0)
+    assert s.MaxOrder == 2
+    assert len(s.PolynomA) == 3
+    assert s.H == 0.0
+    s = elements.Sextupole('sextupole', 1.0, -0.5)
+    assert s.MaxOrder == 2
+    assert len(s.PolynomA) == 3
+    assert s.H == -0.5
+    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.0, 0.005, 0.0])
+    assert s.MaxOrder == 2
+    assert len(s.PolynomA) == 4
+    assert s.H == 0.005
+    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.0, 0.005, 0.001])
+    assert s.MaxOrder == 3
+    assert len(s.PolynomA) == 4
+    assert s.H == 0.005
+    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.5, 0.005, 0.001], MaxOrder=2)
+    assert s.MaxOrder == 2
+    assert len(s.PolynomA) == 4
+    assert s.H == 0.005
+
+
+def test_octupole():
+    o = elements.Octupole('octupole', 1.0, [], [0.0, 0.0, 0.0, 0.0])
+    assert o.MaxOrder == 3
+    assert len(o.PolynomA) == 4
+
+
+def test_thinmultipole():
+    m = elements.ThinMultipole('thin', [], [0.0, 0.0, 0.0, 0.0])
+    assert m.MaxOrder == 0
+    assert len(m.PolynomA) == 4
+    m = elements.ThinMultipole('thin', [], [0.0, 0.0, 1.0, 0.0])
+    assert m.MaxOrder == 2
+    assert len(m.PolynomA) == 4
+
+
 def test_divide_splits_attributes_correctly():
-    pre = elements.Drift('drift', 1, KickAngle=0.5)
+    pre = elements.Drift('drift', 1)
     post = pre.divide([0.2, 0.5, 0.3])
     assert len(post) == 3
     assert sum([e.Length for e in post]) == pre.Length
-    assert sum([e.KickAngle for e in post]) == pre.KickAngle
     pre = elements.Dipole('dipole', 1, KickAngle=[0.5, -0.5], BendingAngle=0.2)
     post = pre.divide([0.2, 0.5, 0.3])
     assert len(post) == 3
@@ -58,11 +138,10 @@ def test_divide_splits_attributes_correctly():
     assert sum([e.KickAngle[1] for e in post]) == pre.KickAngle[1]
     assert sum([e.BendingAngle for e in post]) == pre.BendingAngle
     pre = elements.RFCavity('rfc', 1, voltage=187500, frequency=3.5237e+8,
-                            harmonic_number=31, energy=6.e+9, KickAngle=0.5)
+                            harmonic_number=31, energy=6.e+9)
     post = pre.divide([0.2, 0.5, 0.3])
     assert len(post) == 3
     assert sum([e.Length for e in post]) == pre.Length
-    assert sum([e.KickAngle for e in post]) == pre.KickAngle
     assert sum([e.Voltage for e in post]) == pre.Voltage
 
 
@@ -212,12 +291,6 @@ def test_quad(rin):
     assert q.PolynomB[1] == 0.1
 
 
-def test_quad_incorrect_array(rin):
-    q = elements.Quadrupole('quad', 0.4, k=1)
-    with pytest.raises(ValueError):
-        q.PolynomB = 'a'
-
-
 def test_rfcavity(rin):
     rf = elements.RFCavity('rfcavity', 0.0, 187500, 3.5237e+8, 31, 6.e+9)
     lattice = [rf, rf, rf, rf]
@@ -226,6 +299,7 @@ def test_rfcavity(rin):
     atpass(lattice, rin, 1)
     expected = numpy.array([0., 0., 0., 0., 9.990769e-7, 1.e-6]).reshape(6, 1)
     numpy.testing.assert_allclose(rin, expected, atol=1e-12)
+
 
 @pytest.mark.parametrize("n", (0, 1, 2, 3, 4, 5))
 def test_m66(rin, n):


### PR DESCRIPTION
When exchanging lattices between Matlab and python, I noticed a difference in the way the default value for `MaxOrder` is computed:

**In python**: the default value for `MaxOrder` is 0 for `at.Dipole`, 1 for `at.Quadrupole`, 2 for `at.Sextupole`. Erroneously it is 0 for `at.Octupole`. While this looks coherent, in practice it may be confusing:
- for a focusing dipole (k != 0), the k value is correctly introduced in `PolynomB`, but will not be taken into account until `MaxOrder` is explicitly set to 1 (instead of 0)
- more generally, if additional multipoles are set in any ThinMultipole descendent (that is all magnets) by specifying `PolynomB=[…]` in the constructor, they will not be automatically taken into account.

**In Matlab**: The base value (0 for dipoles, 1 for quadrupoles,…) is incremented to take into account the highest non-zero coefficient of `PolynomA` or `PolynomB`. Of course, if `MaxOrder` is explicitly specified, it is honoured.

This difference does not appear when reading a .mat file, because all the attributes (including `MaxOrder`) are correctly converted. However, for defining or transfering lattice in text files (work in progress), a consistent behaviour is highly preferable. So I propose to switch to the Matlab convention. In all cases where `MaxOrder` is explicitly specified, it will not change anything. In other cases, the declared multipoles (including the dipole focusing strength) will be automatically activated.

I added a few tests to check this behaviour