### PR TITLE
Appveyor: drop Python 3.4 and add Python 3.8.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,10 +11,10 @@ environment:
   CIBW_BEFORE_BUILD: "python -m pip install numpy==1.14.3"
   matrix:
    - PYTHON: 27
-   - PYTHON: 34
    - PYTHON: 35
    - PYTHON: 36
    - PYTHON: 37
+   - PYTHON: 38
 
 install:
   - set "PATH=C:\Python%PYTHON%-x64;C:\Python%PYTHON%-x64\Scripts;%PATH%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       python: 3.6
     - os: linux
       python: 3.7
+    - os: linux
+      python: 3.8
     - os: osx
       language: generic
       env: PYTHON=2

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -45,7 +45,7 @@ def check_radiation(rad):
         @functools.wraps(func)
         def wrapper(ring, *args, **kwargs):
             ringrad = getattr(ring, 'radiation', rad)
-            if ringrad is not rad:
+            if ringrad != rad:
                 raise AtError('{0} needs radiation {1}'.format(
                     func.__name__, 'ON' if rad else 'OFF'))
             return func(ring, *args, **kwargs)
@@ -59,7 +59,7 @@ def uint32_refpts(refpts, n_elements):
     elements.  This is used for indexing a lattice using explicit indices.
     """
     refs = numpy.asarray(refpts).reshape(-1)
-    if (refpts is None) or (refs.size is 0):
+    if (refpts is None) or (refs.size == 0):
         return numpy.array([], dtype=numpy.uint32)
     elif refs.size > n_elements+1:
         raise ValueError('too many reftps given')
@@ -92,7 +92,7 @@ def bool_refpts(refpts, n_elements):
     """
     if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
         diff = 1 + n_elements - refpts.size
-        if diff is 0:
+        if diff == 0:
             return refpts
         elif diff > 0:
             return numpy.append(refpts, numpy.zeros(diff, dtype=bool))

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -113,7 +113,7 @@ def find_class(elem_dict, quiet=False):
     try:
         return _CLASS_MAP[class_name.lower()]
     except KeyError:
-        if (quiet is False) and (class_name != ''):
+        if (quiet == False) and (class_name != ''):
             warn(AtWarning("Class '{0}' does not exist.\n"
                            "{1}".format(class_name, elem_dict)))
         fam_name = elem_dict.get('FamName', '')
@@ -121,10 +121,10 @@ def find_class(elem_dict, quiet=False):
             return _CLASS_MAP[fam_name.lower()]
         except KeyError:
             pass_method = elem_dict.get('PassMethod', '')
-            if (quiet is False) and (pass_method is ''):
+            if (quiet == False) and (pass_method == ''):
                 warn(AtWarning("No PassMethod provided."
                                "\n{0}".format(elem_dict)))
-            elif (quiet is False) and (not pass_method.endswith('Pass')):
+            elif (quiet == False) and (not pass_method.endswith('Pass')):
                 warn(AtWarning("Invalid PassMethod ({0}), provided pass "
                                "methods should end in 'Pass'."
                                "\n{1}".format(pass_method, elem_dict)))

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -81,7 +81,7 @@ def test_find_m66(hmba_lattice, refpts):
 @pytest.mark.parametrize('index', (19, 0, 1))
 def test_find_elem_m66(hmba_lattice, index):
     m66 = physics.find_elem_m66(hmba_lattice[index])
-    if index is 19:
+    if index == 19:
         expected = numpy.array([[1.0386, 0.180911, 0., 0., 0., 0.],
                                 [0.434959, 1.0386, 0., 0., 0., 0.],
                                 [0., 0., 0.961891, 0.176344, 0., 0.],
@@ -150,7 +150,7 @@ def test_get_twiss_no_refpts(dba_lattice):
     twiss0, tune, chrom, twiss = physics.get_twiss(dba_lattice, DP,
                                                    get_chrom=True)
     assert list(twiss) == []
-    assert len(physics.get_twiss(dba_lattice, DP, get_chrom=True)) is 4
+    assert len(physics.get_twiss(dba_lattice, DP, get_chrom=True)) == 4
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
@@ -229,7 +229,7 @@ def test_linopt_no_refpts(dba_lattice):
     lindata0, tune, chrom, lindata = physics.linopt(dba_lattice, DP,
                                                     get_chrom=True)
     assert list(lindata) == []
-    assert len(physics.linopt(dba_lattice, DP, get_chrom=True)) is 4
+    assert len(physics.linopt(dba_lattice, DP, get_chrom=True)) == 4
 
 
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))


### PR DESCRIPTION
Python 3.4 is at end of life so we don't need to worry too much about
supporting it any more. Support is no longer working correctly on
Appveyor.