### PR TITLE
New formats for loading/saving files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,6 @@ install:
   - venv\Scripts\activate
   - cd pyat
   - pip install --only-binary=numpy,scipy -r requirements.txt
-  - python setup.py build
 
 before_build:
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ install: |
   fi
   cd pyat
   pip install --only-binary=numpy,scipy -r requirements.txt
-  python setup.py build
 
 before_script:
+    # Use develop as we will be running the tests from the directory
+    # containing the at package.
   - python setup.py develop
 
 script: |

--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -5,7 +5,7 @@ pyAT is a Python interface to the pass methods defined in Accelerator Toolbox,
 implemented by compiling the C code used in the AT 'integrators' plus a Python
 extension.
 
-It supports Python 2.7 and 3.3 to 3.6.
+It supports Python 2.7 and 3.4 to 3.7.
 
 
 Installation preparation (Windows)
@@ -66,3 +66,29 @@ running the following, inside pyat, should fix it:
 
 N.B. setup.py develop needs to be run with the same version of Python (and
 numpy) that you are using to run pyAT.
+
+Releasing a version to PyPI
+---------------------------
+
+Because pyAT compiles C code, releasing a version is not simple. The code
+must be compiled for different operating systems and Python versions.
+
+To do this, we use the continuous integration services Travis CI (for Linux
+and Mac) and Appveyor (for Windows). When a tag of the form pyat-x.y.z is
+pushed to Github, wheels for each of the different platforms will be built
+and automatically uploaded to
+https://test.pypi.org/project/accelerator-toolbox/. Once there, someone
+should manually test that the wheels are working correctly, then they can
+manually download the files and upload them to PyPI itself.
+
+For Travis to be authenticated to Test PyPI, someone must set the variables
+TWINE_USERNAME and TWINE_PASSWORD in the Travis CI project settings. These
+are not public so it is possible to use personal details; it may be best
+not to use the same password for PyPI.
+
+A similar process is necessary for the Appveyor settings. You can click the
+little lock to keep the variable values private.
+
+Because there are complications putting special characters into these
+environment variables it may be simpler to ensure your Test PyPI password
+contains only alphanumeric characters.

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -533,5 +533,79 @@ class Corrector(LongElement):
                                         KickAngle=kick_angle, **kwargs)
 
 
+class Wiggler(LongElement):
+    """pyAT wiggler element
+
+    See atwiggler.m
+    """
+    REQUIRED_ATTRIBUTES = LongElement.REQUIRED_ATTRIBUTES + ['Lw', 'Bmax',
+                                                             'Nstep', 'Nmeth',
+                                                             'By', 'Bx',
+                                                             'Energy']
+    _conversions = dict(Element._conversions, Lw=float, Bmax=float, Nstep=int,
+                        Nmeth=int, NHharm=int, NVharm=int, By=_array,
+                        Bx=_array, Energy=float)
+
+    def __init__(self, family_name, length, wiggle_period, b_max, n_step,
+                 n_meth, by, bx, energy, **kwargs):
+        """
+
+        Args:
+            length: total length of the wiggler
+            wiggle_period: length must be a multiple of this
+            b_max: peak wiggler field [Tesla]
+            n_step: number of integration steps.
+            n_meth: symplectic integration order: 2 or 4
+            by: harmonics for horizontal wiggler: example [1, 1, 0, 1, 1, 0]
+            bx: harmonics for vertical wiggler: example []
+        Available keywords:
+            NHharm    Number of horizontal harmonics
+            NVharm    Number of vertical harmonics
+        """
+        n_wiggles = length / wiggle_period
+        if abs(round(n_wiggles) - n_wiggles) > 1e-6:
+            raise ValueError("Wiggler: length / wiggle_period is not an "
+                             "integer. ({0}/{1}={2})".format(length,
+                                                             wiggle_period,
+                                                             n_wiggles))
+        nh = kwargs.pop('NHharm', None)
+        nv = kwargs.pop('NVharm', None)
+        if nh is None:
+            try:
+                nh = len(by[0])
+            except TypeError:
+                nh = 1
+            except IndexError:
+                nh = 0
+        if nv is None:
+            try:
+                nv = len(bx[0])
+            except TypeError:
+                nv = 1
+            except IndexError:
+                nv = 0
+        for i in range(nh):
+            if i == 0:
+                dk = abs(by[3]**2 - by[4]**2 - by[2]**2) / abs(by[4])
+            else:
+                dk = abs(by[3, i]**2 - by[4, i]**2 - by[2, i]**2) / abs(by[4])
+            if dk > 1e-6:
+                raise ValueError("Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = "
+                                 "{0}".format(i))
+        for i in range(nv):
+            if i == 0:
+                dk = abs(bx[2]**2 - bx[4]**2 - bx[3]**2) / abs(bx[4])
+            else:
+                dk = abs(bx[2, i]**2 - bx[4, i]**2 - bx[3, i]**2) / abs(bx[4])
+            if dk > 1e-6:
+                raise ValueError("Wiggler(H): ky^2 + kz^2 -kx^2 !=0, i = "
+                                 "{0}".format(i))
+        kwargs.setdefault('PassMethod', 'GWigSymplecticPass')
+        super(Wiggler, self).__init__(family_name, length, Lw=wiggle_period,
+                                      Bmax=b_max, Nstep=n_step, Nmeth=n_meth,
+                                      NHharm=nh, NVharm=nv, By=by, Bx=bx,
+                                      Energy=energy, **kwargs)
+
+
 CLASS_MAP = dict((k, v) for k, v in locals().items()
                  if isinstance(v, type) and issubclass(v, Element))

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -13,7 +13,7 @@ from inspect import getmembers, isdatadescriptor
 def _array(value, shape=(-1,), dtype=numpy.float64):
     # Ensure proper ordering(F) and alignment(A) for "C" access in integrators
     return numpy.require(value, dtype=dtype, requirements=['F', 'A']).reshape(
-        shape, order='F')
+        shape)
 
 
 def _array66(value):
@@ -44,7 +44,9 @@ class Element(object):
         self.FamName = family_name
         self.Length = kwargs.pop('Length', 0.0)
         self.PassMethod = kwargs.pop('PassMethod', 'IdentityPass')
-        self.update(kwargs)
+
+        for (key, value) in kwargs.items():
+            setattr(self, key, value)
 
     def __setattr__(self, key, value):
         try:
@@ -90,24 +92,9 @@ class Element(object):
         # by default, the element is indivisible
         return [self]
 
-    def update(self, *args, **kwargs):
-        """Update the element attributes with the given arguments
-
-        update(**kwargs)
-        update(mapping, **kwargs)
-        update(iterable, **kwargs)
-        """
-        attrs = dict(*args, **kwargs)
-        for (key, value) in attrs.items():
-            setattr(self, key, value)
-
     def copy(self):
         """Return a shallow copy of the element"""
         return copy.copy(self)
-
-    def deepcopy(self):
-        """Return a deep copy of the element"""
-        return copy.deepcopy(self)
 
     def items(self):
         """Iterates through the data members including slots and properties"""
@@ -531,81 +518,3 @@ class Corrector(LongElement):
         kwargs.setdefault('PassMethod', 'CorrectorPass')
         super(Corrector, self).__init__(family_name, length,
                                         KickAngle=kick_angle, **kwargs)
-
-
-class Wiggler(LongElement):
-    """pyAT wiggler element
-
-    See atwiggler.m
-    """
-    REQUIRED_ATTRIBUTES = LongElement.REQUIRED_ATTRIBUTES + ['Lw', 'Bmax',
-                                                             'Nstep', 'Nmeth',
-                                                             'By', 'Bx',
-                                                             'Energy']
-    _conversions = dict(Element._conversions, Lw=float, Bmax=float, Nstep=int,
-                        Nmeth=int, NHharm=int, NVharm=int, By=_array,
-                        Bx=_array, Energy=float)
-
-    def __init__(self, family_name, length, wiggle_period, b_max, n_step,
-                 n_meth, by, bx, energy, **kwargs):
-        """
-
-        Args:
-            length: total length of the wiggler
-            wiggle_period: length must be a multiple of this
-            b_max: peak wiggler field [Tesla]
-            n_step: number of integration steps.
-            n_meth: symplectic integration order: 2 or 4
-            by: harmonics for horizontal wiggler: example [1, 1, 0, 1, 1, 0]
-            bx: harmonics for vertical wiggler: example []
-        Available keywords:
-            NHharm    Number of horizontal harmonics
-            NVharm    Number of vertical harmonics
-        """
-        n_wiggles = length / wiggle_period
-        if abs(round(n_wiggles) - n_wiggles) > 1e-6:
-            raise ValueError("Wiggler: length / wiggle_period is not an "
-                             "integer. ({0}/{1}={2})".format(length,
-                                                             wiggle_period,
-                                                             n_wiggles))
-        nh = kwargs.pop('NHharm', None)
-        nv = kwargs.pop('NVharm', None)
-        if nh is None:
-            try:
-                nh = len(by[0])
-            except TypeError:
-                nh = 1
-            except IndexError:
-                nh = 0
-        if nv is None:
-            try:
-                nv = len(bx[0])
-            except TypeError:
-                nv = 1
-            except IndexError:
-                nv = 0
-        for i in range(nh):
-            if i == 0:
-                dk = abs(by[3]**2 - by[4]**2 - by[2]**2) / abs(by[4])
-            else:
-                dk = abs(by[3, i]**2 - by[4, i]**2 - by[2, i]**2) / abs(by[4])
-            if dk > 1e-6:
-                raise ValueError("Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = "
-                                 "{0}".format(i))
-        for i in range(nv):
-            if i == 0:
-                dk = abs(bx[2]**2 - bx[4]**2 - bx[3]**2) / abs(bx[4])
-            else:
-                dk = abs(bx[2, i]**2 - bx[4, i]**2 - bx[3, i]**2) / abs(bx[4])
-            if dk > 1e-6:
-                raise ValueError("Wiggler(H): ky^2 + kz^2 -kx^2 !=0, i = "
-                                 "{0}".format(i))
-        kwargs.setdefault('PassMethod', 'GWigSymplecticPass')
-        super(Wiggler, self).__init__(family_name, length, Lw=wiggle_period,
-                                      Bmax=b_max, Nstep=n_step, Nmeth=n_meth,
-                                      NHharm=nh, NVharm=nv, By=by, Bx=bx,
-                                      Energy=energy, **kwargs)
-
-
-CLASS_MAP = dict((k, v) for k, v in locals().items()
-                 if isinstance(v, type) and issubclass(v, Element))

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -68,9 +68,12 @@ class Element(object):
                      self.REQUIRED_ATTRIBUTES]
         defelem = self.__class__(*arguments)
         keywords = ['{0!r}'.format(arg) for arg in arguments]
-        keywords += ['{0}={1!r}'.format(k, v) for k, v in attrs.items()
+        keywords += ['{0}={1!r}'.format(k, v) for k, v in sorted(attrs.items())
                      if not numpy.array_equal(v, getattr(defelem, k, None))]
         return '{0}({1})'.format(self.__class__.__name__, ', '.join(keywords))
+
+    def __eq__(self, other):
+        return repr(self) == repr(other)
 
     def divide(self, frac):
         """split the element in len(frac) pieces whose length
@@ -532,6 +535,16 @@ class Corrector(LongElement):
         kwargs.setdefault('PassMethod', 'CorrectorPass')
         super(Corrector, self).__init__(family_name, length,
                                         KickAngle=kick_angle, **kwargs)
+
+
+class Wiggler(LongElement):
+    """
+    place holder for a Wiggler element, acts as a drift
+    """
+    # noinspection PyUnusedLocal
+    def __init__(self, family_name, length, *args, **kwargs):
+        kwargs.setdefault('PassMethod', 'DriftPass')
+        super(Wiggler, self).__init__(family_name, length, **kwargs)
 
 
 CLASS_MAP = dict((k, v) for k, v in locals().items()

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -377,8 +377,7 @@ class Lattice(list):
             return lattice_modify()
 
     @staticmethod
-    def _radiation_attrs(cavity_func, dipole_func,
-                         quadrupole_func, wiggler_func):
+    def _radiation_attrs(cavity_func, dipole_func, quadrupole_func):
         """Create a function returning the modified attributes"""
 
         def elem_func(elem):
@@ -393,8 +392,6 @@ class Lattice(list):
                 return dipole_func(elem)
             elif isinstance(elem, elements.Quadrupole):
                 return quadrupole_func(elem)
-            elif isinstance(elem, elements.Wiggler):
-                return wiggler_func(elem)
             else:
                 return None
 
@@ -402,7 +399,7 @@ class Lattice(list):
 
     # noinspection PyShadowingNames
     def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
-                     quadrupole_pass=None, wiggler_pass='auto', copy=False):
+                     quadrupole_pass=None, copy=False):
         """
         Turn acceleration and radiation on and return the lattice
 
@@ -410,7 +407,6 @@ class Lattice(list):
             cavity_pass='CavityPass'    PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
-            wiggler_pass='auto          PassMethod set on wigglers
             copy=False                  Return a shallow copy of the lattice and
                                         replace only the modified attributes
                                         Otherwise modify the lattice in-place.
@@ -445,13 +441,12 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass),
-                                          repfunc(wiggler_pass))
+                                          repfunc(quadrupole_pass))
         return self.modify_elements(elem_func, copy=copy)
 
     # noinspection PyShadowingNames
     def radiation_off(self, cavity_pass='IdentityPass', dipole_pass='auto',
-                      quadrupole_pass=None, wiggler_pass='auto', copy=False):
+                      quadrupole_pass=None, copy=False):
         """
         Turn acceleration and radiation off and return the lattice
 
@@ -491,8 +486,7 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass),
-                                          repfunc(wiggler_pass))
+                                          repfunc(quadrupole_pass))
         return self.modify_elements(elem_func, copy=copy)
 
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -377,7 +377,8 @@ class Lattice(list):
             return lattice_modify()
 
     @staticmethod
-    def _radiation_attrs(cavity_func, dipole_func, quadrupole_func):
+    def _radiation_attrs(cavity_func, dipole_func,
+                         quadrupole_func, wiggler_func):
         """Create a function returning the modified attributes"""
 
         def elem_func(elem):
@@ -392,6 +393,8 @@ class Lattice(list):
                 return dipole_func(elem)
             elif isinstance(elem, elements.Quadrupole):
                 return quadrupole_func(elem)
+            elif isinstance(elem, elements.Wiggler):
+                return wiggler_func(elem)
             else:
                 return None
 
@@ -399,7 +402,7 @@ class Lattice(list):
 
     # noinspection PyShadowingNames
     def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
-                     quadrupole_pass=None, copy=False):
+                     quadrupole_pass=None, wiggler_pass='auto', copy=False):
         """
         Turn acceleration and radiation on and return the lattice
 
@@ -407,6 +410,7 @@ class Lattice(list):
             cavity_pass='CavityPass'    PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
+            wiggler_pass='auto          PassMethod set on wigglers
             copy=False                  Return a shallow copy of the lattice and
                                         replace only the modified attributes
                                         Otherwise modify the lattice in-place.
@@ -441,12 +445,13 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass))
+                                          repfunc(quadrupole_pass),
+                                          repfunc(wiggler_pass))
         return self.modify_elements(elem_func, copy=copy)
 
     # noinspection PyShadowingNames
     def radiation_off(self, cavity_pass='IdentityPass', dipole_pass='auto',
-                      quadrupole_pass=None, copy=False):
+                      quadrupole_pass=None, wiggler_pass='auto', copy=False):
         """
         Turn acceleration and radiation off and return the lattice
 
@@ -486,7 +491,8 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass))
+                                          repfunc(quadrupole_pass),
+                                          repfunc(wiggler_pass))
         return self.modify_elements(elem_func, copy=copy)
 
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -321,6 +321,10 @@ class Lattice(list):
             Otherwise, elem_modify(elem) must return a dictionary of
             attribute name and values, to be set to elem.
 
+        RETURNS
+            New lattice if copy == True
+            None if copy == False
+
         KEYWORDS
             copy=True           Return a shallow copy of the lattice. Only the
                                 modified attributes are replaced. Otherwise
@@ -338,7 +342,6 @@ class Lattice(list):
                         elem.PassMethod.endswith('CavityPass')):
                     radiate = True
             self._radiation = radiate
-            return self
 
         def lattice_copy(params):
             """Custom iterator for the creation of a new lattice"""
@@ -357,7 +360,7 @@ class Lattice(list):
         if copy:
             return Lattice(iterator=lattice_copy)
         else:
-            return lattice_modify()
+            lattice_modify()
 
     @staticmethod
     def _radiation_attrs(cavity_func, dipole_func,

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -14,12 +14,16 @@ import sys
 import copy
 import numpy
 import math
-import itertools
 from warnings import warn
+import itertools
+from scipy.constants import physical_constants as cst
 from at.lattice import AtError, AtWarning
 from at.lattice import elements, get_s_pos, get_elements, uint32_refpts
 
-__all__ = ['Lattice']
+TWO_PI_ERROR = 1.E-4
+
+__all__ = ['Lattice', 'type_filter', 'params_filter', 'lattice_filter',
+           'no_filter']
 
 
 class Lattice(list):
@@ -27,83 +31,105 @@ class Lattice(list):
     An AT lattice is a sequence of AT elements.
     A Lattice accepts extended indexing (as a numpy ndarray).
 
-    ATTRIBUTES
+    Lattice attributes;
         name        Name of the lattice
         energy      Particle energy
         periodicity Number of super-periods to describe the full ring
 
-    To reduce the inter-package dependencies, some methods of the
-    lattice object are defined in other AT packages, in the module where
-    the underlying function is implemented.
-    """
-    _1st_attributes = ('name', 'energy', 'periodicity')
-
-    def __init__(self, elems=None, name=None, energy=None, periodicity=None,
-                 **kwargs):
-        """Create a new lattice object
+    Lattice(elems, **params)     Create a new lattice object
 
         INPUT
             elems:          any iterable of AT elements
 
         KEYWORDS
+            iterator=None   Custom iterator (see below)
+            scan=False      Scan elements, looking for energy and periodicity
             name            Name of the lattice
             energy          Energy of the lattice
             periodicity     Number of periods
+            *               all other keywords will be set as Lattice attributes
 
-            all other keywords will be set as Lattice attributes
-        """
-        # noinspection PyShadowingNames
-        def check_elems(elems, attrs):
-            """Check the radiation status of a lattice"""
-            radiate = False
-            for idx, elem in enumerate(elems):
-                if isinstance(elem, elements.Element):
-                    if (elem.PassMethod.endswith('RadPass') or
-                            elem.PassMethod.endswith('CavityPass')):
-                        radiate = True
-                    yield elem
-                else:
-                    warn(AtWarning('item {0} ({1}) is not an AT element: '
-                                   'ignored'.format(idx, elem)))
-            attrs['_radiation'] = radiate
+    To reduce the inter-package dependencies, some methods of the
+    lattice object are defined in other AT packages, in the module where
+    the underlying function is implemented.
 
-        if elems is None:
-            elems = []
+    Custom iterators:
+    Instead of running through 'elems', the Lattice constructor can use one
+    or several custom iterators.
 
-        if name is not None:
-            kwargs['name'] = name
-        if energy is not None:
-            kwargs['energy'] = energy
-        if periodicity is not None:
-            kwargs['periodicity'] = periodicity
+    Lattice(*args, iterator=it, **params)
 
-        if isinstance(elems, Lattice):
-            attrs = vars(elems).copy()
-            attrs.update(kwargs)
+        The iterator "it" is called as "it(params, *args)" and must return an
+            iterator over AT elements for building the lattice. It must also
+            fill the "params" dictionary used to set the Lattice attributes.
+
+            params is the dictionary of lattice parameters. It is initialised
+                   with the keywords of the lattice constructor. It can be
+                   modified by the custom iterator to add or remove parameters.
+                   Finally, all remaining parameters will be set as Lattice
+                   attributes.
+            *args  all positional arguments of the Lattice constructor are sent
+                   to the custom iterator.
+
+        An iterator can be:
+            - a "generator" which yields elements from scratch.
+              Examples: a list, or a file iterator,
+            - a "filter" which runs through an input iterator, processes each
+              element, possibly adds parameters to the params dictionary
+              and yields the processed elements.
+
+        Example of chaining iterators (taken from "load_mat"):
+
+        Lattice(ringparam_filter, matfile_generator, filename
+                iterator=params_filter, **params)
+
+        matfile_generator(params, filename)
+            opens filename and generates AT elements for each cell of the
+            Matlab cell array representing the lattice,
+
+        ringparam_filter(params, matfile_generator, *args)
+            runs through matfile_generator(params, *args), looks for RingParam
+            elements, fills params with their information and discards them,
+
+        params_filter(params, ringparam_filter, *args)
+            runs through ringparam_filter(params, *args), looks for energy and
+            periodicity if not yet defined.
+    """
+    _1st_attributes = ('name', 'energy', 'periodicity')
+
+    def __init__(self, *args, **kwargs):
+        """Lattice constructor"""
+
+        iterator = kwargs.pop('iterator', None)
+        scan = kwargs.pop('scan', False)
+        for key in list(k for k in kwargs.keys() if k.startswith('_')):
+            kwargs.pop(key)
+        if iterator is None:
+            elem_list, = args or [[]]  # accept 0 or 1 argument
+            if isinstance(elem_list, Lattice):
+                elems = lattice_filter(kwargs, elem_list)
+            elif scan:
+                elems = params_filter(kwargs, type_filter, elem_list)
+            else:
+                elems = type_filter(kwargs, elem_list)
         else:
-            attrs = kwargs
-
-        # reset the range of interest
-        attrs.pop('_s_range', None)
-        attrs.pop('_i_range', None)
-        # set default values
-        attrs.setdefault('name', '')
-        attrs.setdefault('periodicity', 1)
-        if 'energy' not in attrs:
-            raise AtError('Lattice energy is not defined')
-        if '_radiation' not in attrs:
-            elems = check_elems(elems, attrs)
+            elems = iterator(kwargs, *args)
 
         super(Lattice, self).__init__(elems)
 
-        for key, value in attrs.items():
-            setattr(self, key, value)
+        # set default values
+        kwargs.setdefault('name', '')
+        kwargs.setdefault('periodicity', 1)
+        if 'energy' not in kwargs:
+            raise AtError('Lattice energy is not defined')
+        # set attributes
+        self.update(kwargs)
 
     def __getitem__(self, key):
         try:
             return super(Lattice, self).__getitem__(key.__index__())
         except (AttributeError, TypeError):
-            return Lattice(self.iterator(key), **vars(self))
+            return Lattice(self.iterator(key), iterator=no_filter, **vars(self))
 
     if sys.version_info < (3, 0):
         # This won't be defined if version is at least 3.0
@@ -130,16 +156,16 @@ class Lattice(list):
 
     def __repr__(self):
         attrs = vars(self).copy()
-        k1 = [(k, attrs.pop(k))for k in Lattice._1st_attributes]
+        k1 = [(k, attrs.pop(k)) for k in Lattice._1st_attributes]
         k2 = [(k, v) for k, v in attrs.items() if not k.startswith('_')]
-        keys = ', '.join('{0}={1!r}'.format(k, v) for k, v in (k1+k2))
+        keys = ', '.join('{0}={1!r}'.format(k, v) for k, v in (k1 + k2))
         return 'Lattice({0}, {1})'.format(super(Lattice, self).__repr__(), keys)
 
     def __str__(self):
         attrs = vars(self).copy()
-        k1 = [(k, attrs.pop(k))for k in Lattice._1st_attributes]
+        k1 = [(k, attrs.pop(k)) for k in Lattice._1st_attributes]
         k2 = [(k, v) for k, v in attrs.items() if not k.startswith('_')]
-        keys = ', '.join('{0}={1!r}'.format(k, v) for k, v in (k1+k2))
+        keys = ', '.join('{0}={1!r}'.format(k, v) for k, v in (k1 + k2))
         return 'Lattice(<{0} elements>, {1})'.format(len(self), keys)
 
     def __add__(self, elems):
@@ -157,6 +183,17 @@ class Lattice(list):
         else:
             rg = uint32_refpts(key, len(self))
         return (super(Lattice, self).__getitem__(i) for i in rg)
+
+    def update(self, *args, **kwargs):
+        """Update the element attributes with the given arguments
+
+        update(**kwargs)
+        update(mapping, **kwargs)
+        update(iterable, **kwargs)
+        """
+        attrs = dict(*args, **kwargs)
+        for (key, value) in attrs.items():
+            setattr(self, key, value)
 
     def copy(self):
         """Return a shallow copy"""
@@ -240,13 +277,8 @@ class Lattice(list):
         return uint32_refpts(i_range, len(self))
 
     @property
-    def circumference(self):
-        """Ring circumference"""
-        return self.periodicity * self.get_s_pos(len(self))[0]
-
-    @property
     def voltage(self):
-        """Total accelerating voltage"""
+        """Accelerating voltage"""
         volts = [elem.Voltage for elem in self if
                  isinstance(elem, elements.RFCavity)]
         return self.periodicity * sum(volts)
@@ -261,95 +293,288 @@ class Lattice(list):
     @property
     def radiation(self):
         """If True, at least one element modifies the beam energy"""
-        return self._radiation
+        try:
+            return self._radiation
+        except AttributeError:
+            radiate = False
+            for elem in self:
+                if (elem.PassMethod.endswith('RadPass') or
+                        elem.PassMethod.endswith('CavityPass')):
+                    radiate = True
+                    break
+            # noinspection PyAttributeOutsideInit
+            self._radiation = radiate
+            return radiate
 
-    def _radiation_switch(self, cavity_func=None, dipole_func=None,
-                          quadrupole_func=None):
+    @property
+    def energy_loss(self):
+        """Energy loss per turn [eV]
 
-        def switch(elfunc, elcheck):
-            if elfunc is not None:
-                for el in (e for e in self if elcheck(e)):
-                    elfunc(el)
-
-        def isdipole(elem):
-            return isinstance(elem, elements.Dipole) and (
-                    elem.BendingAngle != 0.0)
-
-        switch(cavity_func, lambda e: isinstance(e, elements.RFCavity))
-        switch(dipole_func, isdipole)
-        switch(quadrupole_func, lambda e: isinstance(e, elements.Quadrupole))
-
-    def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
-                     quadrupole_pass=None):
+        Losses = Cgamma / 2pi * EGeV^4 * i2
         """
-        Turn acceleration and radiation on
+        lenthe = numpy.array(
+            [(elem.Length, elem.BendingAngle) for elem in self if
+             isinstance(elem, elements.Dipole)])
+        lendp = lenthe[:, 0]
+        theta = lenthe[:, 1]
+
+        e_radius = cst['classical electron radius'][0]
+        e_mass = cst['electron mass energy equivalent in MeV'][0]
+        cgamma = 4.0E9 * numpy.pi * e_radius / 3.0 / pow(e_mass, 3)
+
+        i2 = self.periodicity * (numpy.sum(theta * theta / lendp))
+        e_loss = cgamma / 2.0 / numpy.pi * pow(self.energy * 1.0E-9,
+                                               4) * i2 * 1.e9
+        return e_loss
+
+    # noinspection PyShadowingNames
+    def modify_elements(self, elem_modify, copy=True):
+        """Modify selected elements, in-place or in a lattice copy
+
+        PARAMETERS
+            elem_modify         element selection function.
+
+            If elem_modify(elem) returns None, the element is unchanged.
+            Otherwise, elem_modify(elem) must return a dictionary of
+            attribute name and values, to be set to elem.
+
+        KEYWORDS
+            copy=True           Return a shallow copy of the lattice. Only the
+                                modified attributes are replaced. Otherwise
+                                modify the lattice in-place.
+        """
+
+        def lattice_modify():
+            """Modifies the Lattice with elements modified by elem_modify"""
+            radiate = False
+            for elem in self:
+                attrs = elem_modify(elem)
+                if attrs is not None:
+                    elem.update(attrs)
+                if (elem.PassMethod.endswith('RadPass') or
+                        elem.PassMethod.endswith('CavityPass')):
+                    radiate = True
+            self._radiation = radiate
+            return self
+
+        def lattice_copy(params):
+            """Custom iterator for the creation of a new lattice"""
+            radiate = False
+            for elem in lattice_filter(params, self):
+                attrs = elem_modify(elem)
+                if attrs is not None:
+                    elem = elem.copy()
+                    elem.update(attrs)
+                if (elem.PassMethod.endswith('RadPass') or
+                        elem.PassMethod.endswith('CavityPass')):
+                    radiate = True
+                yield elem
+            params['_radiation'] = radiate
+
+        if copy:
+            return Lattice(iterator=lattice_copy)
+        else:
+            return lattice_modify()
+
+    @staticmethod
+    def _radiation_attrs(cavity_func, dipole_func, quadrupole_func):
+        """Create a function returning the modified attributes"""
+
+        def elem_func(elem):
+
+            def isdipole(el):
+                return isinstance(el, elements.Dipole) and (
+                        el.BendingAngle != 0.0)
+
+            if isinstance(elem, elements.RFCavity):
+                return cavity_func(elem)
+            elif isdipole(elem):
+                return dipole_func(elem)
+            elif isinstance(elem, elements.Quadrupole):
+                return quadrupole_func(elem)
+            else:
+                return None
+
+        return elem_func
+
+    # noinspection PyShadowingNames
+    def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
+                     quadrupole_pass=None, copy=False):
+        """
+        Turn acceleration and radiation on and return the lattice
 
         KEYWORDS
             cavity_pass='CavityPass'    PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
+            copy=False                  Return a shallow copy of the lattice and
+                                        replace only the modified attributes
+                                        Otherwise modify the lattice in-place.
 
             For PassMethod names, the convention is:
                 None            no change
                 'auto'          replace *Pass by *RadPass
-                anything else   set as it is
-
+                anything else   set as the new PassMethod
         """
 
         def repfunc(pass_method):
             if pass_method is None:
-                ff = None
+                # noinspection PyUnusedLocal
+                def ff(elem):
+                    return None
             elif pass_method == 'auto':
                 def ff(elem):
                     if not elem.PassMethod.endswith('RadPass'):
-                        elem.PassMethod = ''.join(
-                            (elem.PassMethod[:-4], 'RadPass'))
-                        elem.Energy = self.energy
+                        pass_m = ''.join((elem.PassMethod[:-4], 'RadPass'))
+                        return {'PassMethod': pass_m,
+                                'Energy': self.energy}
+                    else:
+                        return None
             else:
                 def ff(elem):
-                    elem.PassMethod = pass_method
-                    elem.Energy = self.energy
+                    if elem.PassMethod != pass_method:
+                        return {'PassMethod': pass_method,
+                                'Energy': self.energy}
+                    else:
+                        return None
             return ff
 
-        self._radiation_switch(repfunc(cavity_pass), repfunc(dipole_pass),
-                               repfunc(quadrupole_pass))
-        # noinspection PyAttributeOutsideInit
-        self._radiation = True
+        elem_func = self._radiation_attrs(repfunc(cavity_pass),
+                                          repfunc(dipole_pass),
+                                          repfunc(quadrupole_pass))
+        return self.modify_elements(elem_func, copy=copy)
 
+    # noinspection PyShadowingNames
     def radiation_off(self, cavity_pass='IdentityPass', dipole_pass='auto',
-                      quadrupole_pass=None):
+                      quadrupole_pass=None, copy=False):
         """
-        Turn acceleration and radiation off
+        Turn acceleration and radiation off and return the lattice
 
         KEYWORDS
             cavity_pass='IdentityPass'  PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
+            copy=False                  Return a shallow copy of the lattice and
+                                        replace only the modified attributes
+                                        Otherwise modify the lattice in-place.
 
             For PassMethod names, the convention is:
                 None            no change
                 'auto'          replace *RadPass by *Pass
                 anything else   set as it is
-
         """
 
         def repfunc(pass_method):
             if pass_method is None:
-                ff = None
+                # noinspection PyUnusedLocal
+                def ff(elem):
+                    return None
             elif pass_method == 'auto':
                 def ff(elem):
                     if elem.PassMethod.endswith('RadPass'):
-                        elem.PassMethod = ''.join(
-                            (elem.PassMethod[:-7], 'Pass'))
+                        pass_m = ''.join((elem.PassMethod[:-7], 'Pass'))
+                        return {'PassMethod': pass_m}
+                    else:
+                        return None
             else:
                 def ff(elem):
-                    elem.PassMethod = pass_method
+                    if elem.PassMethod != pass_method:
+                        return {'PassMethod': pass_method}
+                    else:
+                        return None
             return ff
 
-        self._radiation_switch(repfunc(cavity_pass), repfunc(dipole_pass),
-                               repfunc(quadrupole_pass))
-        # noinspection PyAttributeOutsideInit
-        self._radiation = False
+        elem_func = self._radiation_attrs(repfunc(cavity_pass),
+                                          repfunc(dipole_pass),
+                                          repfunc(quadrupole_pass))
+        return self.modify_elements(elem_func, copy=copy)
+
+
+def lattice_filter(params, elems):
+    """Copy lattice parameters an run through all lattice elements"""
+    for key, value in vars(elems).items():
+        params.setdefault(key, value)
+    return iter(elems)
+
+
+# noinspection PyUnusedLocal
+def no_filter(params, elems):
+    """Run through all elements without any check"""
+    return iter(elems)
+
+
+def type_filter(params, elems):
+    """Run through all elements and check element validity.
+    Analyses elements for radiation state
+    """
+    radiate = False
+    for idx, elem in enumerate(elems):
+        if isinstance(elem, elements.Element):
+            if (elem.PassMethod.endswith('RadPass') or
+                    elem.PassMethod.endswith('CavityPass')):
+                radiate = True
+            yield elem
+        else:
+            warn(AtWarning('item {0} ({1}) is not an AT element: '
+                           'ignored'.format(idx, elem)))
+    params['_radiation'] = radiate
+
+
+def params_filter(params, elem_iterator, *args):
+    """Run through all elements, looking for energy and periodicity.
+    Remove the Energy attribute of non-radiating elements
+
+    energy is taken from:
+        1) The params dictionary
+        2) Radiative elements (Cavity, RingParam, Radiating magnets)
+        3) Any other element
+
+    periodicity is taken from:
+        1) The params dictionary
+        2) Sum of the bending angles of magnets
+    """
+    rad_energies = []
+    el_energies = []
+    thetas = []
+
+    for idx, elem in enumerate(elem_iterator(params, *args)):
+        if (isinstance(elem, elements.RFCavity) or
+                elem.PassMethod.endswith('RadPass')):
+            rad_energies.append(elem.Energy)
+            try:
+                elem.Energy = params['energy']
+            except KeyError:
+                params['energy'] = elem.Energy
+        elif hasattr(elem, 'Energy'):
+            el_energies.append(elem.Energy)
+            del elem.Energy
+        if isinstance(elem, elements.Dipole):
+            thetas.append(elem.BendingAngle)
+        yield elem
+
+    energies = rad_energies or el_energies
+
+    if 'energy' not in params and energies:
+        # Guess energy from the Energy attribute of the elements
+        params['energy'] = max(energies)
+
+    if energies and min(energies) < max(energies):
+        warn(AtWarning('Inconsistent energy values, '
+                       '"energy" set to {0}'.format(params['energy'])))
+
+    if 'periodicity' not in params:
+        # Guess periodicity from the bending angles of the lattice
+        try:
+            nbp = 2.0 * numpy.pi / sum(thetas)
+        except ZeroDivisionError:
+            periodicity = 1
+            warn(AtWarning('No bending in the cell, set "Periodicity" to 1'))
+        else:
+            periodicity = int(round(nbp))
+            if abs(periodicity - nbp) > TWO_PI_ERROR:
+                warn(AtWarning('Non-integer number of cells: '
+                               '{0} -> {1}'.format(nbp, periodicity)))
+        params['periodicity'] = periodicity
 
 
 Lattice.get_elements = get_elements

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -361,7 +361,7 @@ class Lattice(list):
 
     @staticmethod
     def _radiation_attrs(cavity_func, dipole_func,
-                         quadrupole_func):
+                         quadrupole_func, wiggler_func):
         """Create a function returning the modified attributes"""
 
         def elem_func(elem):
@@ -376,6 +376,8 @@ class Lattice(list):
                 return dipole_func(elem)
             elif isinstance(elem, elements.Quadrupole):
                 return quadrupole_func(elem)
+            elif isinstance(elem, elements.Wiggler):
+                return wiggler_func(elem)
             else:
                 return None
 
@@ -383,7 +385,7 @@ class Lattice(list):
 
     # noinspection PyShadowingNames
     def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
-                     quadrupole_pass=None, copy=False):
+                     quadrupole_pass=None, wiggler_pass='auto', copy=False):
         """
         Turn acceleration and radiation on and return the lattice
 
@@ -391,6 +393,7 @@ class Lattice(list):
             cavity_pass='CavityPass'    PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
+            wiggler_pass=None           PassMethod set on wigglers
             copy=False                  Return a shallow copy of the lattice and
                                         replace only the modified attributes
                                         Otherwise modify the lattice in-place.
@@ -425,12 +428,13 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass))
+                                          repfunc(quadrupole_pass),
+                                          repfunc(wiggler_pass))
         return self.modify_elements(elem_func, copy=copy)
 
     # noinspection PyShadowingNames
     def radiation_off(self, cavity_pass='IdentityPass', dipole_pass='auto',
-                      quadrupole_pass=None, copy=False):
+                      quadrupole_pass=None, wiggler_pass='auto', copy=False):
         """
         Turn acceleration and radiation off and return the lattice
 
@@ -438,6 +442,7 @@ class Lattice(list):
             cavity_pass='IdentityPass'  PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
+            wiggler_pass=None           PassMethod set on wigglers
             copy=False                  Return a shallow copy of the lattice and
                                         replace only the modified attributes
                                         Otherwise modify the lattice in-place.
@@ -470,7 +475,8 @@ class Lattice(list):
 
         elem_func = self._radiation_attrs(repfunc(cavity_pass),
                                           repfunc(dipole_pass),
-                                          repfunc(quadrupole_pass))
+                                          repfunc(quadrupole_pass),
+                                          repfunc(wiggler_pass))
         return self.modify_elements(elem_func, copy=copy)
 
 

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -1,6 +1,8 @@
 """
-Import of AT lattice from different formats:
+Import/export AT lattice from/to different formats:
 - .mat files
+- .m files
 """
-
+from .allfiles import *
 from .matfile import *
+from .reprfile import *

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -1,0 +1,77 @@
+import os.path
+from at.lattice import Lattice
+
+__all__ = ['load_lattice', 'save_lattice', 'register_format']
+
+_load_extension = {}
+_save_extension = {}
+
+
+def load_lattice(filepath, **kwargs):
+    """Load a Lattice object from a file
+
+    The file format is indicated by the filepath extension.
+
+    PARAMETERS
+        filepath        name of the file
+
+    KEYWORDS
+        name            Name of the lattice
+                        (default: taken from the lattice, or '')
+        energy          Energy of the lattice
+                        (default: taken from the elements)
+        periodicity     Number of periods
+                        (default: taken from the elements, or 1)
+        *               all other keywords will be set as Lattice attributes
+
+    MAT-FILE SPECIFIC KEYWORDS
+        mat_key         name of the Matlab variable containing the lattice.
+                        Default: Matlab variable name if there is only one,
+                        otherwise 'RING'
+        check=True      if False, skip the coherence tests
+        quiet=False     If True, suppress the warning for non-standard classes
+        keep_all=False  if True, keep RingParam elements as Markers
+
+    Known extensions are:
+    """
+    _, ext = os.path.splitext(filepath)
+    return _load_extension[ext.lower()](filepath, **kwargs)
+
+
+def save_lattice(ring, filepath, **kwargs):
+    """Save a Lattice object
+
+    The file format is indicated by the filepath extension.
+
+    PARAMETERS
+        ring            Lattice object
+        filepath        name of the file
+
+    MAT-FILE SPECIFIC KEYWORDS
+        mat_key='RING'  Name of the Matlab variable
+
+    Known extensions are:
+    """
+    _, ext = os.path.splitext(filepath)
+    return _save_extension[ext.lower()](ring, filepath, **kwargs)
+
+
+def register_format(extension, load_func=None, save_func=None, descr=''):
+    """Register format-specific processing functions
+
+    PARAMETERS
+        extension       File extension string
+        load_func       load function (default: None)
+        save_func       save_lattice function (default: None)
+        descr           File type description
+    """
+    if load_func is not None:
+        _load_extension[extension] = load_func
+        load_lattice.__doc__ += '\n    {0:<10}\t{1}'.format(extension, descr)
+    if save_func is not None:
+        _save_extension[extension] = save_func
+        save_lattice.__doc__ += '\n    {0:<10}\t{1}'.format(extension, descr)
+
+
+Lattice.load = staticmethod(load_lattice)
+Lattice.save = save_lattice

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -1,3 +1,6 @@
+"""Generic function to save and load python AT lattices. The format is
+determined by the file extension
+"""
 import os.path
 from at.lattice import Lattice
 
@@ -17,11 +20,11 @@ def load_lattice(filepath, **kwargs):
 
     KEYWORDS
         name            Name of the lattice
-                        (default: taken from the lattice, or '')
+                        (default: taken from the file, or '')
         energy          Energy of the lattice
-                        (default: taken from the elements)
+                        (default: taken from the file)
         periodicity     Number of periods
-                        (default: taken from the elements, or 1)
+                        (default: taken from the file, or 1)
         *               all other keywords will be set as Lattice attributes
 
     MAT-FILE SPECIFIC KEYWORDS

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -1,141 +1,104 @@
 """
 Load lattices from Matlab files.
 """
+from __future__ import print_function
+import sys
+from os.path import abspath
 from warnings import warn
 import scipy.io
 import numpy
-from at.lattice import elements, Lattice, AtError, AtWarning
-from at.load.utils import element_from_dict, lattice_to_matlab, RingParam
+from at.lattice import elements, Lattice, AtWarning, params_filter
+from at.load import register_format
+from at.load.utils import element_from_dict, element_from_m, RingParam
+from at.load.utils import element_to_dict, element_to_m
 
-__all__ = ['load_mat', 'save_mat']
+numpy.set_printoptions(linewidth=200, floatmode='unique')
 
-TWO_PI_ERROR = 1.E-4
+__all__ = ['matfile_generator', 'ringparam_filter', 'mfile_generator',
+           'load_mat', 'save_mat', 'load_m', 'save_m', 'load_var']
 
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
                      'FamName': 'name'}
+_param_ignore = {'PassMethod', 'Length'}
+
+# Python to Matlab attribute translation
+_matattr_map = dict(((v, k) for k, v in _param_to_lattice.items()))
 
 
-def _load_element(index, element_array, check=True, quiet=False):
-    """Load what scipy produces into a pyat element object.
+def matfile_generator(params, mat_file):
     """
-    kwargs = {}
-    for field_name in element_array.dtype.fields:
-        # Remove any surplus dimensions in arrays.
-        data = numpy.squeeze(element_array[field_name])
-        # Convert strings in arrays back to strings.
-        if data.dtype.type is numpy.unicode_:
-            data = str(data)
-        kwargs[field_name] = data
+    run through matlab cells and generate AT elements
 
-    return element_from_dict(kwargs, index=index, check=check, quiet=quiet)
-
-
-def _matlab_scanner(elems, **kwargs):
-    """Extract the lattice attributes from an element list
-
-    energy is taken from:
-        1) Radiative elements (Cavity, RingParam, Radiating magnets)
-        2) Any other element
-
-    periodicity is taken from:
-        1) RingParam element
-        2) Sum ofthe bending angles of magnets
-        3) 1
-
-    name is taken from
-        1) RingParam element
-        2) ""
-
-    All RingParam attributes are extracted
-    The function removes the Energy attribute of non-radiating elements
+    KEYWORDS
+        mat_file        name of the .mat file
+        mat_key         name of the Matlab variable containing the lattice.
+                        Default: Matlab variable name if there is only one,
+                        otherwise 'RING'
+        check=True      if False, skip the coherence tests
+        quiet=False     If True, suppress the warning for non-standard classes
     """
-    _ignore = {'energy', 'PassMethod', 'Length'}
+    m = scipy.io.loadmat(params.setdefault('mat_file', mat_file))
+    matvars = [varname for varname in m if not varname.startswith('__')]
+    default_key = matvars[0] if (len(matvars) == 1) else 'RING'
+    key = params.setdefault('mat_key', default_key)
+    check = params.pop('check', True)
+    quiet = params.pop('quiet', False)
+    cell_array = m[key].flat
+    for index, mat_elem in enumerate(cell_array):
+        element_array = mat_elem[0, 0]
+        kwargs = {}
+        for field_name in element_array.dtype.fields:
+            # Remove any surplus dimensions in arrays.
+            data = numpy.squeeze(element_array[field_name])
+            # Convert strings in arrays back to strings.
+            if data.dtype.type is numpy.unicode_:
+                data = str(data)
+            kwargs[field_name] = data
 
-    attributes = {}
-    params = []
-    rad_energies = []
-    el_energies = []
-    thetas = []
+        yield element_from_dict(kwargs, index=index, check=check, quiet=quiet)
 
+
+def ringparam_filter(params, elem_iterator, *args):
+    """"
+    Run through all elements, process and optionally removes RingParam elements
+
+    KEYWORDS
+        keep_all=False  if True, keep RingParam elem_iterator as Markers
+    """
+    keep_all = params.pop('keep_all', False)
+    ringparams = []
     radiate = False
-    for elem in elems:
-        if isinstance(elem, RingParam):
-            params.append(elem)
-        if (isinstance(elem, elements.RFCavity) or
-                elem.PassMethod.endswith('RadPass')):
-            rad_energies.append(elem.Energy)
-        elif hasattr(elem, 'Energy'):
-            el_energies.append(elem.Energy)
-            del elem.Energy
-        if isinstance(elem, elements.Dipole):
-            # noinspection PyUnresolvedReferences
-            thetas.append(elem.BendingAngle)
+    for elem in elem_iterator(params, *args):
         if (elem.PassMethod.endswith('RadPass') or
                 elem.PassMethod.endswith('CavityPass')):
             radiate = True
-
-    if params:
-        # At least one RingParam element, use the 1st one
-        if len(params) > 1:
-            warn(AtWarning(
-                'More than 1 RingParam element, the 1st one is used'))
-        attributes.update((_param_to_lattice.get(key, key.lower()), attr)
-                          for key, attr in vars(params[0]).items()
-                          if key not in _ignore)
-
-    attributes.update(kwargs)
-
-    if '_radiation' not in attributes:
-        attributes['_radiation'] = radiate
-
-    if 'energy' not in attributes:
-        # Guess energy from the Energy attribute of the elements
-        if rad_energies:
-            # Energy of radiating elements must be consistent
-            energy = max(rad_energies)
-            if min(rad_energies) < energy:
-                raise AtError('Inconsistent energy values,')
-        elif el_energies:
-            # Energy of other elements is informative only
-            energy = max(el_energies)
-            if min(el_energies) < energy:
-                warn(AtWarning('Inconsistent energy values, '
-                               '"energy" set to {0}'.format(energy)))
+        if isinstance(elem, RingParam):
+            ringparams.append(elem)
+            for k, v in elem.items():
+                if k not in _param_ignore:
+                    params.setdefault(_param_to_lattice.get(k, k.lower()), v)
+            if keep_all:
+                pars = vars(elem).copy()
+                name = pars.pop('FamName')
+                yield elements.Marker(name, **pars)
         else:
-            raise AtError('Lattice energy is not defined')
-        attributes['energy'] = energy
+            yield elem
+    params['_radiation'] = radiate
 
-    if 'name' not in attributes:
-        attributes['name'] = ''
-
-    if 'periodicity' not in attributes:
-        # Guess periodicity from the bending angles of the lattice
-        try:
-            nbp = 2.0 * numpy.pi / sum(thetas)
-        except ZeroDivisionError:
-            periodicity = 1
-            warn(AtWarning('No bending in the cell, set "Periodicity" to 1'))
-        else:
-            periodicity = int(round(nbp))
-            if abs(periodicity - nbp) > TWO_PI_ERROR:
-                warn(AtWarning('Non-integer number of cells: '
-                               '{0} -> {1}'.format(nbp, periodicity)))
-        attributes['periodicity'] = periodicity
-
-    return attributes
+    if len(ringparams) > 1:
+        warn(AtWarning('More than 1 RingParam element, the 1st one is used'))
 
 
-def load_mat(filename, key=None, check=True, quiet=False, keep_all=False,
-             **kwargs):
-    """Load a matlab at structure into a Python at list
+def load_mat(filename, **kwargs):
+    """Create a lattice object from a matmab mat-file
 
     PARAMETERS
         filename        name of a '.mat' file
-        key             name of the Matlab variable containing the lattice.
-                        Default: Matlab variable name if there is only one,
-                        otherwise 'RING'
 
     KEYWORDS
+        mat_key         name of the Matlab variable containing the lattice.
+                        Default: Matlab variable name if there is only one,
+                        otherwise 'RING'
         check=True      if False, skip the coherence tests
         quiet=False     If True, suppress the warning for non-standard classes
         keep_all=False  if True, keep RingParam elements as Markers
@@ -145,37 +108,119 @@ def load_mat(filename, key=None, check=True, quiet=False, keep_all=False,
                         (default: taken from the elements)
         periodicity     Number of periods
                         (default: taken from the elements, or 1)
+        *               all other keywords will be set as Lattice attributes
 
     OUTPUT
-        list    pyat ring
+        Lattice object
+    """
+    if 'key' in kwargs:  # process the deprecated 'key' keyword
+        kwargs.setdefault('mat_key', kwargs.pop('key'))
+    return Lattice(ringparam_filter, matfile_generator, abspath(filename),
+                   iterator=params_filter, **kwargs)
+
+
+def mfile_generator(params, m_file):
+    """Run through all lines of a m-file and generates AT elements"""
+    with open(params.setdefault('m_file', m_file), 'rt') as file:
+        _ = next(file)  # Matlab function definition
+        _ = next(file)  # Cell array opening
+        for lineno, line in enumerate(file):
+            if line.startswith('};'):
+                break
+            try:
+                elem = element_from_m(line)
+            except ValueError:
+                warn(AtWarning('Invalid line {0} skipped.'.format(lineno)))
+                continue
+            except KeyError:
+                warn(AtWarning('Line {0}: Unknown class'))
+                continue
+            else:
+                yield elem
+
+
+def load_m(filename, **kwargs):
+    """Create a lattice object from a matlab m-file
+
+    PARAMETERS
+        filename        name of a '.m' file
+
+    KEYWORDS
+        keep_all=False  if True, keep RingParam elements as Markers
+        name            Name of the lattice
+                        (default: taken from the elements, or '')
+        energy          Energy of the lattice
+                        (default: taken from the elements)
+        periodicity     Number of periods
+                        (default: taken from the elements, or 1)
+        *               all other keywords will be set as Lattice attributes
+
+    OUTPUT
+        Lattice object
+    """
+    return Lattice(ringparam_filter, mfile_generator, abspath(filename),
+                   iterator=params_filter, **kwargs)
+
+
+def load_var(matlat, **kwargs):
+    """Create a lattice from a Matlab cell array"""
+
+    # noinspection PyUnusedLocal
+    def var_generator(params, latt):
+        for elem in latt:
+            yield element_from_dict(elem)
+
+    return Lattice(ringparam_filter, var_generator, matlat,
+                   iterator=params_filter, **kwargs)
+
+
+def matlab_ring(ring):
+    """Prepend a RingParam element to a lattice"""
+    dct = dict((_matattr_map.get(k, k.title()), v)
+               for k, v in vars(ring).items() if not k.startswith('_'))
+    famname = dct.pop('FamName')
+    energy = dct.pop('Energy')
+    yield RingParam(famname, energy, **dct)
+    for elem in ring:
+        yield elem
+
+
+def save_mat(ring, filename, mat_key='RING'):
+    """Save a Lattice object as a Matlab mat-file
+
+    PARAMETERS
+        ring            Lattice object
+        filename        name of the '.mat' file
+
+    KEYWORDS
+        mat_key='RING'  Name of the Matlab variable representing the lattice
+    """
+    lring = tuple((element_to_dict(elem),) for elem in matlab_ring(ring))
+    scipy.io.savemat(filename, {mat_key: lring})
+
+
+def save_m(ring, filename=None):
+    """Save a lattice as a Matlab m-file
+
+    PARAMETERS
+        ring            Lattice object
+        filename=None   name of the '.m' file. Default: output on sys.stdout
     """
 
-    def substitute(elem):
-        if isinstance(elem, RingParam):
-            params = vars(elem).copy()
-            name = params.pop('FamName')
-            return elements.Marker(name, **params)
-        else:
-            return elem
+    def save(file):
+        print('function ring = {0}()'.format(ring.name), file=file)
+        print('ring = {...', file=file)
+        for elem in matlab_ring(ring):
+            print(element_to_m(elem), file=file)
+        print('};', file=file)
+        print('end', file=file)
 
-    m = scipy.io.loadmat(filename)
-    if key is None:
-        matvars = [varname for varname in m if not varname.startswith('__')]
-        key = matvars[0] if (len(matvars) == 1) else 'RING'
-
-    element_arrays = m[key].flat
-    elem_list = [_load_element(i, elem[0, 0], check=check, quiet=quiet) for
-                 (i, elem) in enumerate(element_arrays)]
-    attrs = _matlab_scanner(elem_list, **kwargs)
-    attrs.update(kwargs)
-    if keep_all:
-        elem_list = (substitute(elem) for elem in elem_list)
+    if filename is None:
+        save(sys.stdout)
     else:
-        elem_list = (elem for elem in elem_list
-                     if not isinstance(elem, RingParam))
-    return Lattice(elem_list, **attrs)
+        with open(filename, 'wt') as mfile:
+            save(mfile)
 
 
-def save_mat(filename, ring, key='ring'):
-    lring = tuple((el_dict,) for el_dict in lattice_to_matlab(ring))
-    scipy.io.savemat(filename, {key: lring})
+register_format('.mat', load_mat, save_mat, descr='Matlab binary mat-file')
+register_format('.m', load_m, save_m, descr='Matlab text m-file')

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -14,8 +14,8 @@ from at.load.utils import element_to_dict, element_to_m
 
 numpy.set_printoptions(linewidth=200, floatmode='unique')
 
-__all__ = ['matfile_generator', 'ringparam_filter', 'mfile_generator',
-           'load_mat', 'save_mat', 'load_m', 'save_m', 'load_var']
+__all__ = ['ringparam_filter', 'load_mat', 'save_mat', 'load_m', 'save_m',
+           'load_var']
 
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
                      'FamName': 'name'}

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+import sys
+from os.path import abspath
+import numpy
+from at.lattice import Lattice
+from at.load import register_format
+from at.load.utils import element_from_string
+
+__all__ = ['load_repr', 'save_repr']
+
+numpy.set_printoptions(linewidth=200, floatmode='unique')
+
+
+def load_repr(filename, **kwargs):
+    """Load a Lattice object stored as a repr-file
+
+    PARAMETERS
+        filename        name of the '.repr' file
+
+    KEYWORDS
+        name            Name of the lattice (default: taken from the file)
+        energy          Energy of the lattice (default: taken from the file)
+        periodicity     Number of periods (default: taken from the file)
+        *               all other keywords will be set as Lattice attributes
+
+    OUTPUT
+        Lattice object
+    """
+    def elem_iterator(params, repr_file):
+        with open(params.setdefault('repr_file', repr_file), 'rt') as file:
+            # the 1st line is the dictionary of saved lattice parameters
+            for k, v in eval(next(file)).items():
+                params.setdefault(k, v)
+            for line in file:
+                yield element_from_string(line.strip())
+
+    return Lattice(abspath(filename), iterator=elem_iterator, **kwargs)
+
+
+def save_repr(ring, filename=None):
+    """Save a Lattice object as a repr-file
+
+    PARAMETERS
+        ring            Lattice object
+        filename=None   name of the '.repr' file. Default: output on sys.stdout
+    """
+    def save(file):
+        print(repr(dict((k, v) for k, v in vars(ring).items()
+                        if not k.startswith('_'))), file=file)
+        for elem in ring:
+            print(repr(elem), file=file)
+
+    if filename is None:
+        save(sys.stdout)
+    else:
+        with open(filename, 'wt') as reprfile:
+            save(reprfile)
+
+
+register_format('.repr', load_repr, save_repr,
+                descr='Text representation of a python AT Lattice')

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -1,3 +1,6 @@
+"""Text representation of a python AT lattice with each element represented by
+its 'repr' string
+"""
 from __future__ import print_function
 import sys
 from os.path import abspath
@@ -7,8 +10,6 @@ from at.load import register_format
 from at.load.utils import element_from_string
 
 __all__ = ['load_repr', 'save_repr']
-
-numpy.set_printoptions(linewidth=200, floatmode='unique')
 
 
 def load_repr(filename, **kwargs):
@@ -50,11 +51,17 @@ def save_repr(ring, filename=None):
         for elem in ring:
             print(repr(elem), file=file)
 
+    # Save the current options
+    opts = numpy.get_printoptions()
+    # Set options to print the full representation of float variables
+    numpy.set_printoptions(linewidth=200, floatmode='unique')
     if filename is None:
         save(sys.stdout)
     else:
         with open(filename, 'wt') as reprfile:
             save(reprfile)
+    # Restore the current options
+    numpy.set_printoptions(**opts)
 
 
 register_format('.repr', load_repr, save_repr,

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -32,7 +32,6 @@ _alias_map = {'rbend': elt.Dipole,
               'rf': elt.RFCavity,
               'bpm': elt.Monitor,
               'ap': elt.Aperture,
-              'wig': elt.Wiggler,
               'ringparam': RingParam}
 
 
@@ -49,8 +48,7 @@ _PASS_MAP = {'DriftPass': elt.Drift,
              'CavityPass': elt.RFCavity, 'RFCavityPass': elt.RFCavity,
              'ThinMPolePass': elt.ThinMultipole,
              'Matrix66Pass': elt.M66,
-             'AperturePass': elt.Aperture,
-             'GWigSymplecticPass': elt.Wiggler}
+             'AperturePass': elt.Aperture}
 
 # Matlab to Python attribute translation
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -6,37 +6,38 @@ import numpy
 from warnings import warn
 from distutils import sysconfig
 from at import integrators
-from at.lattice import elements as elt
-from at.lattice.utils import AtWarning
+from at.lattice import AtWarning
+from at.lattice import CLASS_MAP, elements as elt
+# imports necessary in' globals()' for 'eval'
+# noinspection PyUnresolvedReferences
+from numpy import array, uint8  # For global namespace
 
 
 class RingParam(elt.Element):
     """Private class for Matlab RingParam element"""
-    REQUIRED_ATTRIBUTES = elt.Element.REQUIRED_ATTRIBUTES + ['Energy']
-    _conversions = dict(elt.Element._conversions, Energy=float,
-                        Periodicity=int)
+    REQUIRED_ATTRIBUTES = elt.Element.REQUIRED_ATTRIBUTES + ['Energy',
+                                                             'Periodicity']
+    _conversions = dict(elt.Element._conversions, Energy=float, Periodicity=int)
 
-    def __init__(self, family_name, energy, **kwargs):
-        kwargs.setdefault('Periodicity', 1)
+    def __init__(self, family_name, energy, periodicity=1, **kwargs):
+        kwargs.setdefault('Periodicity', periodicity)
         kwargs.setdefault('PassMethod', 'IdentityPass')
         super(RingParam, self).__init__(family_name, Energy=energy, **kwargs)
 
 
-# Matlab to Python class translation
-_CLASS_MAP = {'drift': elt.Drift,
-              'dipole': elt.Dipole, 'bend': elt.Dipole,
-              'quadrupole': elt.Quadrupole, 'quad': elt.Quadrupole,
-              'sextupole': elt.Sextupole, 'sext': elt.Sextupole,
-              'octupole': elt.Octupole,
-              'multipole': elt.Multipole,
-              'thinmultipole': elt.ThinMultipole,
-              'corrector': elt.Corrector,
-              'rfcavity': elt.RFCavity, 'rf': elt.RFCavity,
-              'monitor': elt.Monitor, 'bpm': elt.Monitor,
-              'marker': elt.Marker,
-              'm66': elt.M66,
-              'aperture': elt.Aperture, 'ap': elt.Aperture,
+_alias_map = {'rbend': elt.Dipole,
+              'sbend': elt.Dipole,
+              'quad': elt.Quadrupole,
+              'sext': elt.Sextupole,
+              'rf': elt.RFCavity,
+              'bpm': elt.Monitor,
+              'ap': elt.Aperture,
               'ringparam': RingParam}
+
+
+# Matlab to Python class translation
+_CLASS_MAP = dict((k.lower(), v) for k, v in CLASS_MAP.items())
+_CLASS_MAP.update(_alias_map)
 
 _PASS_MAP = {'DriftPass': elt.Drift,
              'BendLinearPass': elt.Dipole,
@@ -56,13 +57,14 @@ _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
 # Python to Matlab class translation
 _matclass_map = {'Dipole': 'Bend'}
 
-# Python to Matlab attribute translation
-_matattr_map = dict(((v, k) for k, v in _param_to_lattice.items()))
-
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr,
-                                                             dtype=float)}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr, dtype=float)}
+
+_class_to_matfunc = {
+    elt.Dipole: 'atsbend',
+    elt.Bend: 'atsbend',
+    elt.M66: 'atM66'}
 
 
 def hasattrs(kwargs, *attributes):
@@ -168,18 +170,8 @@ def find_class(elem_dict, quiet=False):
                     return elt.Marker
 
 
-def get_pass_method_file_name(pass_method):
-    extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
-    extension = set(filter(None, extension_list))
-    if len(extension) == 1:
-        return pass_method + extension.pop()
-    else:
-        return pass_method + '.so'
-
-
 def element_from_dict(elem_dict, index=None, check=True, quiet=False):
-    """return an AT element from a dictionary of attributes
-    """
+    """return an AT element from a dictionary of attributes"""
 
     # noinspection PyShadowingNames
     def sanitise_class(index, cls, elem_dict):
@@ -197,6 +189,13 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         Raises:
             AttributeError: if the PassMethod and Class are incompatible.
         """
+
+        def get_extension_name(method_name):
+            extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
+            extension = set(filter(None, extension_list))
+            ext = extension.pop() if len(extension) == 1 else '.so'
+            return method_name + ext
+
         def err(message, *args):
             location = ': ' if index is None else ' {0}: '.format(index)
             msg = ''.join(('Error in element', location,
@@ -209,7 +208,7 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         if pass_method is not None:
             pass_to_class = _PASS_MAP.get(pass_method)
             length = float(elem_dict.get('Length', 0.0))
-            file_name = get_pass_method_file_name(pass_method)
+            file_name = get_extension_name(pass_method)
             file_path = os.path.join(integrators.__path__[0], file_name)
             if not os.path.isfile(os.path.realpath(file_path)):
                 raise err("does not have a {0} file.".format(file_name))
@@ -234,7 +233,44 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
     return element
 
 
+def element_from_string(elem_string):
+    """Generate an AT-element from its repr string"""
+    return eval(elem_string, globals(), CLASS_MAP)
+
+
+def element_from_m(line):
+    """Generate a AT-element from a line in a m-file"""
+
+    def convert(argmt):
+        """convert Matlab syntax to numpy syntax"""
+
+        def setarray(arr):
+            lns = arr.split(';')
+            rr = [setarray(v) for v in lns] if len(lns) > 1 else lns[0].split()
+            return '[{0}]'.format(', '.join(rr))
+
+        if argmt.startswith('['):
+            return 'array({0})'.format(setarray(argmt[1:-1]))
+        else:
+            return argmt
+
+    left = line.index('(')
+    right = line.rindex(')')
+    cls = _CLASS_MAP[line[:left].strip()[2:]]
+    arguments = [a.strip() for a in line[left + 1:right].split(',')]
+    ll = len(cls.REQUIRED_ATTRIBUTES)
+    if ll < len(arguments) and arguments[ll].endswith("Pass'"):
+        arguments.insert(ll, "'PassMethod'")
+    keys = arguments[ll::2]
+    vals = arguments[ll + 1::2]
+    args = [convert(v) for v in arguments[:ll]]
+    keywords = ['='.join((k[1:-1], convert(v))) for k, v in zip(keys, vals)]
+    elem_string = '{0}({1})'.format(cls.__name__, ', '.join(args + keywords))
+    return element_from_string(elem_string)
+
+
 def element_to_dict(elem):
+    """Generate the Matlab structure for a AT element"""
     dct = dict((k, _mattype_map.get(type(v), lambda attr: attr)(v))
                for k, v in elem.items())
     class_name = elem.__class__.__name__
@@ -242,15 +278,33 @@ def element_to_dict(elem):
     return dct
 
 
-def lattice_to_matlab(ring):
-    dct = dict((_matattr_map.get(k, k.title()), v)
-               for k, v in vars(ring).items() if not k.startswith('_'))
-    famname = dct.pop('FamName')
-    energy = dct.pop('Energy')
-    prm = RingParam(famname, energy, **dct)
-    yield element_to_dict(prm)
-    for elem in ring:
-        yield element_to_dict(elem)
+def element_to_m(elem):
+    """Generate the Matlab-evaluable string for a AT element"""
+
+    def convert(arg):
+        if isinstance(arg, numpy.ndarray):
+            if arg.ndim > 1:
+                lns = (str(list(ln)).replace(',', '')[1:-1] for ln in arg)
+                return ''.join(('[', '; '.join(lns), ']'))
+            else:
+                return str(list(arg)).replace(',', '')
+        else:
+            return repr(arg)
+
+    def m_name(elclass):
+        stdname = ''.join(('at', elclass.__name__.lower()))
+        return _class_to_matfunc.get(elclass, stdname)
+
+    attrs = dict(elem.items())
+    args = [attrs.pop(k, getattr(elem, k)) for k in elem.REQUIRED_ATTRIBUTES]
+    defelem = elem.__class__(*args)
+    kwds = dict((k, v) for k, v in attrs.items()
+                if not numpy.array_equal(v, getattr(defelem, k, None)))
+    argstrs = [convert(arg) for arg in args]
+    if 'PassMethod' in kwds:
+        argstrs.append(convert(kwds.pop('PassMethod')))
+    argstrs += [', '.join((repr(k), convert(v))) for k, v in kwds.items()]
+    return '{0:>15}({1});...'.format(m_name(elem.__class__), ', '.join(argstrs))
 
 
 # Kept for compatibility but should be deprecated:

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -66,6 +66,11 @@ _class_to_matfunc = {
     elt.Bend: 'atsbend',
     elt.M66: 'atM66'}
 
+_class_to_matfunc = {
+    elt.Dipole: 'atsbend',
+    elt.Bend: 'atsbend',
+    elt.M66: 'atM66'}
+
 
 def hasattrs(kwargs, *attributes):
     """Check if the element would have the specified attribute(s), i.e. if they

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -32,6 +32,7 @@ _alias_map = {'rbend': elt.Dipole,
               'rf': elt.RFCavity,
               'bpm': elt.Monitor,
               'ap': elt.Aperture,
+              'wig': elt.Wiggler,
               'ringparam': RingParam}
 
 
@@ -48,7 +49,8 @@ _PASS_MAP = {'DriftPass': elt.Drift,
              'CavityPass': elt.RFCavity, 'RFCavityPass': elt.RFCavity,
              'ThinMPolePass': elt.ThinMultipole,
              'Matrix66Pass': elt.M66,
-             'AperturePass': elt.Aperture}
+             'AperturePass': elt.Aperture,
+             'GWigSymplecticPass': elt.Wiggler}
 
 # Matlab to Python attribute translation
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -59,12 +59,8 @@ _matclass_map = {'Dipole': 'Bend'}
 
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr, dtype=float)}
-
-_class_to_matfunc = {
-    elt.Dipole: 'atsbend',
-    elt.Bend: 'atsbend',
-    elt.M66: 'atM66'}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr,
+                                                             dtype=float)}
 
 _class_to_matfunc = {
     elt.Dipole: 'atsbend',
@@ -175,8 +171,16 @@ def find_class(elem_dict, quiet=False):
                     return elt.Marker
 
 
+def get_pass_method_file_name(pass_method):
+    extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
+    extension = set(filter(None, extension_list))
+    ext = extension.pop() if len(extension) == 1 else '.so'
+    return pass_method + ext
+
+
 def element_from_dict(elem_dict, index=None, check=True, quiet=False):
-    """return an AT element from a dictionary of attributes"""
+    """return an AT element from a dictionary of attributes
+    """
 
     # noinspection PyShadowingNames
     def sanitise_class(index, cls, elem_dict):
@@ -194,13 +198,6 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         Raises:
             AttributeError: if the PassMethod and Class are incompatible.
         """
-
-        def get_extension_name(method_name):
-            extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
-            extension = set(filter(None, extension_list))
-            ext = extension.pop() if len(extension) == 1 else '.so'
-            return method_name + ext
-
         def err(message, *args):
             location = ': ' if index is None else ' {0}: '.format(index)
             msg = ''.join(('Error in element', location,
@@ -213,7 +210,7 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         if pass_method is not None:
             pass_to_class = _PASS_MAP.get(pass_method)
             length = float(elem_dict.get('Length', 0.0))
-            file_name = get_extension_name(pass_method)
+            file_name = get_pass_method_file_name(pass_method)
             file_path = os.path.join(integrators.__path__[0], file_name)
             if not os.path.isfile(os.path.realpath(file_path)):
                 raise err("does not have a {0} file.".format(file_name))

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -32,7 +32,6 @@ _alias_map = {'rbend': elt.Dipole,
               'rf': elt.RFCavity,
               'bpm': elt.Monitor,
               'ap': elt.Aperture,
-              'wig': elt.Wiggler,
               'ringparam': RingParam}
 
 
@@ -49,8 +48,7 @@ _PASS_MAP = {'DriftPass': elt.Drift,
              'CavityPass': elt.RFCavity, 'RFCavityPass': elt.RFCavity,
              'ThinMPolePass': elt.ThinMultipole,
              'Matrix66Pass': elt.M66,
-             'AperturePass': elt.Aperture,
-             'GWigSymplecticPass': elt.Wiggler}
+             'AperturePass': elt.Aperture}
 
 # Matlab to Python attribute translation
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
@@ -61,8 +59,7 @@ _matclass_map = {'Dipole': 'Bend'}
 
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr,
-                                                             dtype=float)}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr, dtype=float)}
 
 _class_to_matfunc = {
     elt.Dipole: 'atsbend',
@@ -173,16 +170,8 @@ def find_class(elem_dict, quiet=False):
                     return elt.Marker
 
 
-def get_pass_method_file_name(pass_method):
-    extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
-    extension = set(filter(None, extension_list))
-    ext = extension.pop() if len(extension) == 1 else '.so'
-    return pass_method + ext
-
-
 def element_from_dict(elem_dict, index=None, check=True, quiet=False):
-    """return an AT element from a dictionary of attributes
-    """
+    """return an AT element from a dictionary of attributes"""
 
     # noinspection PyShadowingNames
     def sanitise_class(index, cls, elem_dict):
@@ -200,6 +189,13 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         Raises:
             AttributeError: if the PassMethod and Class are incompatible.
         """
+
+        def get_extension_name(method_name):
+            extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
+            extension = set(filter(None, extension_list))
+            ext = extension.pop() if len(extension) == 1 else '.so'
+            return method_name + ext
+
         def err(message, *args):
             location = ': ' if index is None else ' {0}: '.format(index)
             msg = ''.join(('Error in element', location,
@@ -212,7 +208,7 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         if pass_method is not None:
             pass_to_class = _PASS_MAP.get(pass_method)
             length = float(elem_dict.get('Length', 0.0))
-            file_name = get_pass_method_file_name(pass_method)
+            file_name = get_extension_name(pass_method)
             file_path = os.path.join(integrators.__path__[0], file_name)
             if not os.path.isfile(os.path.realpath(file_path)):
                 raise err("does not have a {0} file.".format(file_name))

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -61,7 +61,7 @@ def ohmi_envelope(ring, refpts=None, orbit=None, keep_lattice=False):
         emitXY              (2,) betatron emittance projected on xxp and yyp
         emitXYZ             (3,) 6x6 emittance projected on xxp, yyp, ldp
 
-        beamdata is a redord array with fields:
+        beamdata is a record array with fields:
         tunes               tunes of the 3 normal modes
         damping_rates       damping rates of the 3 normal modes
         mode_matrices       R-matrices of the 3 normal modes

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -1,52 +1,20 @@
-import os
 import glob
+from io import open
+import os
+from os.path import abspath, basename, dirname, exists, join, splitext
 import sys
 import shutil
+from setuptools import setup, Extension, find_packages
 try:
     import numpy
 except ImportError:
     print('\npyAT requires numpy. '
           'Please install numpy: "pip install numpy"\n')
     sys.exit()
-from io import open
-from setuptools import setup, Extension, find_packages
-from setuptools.command.build_ext import build_ext
 
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = abspath(dirname(__file__))
 macros = [('PYAT', None)]
-
-
-# Get the long description from the README file
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
-
-
-class CopyDuringBuild(build_ext):
-    """Only copy integrators and diffmatrix during build. This avoids filepath
-    issues during wheel building where a temporary copy of pyAT is made.
-    """
-    def run(self):
-        here = os.path.abspath(os.path.dirname(__file__))
-        integrator_src_orig = os.path.abspath(os.path.join(here, '../atintegrators'))
-        integrator_src = os.path.abspath(os.path.join(here, 'integrator-src'))
-        diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
-        # Copy files into pyat for distribution.
-        source_files = glob.glob(os.path.join(integrator_src_orig, '*.[ch]'))
-        source_files.extend(glob.glob(os.path.join(diffmatrix_source, 'findmpoleraddiffmatrix.c')))
-        if not os.path.exists(integrator_src):
-            os.makedirs(integrator_src)
-        for f in source_files:
-            shutil.copy2(f, integrator_src)
-        build_ext.run(self)
-
-
-at_source = os.path.abspath(os.path.join(here,'at.c'))
-integrator_src_orig = os.path.abspath(os.path.join(here, '../atintegrators'))
-integrator_src = os.path.abspath(os.path.join(here, 'integrator-src'))
-diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
-pass_methods = glob.glob(os.path.join(integrator_src, '*Pass.c'))
-diffmatrix_method = os.path.join(integrator_src, 'findmpoleraddiffmatrix.c')
 
 cflags = []
 
@@ -54,38 +22,78 @@ if not sys.platform.startswith('win32'):
     cflags += ['-Wno-unused-function']
 
 
-def integrator_extension(pass_method):
-    name, _ = os.path.splitext(os.path.basename(pass_method))
+# Get the long description from the README file
+with open(join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+# It is easier to copy the integrator files into a directory inside pyat
+# for packaging. However, we cannot always rely on this directory being
+# inside a clone of at and having the integrator sources available, and
+# this file is executed each time any setup.py command is run.
+# It appears that only copying the files when they are available is
+# sufficient.
+at_source = abspath(join(here,'at.c'))
+integrator_src_orig = abspath(join(here, '..', 'atintegrators'))
+integrator_src = abspath(join(here, 'integrator-src'))
+diffmatrix_source = abspath(
+    join(here, '..', 'atmat', 'atphysics', 'Radiation')
+)
+
+if exists(integrator_src_orig):
+    # Copy files into pyat for distribution.
+    source_files = glob.glob(join(integrator_src_orig, '*.[ch]'))
+    source_files.extend(
+        glob.glob(join(diffmatrix_source, 'findmpoleraddiffmatrix.c'))
+    )
+    if not exists(integrator_src):
+        os.makedirs(integrator_src)
+    for f in source_files:
+        shutil.copy2(f, integrator_src)
+
+pass_methods = glob.glob(join(integrator_src, '*Pass.c'))
+diffmatrix_method = join(integrator_src, 'findmpoleraddiffmatrix.c')
+
+
+def integrator_ext(pass_method):
+    name, _ = splitext(basename(pass_method))
     name = ".".join(('at', 'integrators', name))
-    return Extension(name=name,
-                     sources=[pass_method],
-                     include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-                     define_macros=macros,
-                     extra_compile_args=cflags)
+    return Extension(
+        name=name,
+        sources=[pass_method],
+        include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+        define_macros=macros,
+        extra_compile_args=cflags
+    )
 
 
-at = Extension('at.tracking.atpass',
-               sources=[at_source],
-               define_macros=macros,
-               include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-               extra_compile_args=cflags)
+at = Extension(
+    'at.tracking.atpass',
+    sources=[at_source],
+    define_macros=macros,
+    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    extra_compile_args=cflags
+)
 
-diffmatrix = Extension(name='at.physics.diffmatrix',
-                       sources=[diffmatrix_method],
-                       include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-                       define_macros=macros,
-                       extra_compile_args=cflags)
+diffmatrix = Extension(
+    name='at.physics.diffmatrix',
+    sources=[diffmatrix_method],
+    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    define_macros=macros,
+    extra_compile_args=cflags
+)
 
-setup(cmdclass={'build_ext': CopyDuringBuild},
-      name='accelerator-toolbox',
-      version='0.0.2',
-      description='Accelerator Toolbox',
-      long_description=long_description,
-      author='The AT collaboration',
-      author_email='atcollab-general@lists.sourceforge.net',
-      url='https://pypi.org/project/accelerator-toolbox/',
-      install_requires=['numpy>=1.10', 'scipy>=0.16'],
-      packages=find_packages(),
-      ext_modules=[at, diffmatrix] + [integrator_extension(pm) for pm in pass_methods],
-      zip_safe=False,
-      python_requires='>=2.7.4')
+setup(
+    name='accelerator-toolbox',
+    version='0.0.2',
+    description='Accelerator Toolbox',
+    long_description=long_description,
+    author='The AT collaboration',
+    author_email='atcollab-general@lists.sourceforge.net',
+    url='https://pypi.org/project/accelerator-toolbox/',
+    install_requires=['numpy>=1.10', 'scipy>=0.16'],
+    packages=find_packages(),
+    ext_modules=[at, diffmatrix] + [integrator_ext(pm) for pm in pass_methods],
+    zip_safe=False,
+    python_requires='>=2.7.4'
+)

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -62,8 +62,7 @@ def test_dipole():
     assert d.MaxOrder == 2
     assert len(d.PolynomA) == 3
     assert d.K == 0.0
-    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005],
-                        MaxOrder=0)
+    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005], MaxOrder=0)
     assert d.MaxOrder == 0
     assert len(d.PolynomA) == 3
     assert d.K == 0.0
@@ -82,8 +81,7 @@ def test_quadrupole():
     assert q.MaxOrder == 2
     assert len(q.PolynomA) == 3
     assert q.K == 0.0
-    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.5, 0.005],
-                            MaxOrder=1)
+    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.5, 0.005], MaxOrder=1)
     assert q.MaxOrder == 1
     assert len(q.PolynomA) == 3
     assert q.K == 0.5
@@ -106,8 +104,7 @@ def test_sextupole():
     assert s.MaxOrder == 3
     assert len(s.PolynomA) == 4
     assert s.H == 0.005
-    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.5, 0.005, 0.001],
-                           MaxOrder=2)
+    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.5, 0.005, 0.001], MaxOrder=2)
     assert s.MaxOrder == 2
     assert len(s.PolynomA) == 4
     assert s.H == 0.005
@@ -171,20 +168,21 @@ def test_insert_into_drift():
 
 
 def test_correct_dimensions_does_not_raise_error(rin):
-    atpass([], rin, 1)
+    l = []
+    atpass(l, rin, 1)
     rin = numpy.zeros((6,))
-    atpass([], rin, 1)
+    atpass(l, rin, 1)
     rin = numpy.array(numpy.zeros((6, 2), order='F'))
-    atpass([], rin, 1)
+    atpass(l, rin, 1)
 
 
 @pytest.mark.parametrize("dipole_class", (elements.Dipole, elements.Bend))
-def test_dipole_bend_synonym(rin, dipole_class):
+def test_dipole(rin, dipole_class):
     b = dipole_class('dipole', 1.0, 0.1, EntranceAngle=0.05, ExitAngle=0.05)
-    lat = [b]
+    l = [b]
     rin[0, 0] = 1e-6
     rin_orig = numpy.copy(rin)
-    atpass(lat, rin, 1)
+    atpass(l, rin, 1)
     rin_expected = numpy.array([1e-6, 0, 0, 0, 0, 1e-7]).reshape((6, 1))
     numpy.testing.assert_almost_equal(rin_orig, rin_expected)
     assert b.K == 0.0
@@ -254,8 +252,7 @@ def test_drift_divergence(rin):
     rin[3, 0] = -2e-6
     atpass(lattice, rin, 1)
     # results from Matlab
-    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0,
-                                2.5e-12]).reshape(6, 1)
+    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
     numpy.testing.assert_equal(rin, rin_expected)
 
 
@@ -274,8 +271,7 @@ def test_drift_two_particles(rin):
     atpass(lattice, two_rin, 1)
     # results from Matlab
     p1_expected = numpy.array(two_rin_orig[:, 0]).reshape(6, 1)
-    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0,
-                               2.5e-12]).reshape(6, 1)
+    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
     two_rin_expected = numpy.concatenate((p1_expected, p2_expected), axis=1)
     numpy.testing.assert_equal(two_rin, two_rin_expected)
 
@@ -319,8 +315,7 @@ def test_m66(rin, n):
 
 
 def test_corrector(rin):
-    c = elements.Corrector('corrector', 0.0, numpy.array([0.9, 0.5],
-                                                         dtype=numpy.float64))
+    c = elements.Corrector('corrector', 0.0, numpy.array([0.9, 0.5], dtype=numpy.float64))
     assert c.Length == 0
     lattice = [c]
     rin[0, 0] = 1e-6

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -62,7 +62,8 @@ def test_dipole():
     assert d.MaxOrder == 2
     assert len(d.PolynomA) == 3
     assert d.K == 0.0
-    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005], MaxOrder=0)
+    d = elements.Dipole('dipole', 1.0, 0.01, PolynomB=[0.0, 0.0, 0.005],
+                        MaxOrder=0)
     assert d.MaxOrder == 0
     assert len(d.PolynomA) == 3
     assert d.K == 0.0
@@ -81,7 +82,8 @@ def test_quadrupole():
     assert q.MaxOrder == 2
     assert len(q.PolynomA) == 3
     assert q.K == 0.0
-    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.5, 0.005], MaxOrder=1)
+    q = elements.Quadrupole('quadrupole', 1.0, PolynomB=[0.0, 0.5, 0.005],
+                            MaxOrder=1)
     assert q.MaxOrder == 1
     assert len(q.PolynomA) == 3
     assert q.K == 0.5
@@ -104,7 +106,8 @@ def test_sextupole():
     assert s.MaxOrder == 3
     assert len(s.PolynomA) == 4
     assert s.H == 0.005
-    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.5, 0.005, 0.001], MaxOrder=2)
+    s = elements.Sextupole('sextupole', 1.0, PolynomB=[0.0, 0.5, 0.005, 0.001],
+                           MaxOrder=2)
     assert s.MaxOrder == 2
     assert len(s.PolynomA) == 4
     assert s.H == 0.005
@@ -168,21 +171,20 @@ def test_insert_into_drift():
 
 
 def test_correct_dimensions_does_not_raise_error(rin):
-    l = []
-    atpass(l, rin, 1)
+    atpass([], rin, 1)
     rin = numpy.zeros((6,))
-    atpass(l, rin, 1)
+    atpass([], rin, 1)
     rin = numpy.array(numpy.zeros((6, 2), order='F'))
-    atpass(l, rin, 1)
+    atpass([], rin, 1)
 
 
 @pytest.mark.parametrize("dipole_class", (elements.Dipole, elements.Bend))
-def test_dipole(rin, dipole_class):
+def test_dipole_bend_synonym(rin, dipole_class):
     b = dipole_class('dipole', 1.0, 0.1, EntranceAngle=0.05, ExitAngle=0.05)
-    l = [b]
+    lat = [b]
     rin[0, 0] = 1e-6
     rin_orig = numpy.copy(rin)
-    atpass(l, rin, 1)
+    atpass(lat, rin, 1)
     rin_expected = numpy.array([1e-6, 0, 0, 0, 0, 1e-7]).reshape((6, 1))
     numpy.testing.assert_almost_equal(rin_orig, rin_expected)
     assert b.K == 0.0
@@ -252,7 +254,8 @@ def test_drift_divergence(rin):
     rin[3, 0] = -2e-6
     atpass(lattice, rin, 1)
     # results from Matlab
-    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
+    rin_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0,
+                                2.5e-12]).reshape(6, 1)
     numpy.testing.assert_equal(rin, rin_expected)
 
 
@@ -271,7 +274,8 @@ def test_drift_two_particles(rin):
     atpass(lattice, two_rin, 1)
     # results from Matlab
     p1_expected = numpy.array(two_rin_orig[:, 0]).reshape(6, 1)
-    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0, 2.5e-12]).reshape(6, 1)
+    p2_expected = numpy.array([1e-6, 1e-6, -2e-6, -2e-6, 0,
+                               2.5e-12]).reshape(6, 1)
     two_rin_expected = numpy.concatenate((p1_expected, p2_expected), axis=1)
     numpy.testing.assert_equal(two_rin, two_rin_expected)
 
@@ -315,7 +319,8 @@ def test_m66(rin, n):
 
 
 def test_corrector(rin):
-    c = elements.Corrector('corrector', 0.0, numpy.array([0.9, 0.5], dtype=numpy.float64))
+    c = elements.Corrector('corrector', 0.0, numpy.array([0.9, 0.5],
+                                                         dtype=numpy.float64))
     assert c.Length == 0
     lattice = [c]
     rin[0, 0] = 1e-6

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -1,11 +1,19 @@
 import at
 import numpy
 import pytest
-from at import AtError, AtWarning
-from at.lattice import elements
+from at import AtWarning
+from at.lattice import Lattice, elements, params_filter, no_filter
 from at.load.utils import find_class, element_from_dict
 from at.load.utils import _CLASS_MAP, _PASS_MAP, RingParam
-from at.load.matfile import _matlab_scanner
+from at.load import ringparam_filter
+
+
+def _matlab_scanner(element_list, **kwargs):
+    """This function simulates a mat-file reading but replaces the mat-file by
+    a list of elements"""
+    latt = Lattice(ringparam_filter, no_filter, element_list,
+                   iterator=params_filter, **kwargs)
+    return vars(latt)
 
 
 def test_lattice_gets_attributes_from_RingParam():
@@ -50,8 +58,9 @@ def test_inconsistent_energy_values_warns_correctly():
     with pytest.warns(AtWarning):
         params = _matlab_scanner([m1, m2])
         assert params['energy'] == 5.e+9
-    with pytest.raises(AtError):
+    with pytest.warns(AtWarning):
         params = _matlab_scanner([d1, d2])
+        assert params['energy'] == 5.e+9
 
 
 def test_more_than_one_RingParam_in_ring_raises_warning():

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -32,8 +32,10 @@ def test_find_orbit4_result_unchanged_by_atpass(dba_lattice):
 
 
 def test_find_orbit4_with_two_refpts_with_and_without_guess(dba_lattice):
-    expected = [[8.148212e-6, 1.0993354e-5, 0, 0, DP, 2.963929e-6],
-                [3.0422808e-8, 9.1635269e-8, 0, 0, DP, 5.9280346e-6]]
+    expected = numpy.array(
+        [[8.148212e-6, 1.0993354e-5, 0, 0, DP, 2.963929e-6],
+         [3.0422808e-8, 9.1635269e-8, 0, 0, DP, 5.9280346e-6]]
+    )
     _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99])
     numpy.testing.assert_allclose(all_points, expected, atol=1e-12)
     _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99],
@@ -64,12 +66,13 @@ def test_find_m44_returns_same_answer_as_matlab(dba_lattice, refpts):
 @pytest.mark.parametrize('refpts', ([145], [20], [1, 2, 3]))
 def test_find_m66(hmba_lattice, refpts):
     m66, mstack = physics.find_m66(hmba_lattice, refpts=refpts)
-    expected = [[-0.735654, 4.673766, 0., 0., 2.997161e-3, 0.],
-                [-9.816788e-2, -0.735654, 0., 0., 1.695263e-4, 0.],
-                [0., 0., 0.609804, -2.096051, 0., 0.],
-                [0., 0., 0.299679, 0.609799, 0., 0.],
-                [0., 0., 0., 0., 1., 0.],
-                [1.695128e-4, 2.997255e-3, 0., 0., 2.243281e-3, 1.]]
+    expected = numpy.array(
+        [[-0.735654, 4.673766, 0., 0., 2.997161e-3, 0.],
+         [-9.816788e-2, -0.735654, 0., 0., 1.695263e-4, 0.],
+         [0., 0., 0.609804, -2.096051, 0., 0.],
+         [0., 0., 0.299679, 0.609799, 0., 0.],
+         [0., 0., 0., 0., 1., 0.],
+         [1.695128e-4, 2.997255e-3, 0., 0., 2.243281e-3, 1.]])
     numpy.testing.assert_allclose(m66, expected, rtol=1e-5, atol=1e-7)
     stack_size = 0 if refpts is None else len(refpts)
     assert mstack.shape == (stack_size, 6, 6)
@@ -118,9 +121,11 @@ def test_find_orbit6_raises_AtError_if_there_is_no_cavity(dba_lattice):
 
 def test_find_m44_no_refpts(dba_lattice):
     m44 = physics.find_m44(dba_lattice, dp=DP)[0]
-    expected = [[-0.66380, 2.23415, 0., 0.], [-0.25037, -0.66380, 0., 0.],
-                [-1.45698e-31, -1.15008e-30, -0.99922, 0.26217],
-                [6.57748e-33, 8.75482e-32, -5.9497e-3, -0.99922]]
+    expected = numpy.array(
+        [[-0.66380, 2.23415, 0., 0.],
+         [-0.25037, -0.66380, 0., 0.],
+         [-1.45698e-31, -1.15008e-30, -0.99922, 0.26217],
+         [6.57748e-33, 8.75482e-32, -5.9497e-3, -0.99922]])
     numpy.testing.assert_allclose(m44, expected, rtol=1e-5, atol=1e-7)
 
 
@@ -234,7 +239,8 @@ def test_ohmi_envelope(hmba_lattice, refpts):
     numpy.testing.assert_almost_equal(beamdata['tunes'],
                                       [0.38156302, 0.85437641, 1.0906073e-4])
     numpy.testing.assert_almost_equal(beamdata['damping_rates'],
-                                      [1.004454e-5, 6.623816e-6, 9.653347e-6])
+                                      [1.0044543e-5, 6.6238162e-6,
+                                       9.6533473e-6])
     numpy.testing.assert_almost_equal(
         beamdata['mode_matrices'],
         [[[6.9000153, -2.6064253e-5, 1.643376e-25,

--- a/pyat/test_matlab/test_cmp_physics.py
+++ b/pyat/test_matlab/test_cmp_physics.py
@@ -134,7 +134,7 @@ def test_ohmi_envelope(engine, ml_lattice, py_lattice, refpts):
     refpts = range(nelems + 1) if refpts is None else refpts
 
     # Python call
-    py_lattice.radiation_on()
+    py_lattice = py_lattice.radiation_on(copy=True)
     py_emit0, py_beamdata, py_emit = py_lattice.ohmi_envelope(refpts)
     # Matlab call
     ml_emit = engine.pyproxy('atx', ml_lattice, 0.0, _ml_refs(refpts, nelems))
@@ -172,7 +172,6 @@ def test_parameters(engine, ml_lattice, py_lattice, dp):
     assert py_lattice.harmonic_number == int(ml_harms)
 
     # test momentum compaction factor
-    py_lattice.radiation_off()
     py_mcf = py_lattice.get_mcf(dp, ddp=1.E-6)  # Matlab uses ddp=1.E-6
     ml_mcf = engine.mcf(ml_lattice, dp)
     numpy.testing.assert_allclose(py_mcf, ml_mcf, rtol=1.E-8)


### PR DESCRIPTION
Load and save AT lattices in different formats:
- load and save binary .mat files
- load and save text .m files: format used by Matlab, each element is represented by the Matlab command which is used to create the element,
- load and save text .repr files: a new format, similar to .m, but each element is represented
by its python ‘repr’ string
- load from a Matlab cell array: can be used when run in python under Matlab to convert a Matlab lattice into a python lattice. 

In addition to the specific functions
`load_mat` / `save_mat`
`load_m` / `save_m`
`load_repr` / `save_repr`

there is a generic  Lattice method` ring.save(filepath)` which selects the format from the file extension and a corresponding static Lattice method `Lattice.load(filepath)`

Adding new formats should be easy.

This required a significant change in the Lattice constructor, to allow building lattices in a more flexible way. Here is an excerpt from the Lattice docstring:

```
Lattice(elems, **params)     Create a new lattice object

…
…

Custom iterators:
Instead of running through 'elems', the Lattice constructor can use one
or several custom iterators.

Lattice(*args, iterator=it, **params)

The iterator "it" is called as "it(params, *args)" and must return
a python iterator over AT elements for building the lattice. It must also
fill the "params" dictionary used to set the Lattice attributes.

        params is the dictionary of lattice parameters. It is initialised
               with the keywords of the lattice constructor. It can be
               modified by the custom iterator to add or remove parameters.
               Finally, all remaining parameters will be set as Lattice
               attributes.
        *args  all positional arguments of the Lattice constructor are sent
               to the custom iterator.

    An iterator can be:
        - a "generator" which yields elements from scratch.
          Examples: a list, or a file iterator,
        - a "filter" which runs through an input iterator, processes each
          element, possibly adds parameters to the params dictionary
          and yields the processed elements.

    Example of chaining iterators (taken from "load_mat"):

    Lattice(ringparam_filter, matfile_generator, filename,
            iterator=params_filter, **params)

    params_filter(params, ringparam_filter, *args)
        runs through ringparam_filter(params, *args), looks for energy and
        periodicity if not yet defined.

    ringparam_filter(params, matfile_generator, *args)
        runs through matfile_generator(params, *args), looks for RingParam
        elements, fills params with their information and discards them,

    matfile_generator(params, filename)
        opens filename and generates AT elements for each cell of the
        Matlab cell array representing the lattice,

```
Such iterators can be re-used, for instance `ringparam_filter` is used for both .m and .mat files.

As a side effect, there is also a new `copy` keyword in the method `radiation_on`. It defaults to `False`, but if set `True`, instead on modifying the lattice in-place, it returns a shallow copy of the lattice with radiation set on and leaves the lattice itself unchanged. This is convenient to keep both radiating and non-radiating versions of the lattice.