### PR TITLE
Simplify setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,6 @@ install:
   - venv\Scripts\activate
   - cd pyat
   - pip install --only-binary=numpy,scipy -r requirements.txt
-  - python setup.py build
 
 before_build:
   - python setup.py develop

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,8 +37,6 @@ build_script:
         if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
         python setup.py sdist --dist-dir=wheelhouse
         if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
-        python -m pip install twine
-        python -m twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*
       }
       else {
         python -m pip install pytest-cov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,6 +37,8 @@ build_script:
         if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
         python setup.py sdist --dist-dir=wheelhouse
         if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
+        python -m pip install twine
+        python -m twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*
       }
       else {
         python -m pip install pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install: |
   fi
   cd pyat
   pip install --only-binary=numpy,scipy -r requirements.txt
-  python setup.py build
 
 before_script:
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ install: |
   pip install --only-binary=numpy,scipy -r requirements.txt
 
 before_script:
+    # Use develop as we will be running the tests from the directory
+    # containing the at package.
   - python setup.py develop
 
 script: |

--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -5,7 +5,7 @@ pyAT is a Python interface to the pass methods defined in Accelerator Toolbox,
 implemented by compiling the C code used in the AT 'integrators' plus a Python
 extension.
 
-It supports Python 2.7 and 3.3 to 3.6.
+It supports Python 2.7 and 3.4 to 3.7.
 
 
 Installation preparation (Windows)
@@ -66,3 +66,29 @@ running the following, inside pyat, should fix it:
 
 N.B. setup.py develop needs to be run with the same version of Python (and
 numpy) that you are using to run pyAT.
+
+Releasing a version to PyPI
+---------------------------
+
+Because pyAT compiles C code, releasing a version is not simple. The code
+must be compiled for different operating systems and Python versions.
+
+To do this, we use the continuous integration services Travis CI (for Linux
+and Mac) and Appveyor (for Windows). When a tag of the form pyat-x.y.z is
+pushed to Github, wheels for each of the different platforms will be built
+and automatically uploaded to
+https://test.pypi.org/project/accelerator-toolbox/. Once there, someone
+should manually test that the wheels are working correctly, then they can
+manually download the files and upload them to PyPI itself.
+
+For Travis to be authenticated to Test PyPI, someone must set the variables
+TWINE_USERNAME and TWINE_PASSWORD in the Travis CI project settings. These
+are not public so it is possible to use personal details; it may be best
+not to use the same password for PyPI.
+
+A similar process is necessary for the Appveyor settings. You can click the
+little lock to keep the variable values private.
+
+Because there are complications putting special characters into these
+environment variables it may be simpler to ensure your Test PyPI password
+contains only alphanumeric characters.

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -1,5 +1,7 @@
-import os
 import glob
+from io import open
+import os
+from os.path import abspath, basename, dirname, exists, join, splitext
 import sys
 import shutil
 try:
@@ -8,37 +10,12 @@ except ImportError:
     print('\npyAT requires numpy. '
           'Please install numpy: "pip install numpy"\n')
     sys.exit()
-from io import open
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = abspath(dirname(__file__))
 macros = [('PYAT', None)]
-
-
-# Get the long description from the README file
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
-
-
-at_source = os.path.abspath(os.path.join(here,'at.c'))
-integrator_src_orig = os.path.abspath(os.path.join(here, '..', 'atintegrators'))
-integrator_src = os.path.abspath(os.path.join(here, 'integrator-src'))
-diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
-if os.path.exists(integrator_src_orig):
-    diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
-    # Copy files into pyat for distribution.
-    source_files = glob.glob(os.path.join(integrator_src_orig, '*.[ch]'))
-    source_files.extend(glob.glob(os.path.join(diffmatrix_source, 'findmpoleraddiffmatrix.c')))
-    if not os.path.exists(integrator_src):
-        os.makedirs(integrator_src)
-    for f in source_files:
-        shutil.copy2(f, integrator_src)
-
-
-pass_methods = glob.glob(os.path.join(integrator_src, '*Pass.c'))
-diffmatrix_method = os.path.join(integrator_src, 'findmpoleraddiffmatrix.c')
 
 cflags = []
 
@@ -46,27 +23,67 @@ if not sys.platform.startswith('win32'):
     cflags += ['-Wno-unused-function']
 
 
-def integrator_extension(pass_method):
-    name, _ = os.path.splitext(os.path.basename(pass_method))
+# Get the long description from the README file
+with open(join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+# It is easier to copy the integrator files into a directory inside pyat
+# for packaging. However, we cannot always rely on this directory being
+# inside a clone of at and having the integrator sources available, and
+# this file is executed each time any setup.py command is run.
+# It appears that only copying the files when they are available is
+# sufficient.
+at_source = abspath(join(here,'at.c'))
+integrator_src_orig = abspath(join(here, '..', 'atintegrators'))
+integrator_src = abspath(join(here, 'integrator-src'))
+diffmatrix_source = abspath(
+    join(here, '..', 'atmat', 'atphysics', 'Radiation')
+)
+
+if exists(integrator_src_orig):
+    diffmatrix_source = abspath(join(here, '../atmat/atphysics/Radiation'))
+    # Copy files into pyat for distribution.
+    source_files = glob.glob(join(integrator_src_orig, '*.[ch]'))
+    source_files.extend(
+        glob.glob(join(diffmatrix_source, 'findmpoleraddiffmatrix.c'))
+    )
+    if not exists(integrator_src):
+        os.makedirs(integrator_src)
+    for f in source_files:
+        shutil.copy2(f, integrator_src)
+
+pass_methods = glob.glob(join(integrator_src, '*Pass.c'))
+diffmatrix_method = join(integrator_src, 'findmpoleraddiffmatrix.c')
+
+
+def integrator_ext(pass_method):
+    name, _ = splitext(basename(pass_method))
     name = ".".join(('at', 'integrators', name))
-    return Extension(name=name,
-                     sources=[pass_method],
-                     include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-                     define_macros=macros,
-                     extra_compile_args=cflags)
+    return Extension(
+        name=name,
+        sources=[pass_method],
+        include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+        define_macros=macros,
+        extra_compile_args=cflags
+    )
 
 
-at = Extension('at.tracking.atpass',
-               sources=[at_source],
-               define_macros=macros,
-               include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-               extra_compile_args=cflags)
+at = Extension(
+    'at.tracking.atpass',
+    sources=[at_source],
+    define_macros=macros,
+    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    extra_compile_args=cflags
+)
 
-diffmatrix = Extension(name='at.physics.diffmatrix',
-                       sources=[diffmatrix_method],
-                       include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
-                       define_macros=macros,
-                       extra_compile_args=cflags)
+diffmatrix = Extension(
+    name='at.physics.diffmatrix',
+    sources=[diffmatrix_method],
+    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    define_macros=macros,
+    extra_compile_args=cflags
+)
 
 setup(
     name='accelerator-toolbox',
@@ -78,7 +95,7 @@ setup(
     url='https://pypi.org/project/accelerator-toolbox/',
     install_requires=['numpy>=1.10', 'scipy>=0.16'],
     packages=find_packages(),
-    ext_modules=[at, diffmatrix] + [integrator_extension(pm) for pm in pass_methods],
+    ext_modules=[at, diffmatrix] + [integrator_ext(pm) for pm in pass_methods],
     zip_safe=False,
     python_requires='>=2.7.4'
 )

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -4,14 +4,13 @@ import os
 from os.path import abspath, basename, dirname, exists, join, splitext
 import sys
 import shutil
+from setuptools import setup, Extension, find_packages
 try:
     import numpy
 except ImportError:
     print('\npyAT requires numpy. '
           'Please install numpy: "pip install numpy"\n')
     sys.exit()
-from setuptools import setup, Extension, find_packages
-from setuptools.command.build_ext import build_ext
 
 
 here = abspath(dirname(__file__))
@@ -42,7 +41,6 @@ diffmatrix_source = abspath(
 )
 
 if exists(integrator_src_orig):
-    diffmatrix_source = abspath(join(here, '../atmat/atphysics/Radiation'))
     # Copy files into pyat for distribution.
     source_files = glob.glob(join(integrator_src_orig, '*.[ch]'))
     source_files.extend(

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -22,29 +22,21 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-class CopyDuringBuild(build_ext):
-    """Only copy integrators and diffmatrix during build. This avoids filepath
-    issues during wheel building where a temporary copy of pyAT is made.
-    """
-    def run(self):
-        here = os.path.abspath(os.path.dirname(__file__))
-        integrator_src_orig = os.path.abspath(os.path.join(here, '../atintegrators'))
-        integrator_src = os.path.abspath(os.path.join(here, 'integrator-src'))
-        diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
-        # Copy files into pyat for distribution.
-        source_files = glob.glob(os.path.join(integrator_src_orig, '*.[ch]'))
-        source_files.extend(glob.glob(os.path.join(diffmatrix_source, 'findmpoleraddiffmatrix.c')))
-        if not os.path.exists(integrator_src):
-            os.makedirs(integrator_src)
-        for f in source_files:
-            shutil.copy2(f, integrator_src)
-        build_ext.run(self)
-
-
 at_source = os.path.abspath(os.path.join(here,'at.c'))
-integrator_src_orig = os.path.abspath(os.path.join(here, '../atintegrators'))
+integrator_src_orig = os.path.abspath(os.path.join(here, '..', 'atintegrators'))
 integrator_src = os.path.abspath(os.path.join(here, 'integrator-src'))
 diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
+if os.path.exists(integrator_src_orig):
+    diffmatrix_source = os.path.abspath(os.path.join(here, '../atmat/atphysics/Radiation'))
+    # Copy files into pyat for distribution.
+    source_files = glob.glob(os.path.join(integrator_src_orig, '*.[ch]'))
+    source_files.extend(glob.glob(os.path.join(diffmatrix_source, 'findmpoleraddiffmatrix.c')))
+    if not os.path.exists(integrator_src):
+        os.makedirs(integrator_src)
+    for f in source_files:
+        shutil.copy2(f, integrator_src)
+
+
 pass_methods = glob.glob(os.path.join(integrator_src, '*Pass.c'))
 diffmatrix_method = os.path.join(integrator_src, 'findmpoleraddiffmatrix.c')
 
@@ -76,16 +68,17 @@ diffmatrix = Extension(name='at.physics.diffmatrix',
                        define_macros=macros,
                        extra_compile_args=cflags)
 
-setup(cmdclass={'build_ext': CopyDuringBuild},
-      name='accelerator-toolbox',
-      version='0.0.2',
-      description='Accelerator Toolbox',
-      long_description=long_description,
-      author='The AT collaboration',
-      author_email='atcollab-general@lists.sourceforge.net',
-      url='https://pypi.org/project/accelerator-toolbox/',
-      install_requires=['numpy>=1.10', 'scipy>=0.16'],
-      packages=find_packages(),
-      ext_modules=[at, diffmatrix] + [integrator_extension(pm) for pm in pass_methods],
-      zip_safe=False,
-      python_requires='>=2.7.4')
+setup(
+    name='accelerator-toolbox',
+    version='0.0.2',
+    description='Accelerator Toolbox',
+    long_description=long_description,
+    author='The AT collaboration',
+    author_email='atcollab-general@lists.sourceforge.net',
+    url='https://pypi.org/project/accelerator-toolbox/',
+    install_requires=['numpy>=1.10', 'scipy>=0.16'],
+    packages=find_packages(),
+    ext_modules=[at, diffmatrix] + [integrator_extension(pm) for pm in pass_methods],
+    zip_safe=False,
+    python_requires='>=2.7.4'
+)


### PR DESCRIPTION
@lfarv @swhite2401 @T-Nicholls I believe these changes should improve `setup.py`.

In my testing this should work with both `python setup.py install` and `python setup.py develop` with no preceding build step, and it successfully builds the wheels on Travis as before.