### PR TITLE
fix a getcellstruct bug

### DIFF
--- a/atmat/lattice/getcellstruct.m
+++ b/atmat/lattice/getcellstruct.m
@@ -15,5 +15,5 @@ function values = getcellstruct(CELLARRAY,field,varargin)
 %
 % See also ATGETFIELDVALUES SETCELLSTRUCT FINDCELLS
 
-values=atgetfieldvalues(CELLARRAY(varargin{1}),field,varargin{2:end});
+values=atgetfieldvalues(CELLARRAY(varargin{1}),field,varargin(2:end));
 end


### PR DESCRIPTION
A bug was introduced when trying to remove a warning issued by recent Matlab versions