### PR TITLE
bug correction on IdTablePass

### DIFF
--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -107,6 +107,10 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         double *R1, *R2, *T1, *T2;
         Length=atGetDouble(ElemData,"Length"); check_error();
         xkick=atGetDoubleArraySz(ElemData,"xkick", &ny_map, &nx_map); check_error();
+        /* the third input of atGetDoubleArraySz is a pointer for the 
+         * number of rows in the 2-D array, the fourth input is a pointer 
+         * for the number of columns
+         */
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
         x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
         y_map=atGetDoubleArray(ElemData,"ytable"); check_error();
@@ -156,6 +160,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double *R1, *R2, *T1, *T2;
         Length=atGetDouble(ElemData,"Length"); check_error();
         xkick=atGetDoubleArraySz(ElemData,"xkick", &ny_map, &nx_map); check_error();
+        /* the third input of atGetDoubleArraySz is a pointer for the 
+         * number of rows in the 2-D array, the fourth input is a pointer 
+         * for the number of columns
+         */
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
         x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
         y_map=atGetDoubleArray(ElemData,"ytable"); check_error();

--- a/atintegrators/IdTablePass.c
+++ b/atintegrators/IdTablePass.c
@@ -106,7 +106,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         double *xkick1, *ykick1;
         double *R1, *R2, *T1, *T2;
         Length=atGetDouble(ElemData,"Length"); check_error();
-        xkick=atGetDoubleArraySz(ElemData,"xkick", &nx_map, &ny_map); check_error();
+        xkick=atGetDoubleArraySz(ElemData,"xkick", &ny_map, &nx_map); check_error();
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
         x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
         y_map=atGetDoubleArray(ElemData,"ytable"); check_error();
@@ -155,7 +155,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double *xkick1, *ykick1;
         double *R1, *R2, *T1, *T2;
         Length=atGetDouble(ElemData,"Length"); check_error();
-        xkick=atGetDoubleArraySz(ElemData,"xkick", &nx_map, &ny_map); check_error();
+        xkick=atGetDoubleArraySz(ElemData,"xkick", &ny_map, &nx_map); check_error();
         ykick=atGetDoubleArray(ElemData,"ykick"); check_error();
         x_map=atGetDoubleArray(ElemData,"xtable"); check_error();
         y_map=atGetDoubleArray(ElemData,"ytable"); check_error();

--- a/atintegrators/atelem.c
+++ b/atintegrators/atelem.c
@@ -72,8 +72,8 @@ static double* atGetDoubleArraySz(const mxArray *ElemData, const char *fieldname
 {
     mxArray *field=mxGetField(ElemData,0,fieldname);
     if (!field) mexErrMsgIdAndTxt("AT:WrongArg", "The required attribute %s is missing.", fieldname);
-    *msz = mxGetM(field);
-    *nsz = mxGetN(field);
+    *msz = mxGetM(field);  /*Number of rows in the 2-D array*/
+    *nsz = mxGetN(field);  /*Number of columns in the 2-D array.*/
     return mxGetDoubles(field);
 }
 


### PR DESCRIPTION
This should solve issue #133 from @ZeusMarti for Matlab AT.
`atGetDoubleArraySz` wants the pointer to the vertical size of the array as third input and the pointer to the horizontal size as fourth input. Third and fourth inputs were inverted.

Does `atGetDoubleArraySz` for pyat do the same thing? Is third input vertical and fourth horizontal?