### PR TITLE
Support only numpy 1.14.3 and newer.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,8 @@
 image: Visual Studio 2015
 platform: x64
 environment:
-  CIBW_BEFORE_BUILD: "pip install numpy"
+  # Build against the oldest supported version of numpy.
+  CIBW_BEFORE_BUILD: "python -m pip install numpy==1.14.3"
   matrix:
    - PYTHON: 27
    - PYTHON: 34

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ dist: xenial
 language: python
 env:
   global:
-    - CIBW_BEFORE_BUILD='pip install numpy'
+    # Build against the oldest supported version of numpy.
+    - CIBW_BEFORE_BUILD='python -m pip install numpy==1.14.3'
 matrix:
   include:
     - os: linux

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -85,13 +85,14 @@ diffmatrix = Extension(
 
 setup(
     name='accelerator-toolbox',
-    version='0.0.2',
+    version='0.0.3',
     description='Accelerator Toolbox',
     long_description=long_description,
     author='The AT collaboration',
     author_email='atcollab-general@lists.sourceforge.net',
     url='https://pypi.org/project/accelerator-toolbox/',
-    install_requires=['numpy>=1.10', 'scipy>=0.16'],
+    # Numpy 1.14.3 is the oldest version that builds with Python 3.7.
+    install_requires=['numpy>=1.14.3', 'scipy>=0.16'],
     packages=find_packages(),
     ext_modules=[at, diffmatrix] + [integrator_ext(pm) for pm in pass_methods],
     zip_safe=False,


### PR DESCRIPTION
1.14.3 is the latest version that builds for python 3.7. Although
setup.py previously claimed that 1.10.1 was supported this wasn't
actually true and trying to use older versions would fail.

See also #127 and #128.