### PR TITLE
Fix behaviour of lattice_pass for non-F_CONTIGUOUS input

### DIFF
--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -23,28 +23,30 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
 
     PARAMETERS
         lattice:    iterable of AT elements
-        r_in:       6xN array: input coordinates of N particles
+        r_in:       (6, N) array: input coordinates of N particles.
+                    r_in is modified in-place and reports the coordinates at
+                    the end of the tracking. For the the best efficiency, r_in
+                    should be given as F_CONTIGUOUS numpy array.
         nturns:     number of passes through the lattice line
-        refpts          elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-                        Defaults to None, meaning no refpts, equivelent to
-                        passing an empty array for calculation purposes.
+        refpts      elements at which data is returned. It can be:
+                    1) an integer in the range [-len(ring), len(ring)-1]
+                       selecting the element according to python indexing
+                       rules. As a special case, len(ring) is allowed and
+                       refers to the end of the last element,
+                    2) an ordered list of such integers without duplicates,
+                    3) a numpy array of booleans of maximum length
+                       len(ring)+1, where selected elements are True.
+                    Defaults to None, meaning no refpts, equivelent to
+                    passing an empty array for calculation purposes.
         keep_lattice: use elements persisted from a previous call to at.atpass.
                     If True, assume that the lattice has not changed since
                     that previous call.
 
     OUTPUT
-        (6, A, B, C) array containing output coordinates of A particles
-        at B selected indices for C turns.
+        (6, N, R, T) array containing output coordinates of N particles
+        at R reference points for T turns.
     """
     assert r_in.shape[0] == 6 and r_in.ndim in (1, 2), DIMENSION_ERROR
-    r_in = numpy.asfortranarray(r_in)
     if not isinstance(lattice, list):
         lattice = list(lattice)
     nelems = len(lattice)
@@ -55,7 +57,13 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False):
     # * A is number of particles;
     # * B is number of refpts
     # * C is the number of turns
-    return atpass(lattice, r_in, nturns, refs, int(keep_lattice))
+    if r_in.flags.f_contiguous:
+        return atpass(lattice, r_in, nturns, refs, int(keep_lattice))
+    else:
+        r_fin = numpy.asfortranarray(r_in)
+        r_out = atpass(lattice, r_fin, nturns, refs, int(keep_lattice))
+        r_in[:] = r_fin[:]
+        return r_out
 
 
 def element_pass(element, r_in):


### PR DESCRIPTION
For multi-particule input and C-ordered input array,  the `lattice_pass` tracking was correct, but the value of `r_in` was not reflecting the coordinates at the end of the tracking, but still at the beginning.
When using multi-particle C-ordered input arrays (Python default), `lattice_pass` must make a copy at both input and output of the tracking. To mitigate this efficiency reduction, there are 3 possibilities:

1. Implementing transparently both copies (up to now, only the copy at input was done). This is the present solution in this pull request,
2. Implementing both copies with a warning on efficiency-loss when using non-F_CONTIGUOUS input,
3. enforcing the use of F_CONTIGUOUS input.

What is your preferred solution ?