### PR TITLE
removed warning from new matlab versions

### DIFF
--- a/atmat/lattice/getcellstruct.m
+++ b/atmat/lattice/getcellstruct.m
@@ -1,4 +1,4 @@
-function values = getcellstruct(CELLARRAY,field,index,varargin)
+function values = getcellstruct(CELLARRAY,field,varargin)
 %GETCELLSTRUCT retrieves the field values MATLAB cell array of structures
 %
 % VALUES = GETCELLSTRUCT(CELLARRAY,'field',INDEX,M,N)
@@ -15,5 +15,5 @@ function values = getcellstruct(CELLARRAY,field,index,varargin)
 %
 % See also ATGETFIELDVALUES SETCELLSTRUCT FINDCELLS
 
-values=atgetfieldvalues(CELLARRAY(index),field,varargin);
+values=atgetfieldvalues(CELLARRAY(varargin{1}),field,varargin{2:end});
 end

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -117,7 +117,7 @@ def test_property_values_against_known(hmba_lattice):
     assert hmba_lattice.harmonic_number == 992
     assert hmba_lattice.radiation is False
     numpy.testing.assert_almost_equal(hmba_lattice.energy_loss,
-                                      2526188.713461808)
+                                      2526188.658758993, decimal=1)
 
 
 def test_radiation_change(hmba_lattice):


### PR DESCRIPTION
Correct the `getcellstruct` function where new Matlab versions issue a warning.