### PR TITLE
Fix phase advance computation in twissring.m

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/twissring.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/twissring.m
@@ -83,8 +83,8 @@ BY = squeeze((MS(3,3,:)*by-MS(3,4,:)*ay).^2 + MS(3,4,:).^2)/by;
 AX = -squeeze((MS(1,1,:)*bx-MS(1,2,:)*ax).*(MS(2,1,:)*bx-MS(2,2,:)*ax) + MS(1,2,:).*MS(2,2,:))/bx;
 AY = -squeeze((MS(3,3,:)*by-MS(3,4,:)*ay).*(MS(4,3,:)*by-MS(4,4,:)*ay) + MS(3,4,:).*MS(4,4,:))/by;
 
-MX = atan(squeeze( MS(1,2,:)./(MS(1,1,:)*bx-MS(1,2,:)*ax)));
-MY = atan(squeeze(MS(3,4,:)./(MS(3,3,:)*by-MS(3,4,:)*ay)));
+MX = atan2(squeeze(MS(1,2,:),(MS(1,1,:)*bx-MS(1,2,:)*ax)));
+MY = atan2(squeeze(MS(3,4,:),(MS(3,3,:)*by-MS(3,4,:)*ay)));
 
 MX = BetatronPhaseUnwrap(MX);
 MY = BetatronPhaseUnwrap(MY);

--- a/atmat/atphysics/ParameterSummaryFunctions/twissring.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/twissring.m
@@ -83,8 +83,8 @@ BY = squeeze((MS(3,3,:)*by-MS(3,4,:)*ay).^2 + MS(3,4,:).^2)/by;
 AX = -squeeze((MS(1,1,:)*bx-MS(1,2,:)*ax).*(MS(2,1,:)*bx-MS(2,2,:)*ax) + MS(1,2,:).*MS(2,2,:))/bx;
 AY = -squeeze((MS(3,3,:)*by-MS(3,4,:)*ay).*(MS(4,3,:)*by-MS(4,4,:)*ay) + MS(3,4,:).*MS(4,4,:))/by;
 
-MX = atan2(squeeze(MS(1,2,:),(MS(1,1,:)*bx-MS(1,2,:)*ax)));
-MY = atan2(squeeze(MS(3,4,:),(MS(3,3,:)*by-MS(3,4,:)*ay)));
+MX = atan2(squeeze(MS(1,2,:)), squeeze(MS(1,1,:)*bx-MS(1,2,:)*ax));
+MY = atan2(squeeze(MS(3,4,:)), squeeze(MS(3,3,:)*by-MS(3,4,:)*ay));
 
 MX = BetatronPhaseUnwrap(MX);
 MY = BetatronPhaseUnwrap(MY);


### PR DESCRIPTION
Correction of the bug in the phase advance computation in `twissring` reported by @lnadolski. We now use `atan2` instead of `atan` so that unwrapping with 2*pi is correct. 