### PR TITLE
get_chrom convenience functions

### DIFF
--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -21,3 +21,4 @@ from .ring_parameters import *
 from .diffmatrix import find_mpole_raddiff_matrix
 from .radiation import *
 from .harmonic_analysis import *
+from .nonlinear import *

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -221,8 +221,10 @@ def get_spectrum_harmonic(cent, num_harmonics=20, method='laskar', hann=False):
 def get_tunes_harmonic(cents, method,
                        num_harmonics=20,
                        hann=False,
-                       fmin=0,
-                       fmax=1):
+                       fmin_x=0,
+                       fmax_x=1,
+                       fmin_y=0,
+                       fmax_y=1):
     """
     INPUT
     cents: are the centroid motions of the particles
@@ -252,11 +254,13 @@ def get_tunes_harmonic(cents, method,
         npart = 1
     tunes = np.zeros(npart)
 
+    frg = [[fmin_x, fmax_x],[fmin_y, fmax_y]]
     for i in range(npart):
         freq, amp = get_spectrum_harmonic(cents[i],
                                           num_harmonics=num_harmonics,
                                           method=method,
                                           hann=hann)
+        fmin, fmax = frg[i]
         tunes[i] = get_max_spectrum(freq, amp, fmin, fmax)
 
     return tunes

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -221,10 +221,8 @@ def get_spectrum_harmonic(cent, num_harmonics=20, method='laskar', hann=False):
 def get_tunes_harmonic(cents, method,
                        num_harmonics=20,
                        hann=False,
-                       fmin_x=0,
-                       fmax_x=1,
-                       fmin_y=0,
-                       fmax_y=1):
+                       fmin=0,
+                       fmax=1):
     """
     INPUT
     cents: are the centroid motions of the particles
@@ -254,13 +252,11 @@ def get_tunes_harmonic(cents, method,
         npart = 1
     tunes = np.zeros(npart)
 
-    frg = [[fmin_x, fmax_x],[fmin_y, fmax_y]]
     for i in range(npart):
         freq, amp = get_spectrum_harmonic(cents[i],
                                           num_harmonics=num_harmonics,
                                           method=method,
                                           hann=hann)
-        fmin, fmax = frg[i]
         tunes[i] = get_max_spectrum(freq, amp, fmin, fmax)
 
     return tunes

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -535,6 +535,7 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
 
     def gen_centroid(ring, ampl, nturns, dp, remove_dc):
         orbit, _ = find_orbit4(ring, dp)
+        ld, _, _, _ = linopt(ring, dp)
         p0 = numpy.array([orbit, ]*2).T
         p0[0, 0] += ampl
         p0[2, 1] += ampl
@@ -548,7 +549,8 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
             cent_y -= numpy.mean(cent_y)
             cent_xp -= numpy.mean(cent_xp)
             cent_yp -= numpy.mean(cent_yp)
-        return cent_x - 1j*cent_xp, cent_y - 1j*cent_yp
+        return (cent_x - 1j * ld['beta'][0] * cent_xp,
+                cent_y - 1j * ld['beta'][1] * cent_yp)
 
     if method == 'linopt':
         _, tunes, _, _ = linopt(ring, dp=dp)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -563,7 +563,7 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
 
 
 @check_radiation(False)
-def get_chrom(ring, method='linopt', **kwargs):
+def get_chrom(ring, method='linopt', dp=0, **kwargs):
     """
     gets the chromaticty using several available methods
 
@@ -584,8 +584,6 @@ def get_chrom(ring, method='linopt', **kwargs):
         print('Warning fft method not accurate to get the '+ 
               'chromaticity')
 
-
-    dp = kwargs.pop('dp', 0)
     ddp = kwargs.pop('ddp', DDP)
     tune_up = get_tune(ring, method=method, dp=dp + 0.5 * ddp, **kwargs)
     tune_down = get_tune(ring, method=method, dp=dp - 0.5 * ddp, **kwargs)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -525,7 +525,7 @@ def get_tune(ring, method='linopt', **kwargs):
         fmin/fmax: determine the boundaries within which the tune is
         located [default 0->1]
         hann: flag to turn on hanning window [default-> False]
-
+        remove_dc: Removes the mean offset of oscillation data
 
     OUTPUT
         tunes = np.array([Qx,Qy])
@@ -555,6 +555,7 @@ def get_tune(ring, method='linopt', **kwargs):
         fmax_y = kwargs.pop('fmax_y', 1)
         nturns = kwargs.pop('nturns', None)
         ampl = kwargs.pop('ampl', None)
+        remove_dc = kwargs.pop('remove_dc', False)
         try:
             assert nturns is not None
             assert ampl is not None
@@ -562,6 +563,11 @@ def get_tune(ring, method='linopt', **kwargs):
             raise ValueError('The number of turns and amplitude '
                              'have to be defined for ' + method)
         cent_x, cent_y = gen_centroid(ring, ampl, nturns, dp)
+
+        if remove_dc:
+            cent_x -= numpy.mean(cent_x)
+            cent_y -= numpy.mean(cent_y)
+
         cents = numpy.vstack((cent_x, cent_y))
         tunes = get_tunes_harmonic(cents, method,
                                    num_harmonics=num_harmonics,
@@ -601,7 +607,8 @@ def get_chrom(ring, method='linopt', **kwargs):
         fmax_y = kwargs.pop('fmax_y', 1)
         nturns = kwargs.pop('nturns', None)
         ampl = kwargs.pop('ampl', None)
-        
+        remove_dc = kwargs.pop('remove_dc', False)
+
     dp = kwargs.pop('dp', DDP)
     if method == 'linopt':
         _, _, xsi, _ = linopt(ring, dp=dp, get_chrom=True)
@@ -614,7 +621,8 @@ def get_chrom(ring, method='linopt', **kwargs):
             if tune_method == 'linopt':
                 qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp)
             else:
-                qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl)
+                qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl,
+remove_dc=remove_dc)
 
         fit_x = numpy.polyfit(dp_range, qxs, 1)[::-1]
         fit_y = numpy.polyfit(dp_range, qys, 1)[::-1]
@@ -652,6 +660,7 @@ def get_chrom_nonlinear(ring, **kwargs):
         fmax_y = kwargs.pop('fmax_y', 1)
         nturns = kwargs.pop('nturns', None)
         ampl = kwargs.pop('ampl', None)
+        remove_dx = kwargs.pop('remove_dc', False)
 
     fit_order = kwargs.pop('fit_order', None)
     dp_range = kwargs.pop('dp_range', None)
@@ -676,12 +685,12 @@ def get_chrom_nonlinear(ring, **kwargs):
             qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp)
         else:
             if not track_tune:
-                qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl)
+                qxs[i], qys[i] = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl, remove_dc=remove_dc)
             else:
                 if i==0:
-                    qtx, qty = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl)
+                    qtx, qty = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=fmin_x, fmax_x=fmax_x, fmin_y=fmin_y, fmax_y=fmax_y, nturns=nturns, ampl=ampl, remove_dc=remove_dc)
                 else:
-                    qtx, qty = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=qtx - window, fmax_x=qtx + window, fmin_y=qty - window, fmax_y=qty + window, nturns=nturns, ampl=ampl)     
+                    qtx, qty = get_tune(ring, method=tune_method, dp=dp, hann=hann, fmin_x=qtx - window, fmax_x=qtx + window, fmin_y=qty - window, fmax_y=qty + window, nturns=nturns, ampl=ampl, remove_dc=remove_dc)     
                 if (qtx < 0.01) or (qty < 0.01):
                     raise ValueError('Calculated tune too close to zero. Possibly too large dp so harmonic_analysis not working.') 
                 qxs[i] = qtx

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -563,7 +563,7 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
 
 
 @check_radiation(False)
-def get_chrom(ring, method='linopt', dp=0, **kwargs):
+def get_chrom(ring, method='linopt', dp=0, ddp=DDP, **kwargs):
     """
     gets the chromaticty using several available methods
 
@@ -584,7 +584,6 @@ def get_chrom(ring, method='linopt', dp=0, **kwargs):
         print('Warning fft method not accurate to get the '+ 
               'chromaticity')
 
-    ddp = kwargs.pop('ddp', DDP)
     tune_up = get_tune(ring, method=method, dp=dp + 0.5 * ddp, **kwargs)
     tune_down = get_tune(ring, method=method, dp=dp - 0.5 * ddp, **kwargs)
     chrom = (tune_up - tune_down) / ddp

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -634,7 +634,7 @@ remove_dc=remove_dc)
 
 def get_chrom_nonlinear(ring, **kwargs):
     """
-    gets the chromaticty using several available methods
+    gets the full chromaticty using several available methods
 
     method can be 'linopt' or 'scan'
     linopt: returns the chromaticity from the linopt function
@@ -645,11 +645,24 @@ def get_chrom_nonlinear(ring, **kwargs):
     INPUT
     for linopt:
         no input needed
-
-
+    for scan:
+        a tune_method must be specified (either linopt or laskar)
+        all of the relevant kwargs can be passed for these two 
+        fit_order: numpy.polyfit package is used for the fitting
+        fmin_x, fmin_y, fmax_x, fmax_y can be used to specify ranges
+        nturns
+        ampl
+        dp_range: numpy array of dp values for the scan
+        track_tune: if True then a 'window' must be specified
+        this always searches for the next tune in the scan close
+        to the tune before. Can be useful with high chromaticity.
     OUTPUT
-        tunes = np.array([Qx,Qy])
+        [xr, yr] = get_chrom_nonlinear()
+        xr = Qx, Q'x, Q''x, Q'''x -> up to specified order
+        for the computation of the Q'' and higher, the factorial is
+        taken into account
     """
+
     tune_method = kwargs.pop('tune_method', 'linopt')
     if tune_method != 'linopt':
         num_harmonics = kwargs.pop('num_harmonics', 20)
@@ -660,7 +673,7 @@ def get_chrom_nonlinear(ring, **kwargs):
         fmax_y = kwargs.pop('fmax_y', 1)
         nturns = kwargs.pop('nturns', None)
         ampl = kwargs.pop('ampl', None)
-        remove_dx = kwargs.pop('remove_dc', False)
+        remove_dc = kwargs.pop('remove_dc', False)
 
     fit_order = kwargs.pop('fit_order', None)
     dp_range = kwargs.pop('dp_range', None)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -534,8 +534,8 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
     """
 
     def gen_centroid(ring, ampl, nturns, dp, remove_dc):
-        orbit, _ = find_orbit4(ring,dp)
-        p0 = numpy.array([orbit,]*2).T
+        orbit, _ = find_orbit4(ring, dp)
+        p0 = numpy.array([orbit, ]*2).T
         p0[0, 0] += ampl
         p0[2, 1] += ampl
         p1 = lattice_pass(ring, p0, refpts=len(ring), nturns=nturns)
@@ -558,7 +558,7 @@ def get_tune(ring, method='linopt', dp=0, **kwargs):
         remove_dc = kwargs.pop('remove_dc', True)
         cent_x, cent_y = gen_centroid(ring, ampl, nturns, dp, remove_dc)
         cents = numpy.vstack((cent_x, cent_y))
-        tunes = get_tunes_harmonic(cents, method,**kwargs)
+        tunes = get_tunes_harmonic(cents, method, **kwargs)
     return tunes
 
 
@@ -580,8 +580,8 @@ def get_chrom(ring, method='linopt', dp=0, ddp=DDP, **kwargs):
         chromaticities = np.array([Q'x,Q'y])
     """
 
-    if method=='fft':
-        print('Warning fft method not accurate to get the '+ 
+    if method == 'fft':
+        print('Warning fft method not accurate to get the ' +
               'chromaticity')
 
     tune_up = get_tune(ring, method=method, dp=dp + 0.5 * ddp, **kwargs)

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -84,7 +84,8 @@ def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,
     This function uses computes the tunes to compute the tune for
     the specified momentum offsets. Then it fits this data and returns
     the chromaticity up to the given order (npoints>order)
-    Q'n = 1/n!*dQ/ddp
+    OUTPUT
+        (fitx, fity), dpa, qz
     """
     if order == 0:
         return get_chrom(ring, dp=dp, **kwargs)

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -81,8 +81,8 @@ def detuning(ring, xm=1.0e-4, ym=1.0e-4, npoints=3, dp=0, window=1,
 def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,
                  **kwargs):
     """
-    This function uses tunes_vs_amp to compute the tune for
-    the specified amplitudes. Then it fits this data and returns
+    This function uses computes the tunes to compute the tune for
+    the specified momentum offsets. Then it fits this data and returns
     the chromaticity up to the given order (npoints>order)
     Q'n = 1/n!*dQ/ddp
     """

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -1,0 +1,99 @@
+"""
+Function to compute quantities related to non-linear optics
+"""
+import numpy
+from math import sqrt, atan2
+from scipy.special import factorial
+from at.lattice import Lattice, check_radiation, uint32_refpts, get_s_pos, \
+    bool_refpts
+from at.tracking import lattice_pass
+from at.physics import HarmonicAnalysis, get_tune, linopt, find_orbit4, \
+    get_tunes_harmonic, get_chrom
+from at.lattice import Element
+
+__all__ = ['detuning', 'chromaticity']
+
+
+def tunes_vs_amp(ring, amp=None, dim=0,
+                 dp=0, window=1, nturns=512):
+    """
+    Generates a range of tunes for varying x, y, or z amplitudes
+    """
+    def _gen_part(ring, amp, dim, orbit, nturns):
+        part = numpy.array([orbit, ] * len(amp)).T + 1.0e-6
+        part[dim, :] += amp
+        part = lattice_pass(ring, part, nturns=nturns)
+        sh = part.shape
+        partx = numpy.reshape(part[0, :], (sh[1], sh[3]))
+        party = numpy.reshape(part[2, :], (sh[1], sh[3]))
+        return partx, party
+
+    orbit, _ = find_orbit4(ring)
+    q0 = get_tune(ring)
+    fmin = numpy.maximum([0,0],q0-window)
+    fmax = numpy.minimum([1,1],q0+window)
+    tunes = []
+
+    if amp is not None:
+        partx, party = _gen_part(ring, amp, dim, orbit, nturns)
+        qx = get_tunes_harmonic(partx, 'laskar',
+                                fmin=fmin[0], fmax=fmax[0])
+        qy = get_tunes_harmonic(party, 'laskar',
+                                fmin=fmin[1], fmax=fmax[1])
+        tunes = numpy.vstack((qx, qy)).T
+
+    return numpy.array(tunes)
+
+
+def detuning(ring, xm=1.0e-4, ym=1.0e-4, npoints=3, dp=0, window=1, nturns=512):
+    """
+    This function uses tunes_vs_amp to compute the tunes for
+    the specified amplitudes. Then it fits this data and returns
+    result for dQx/dx, dQy/dx, dQx/dy, dQy/dy
+    """
+    lindata0, _, _, _ = linopt(ring, dp=dp)
+    gamma = (1 + lindata0.alpha * lindata0.alpha) / lindata0.beta
+
+    x = numpy.linspace(-xm, xm, npoints)
+    y = numpy.linspace(-ym, ym, npoints)
+    x2 = x * x
+    y2 = y * y
+
+    q_dx =  tunes_vs_amp(ring, amp=x, dim=0, dp=dp, window=window, nturns=nturns)
+    q_dy =  tunes_vs_amp(ring, amp=y, dim=2, dp=dp, window=window, nturns=nturns)
+
+    fx = numpy.polyfit(x2, q_dx, 1)
+    fy = numpy.polyfit(y2, q_dy, 1)
+
+    q0 = [[fx[1, 0], fx[1, 1]], 
+          [fy[1, 0], fy[1, 1]]]
+    q1 = [[2 * fx[0, 0] / gamma[0],2 * fx[0, 1] / gamma[0]],
+          [2 * fy[0, 0] / gamma[1],2 * fy[0, 1] / gamma[1]]]
+
+    return numpy.array(q0), numpy.array(q1), x, q_dx, y, q_dy
+
+
+def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,**kwargs):
+    """
+    This function uses tunes_vs_amp to compute the tune for
+    the specified amplitudes. Then it fits this data and returns
+    the chromaticity up to the given order (npoints>order)
+    Q'n = 1/n!*dQ/ddp
+    """
+    if order ==0:
+       return get_chrom(ring,dp=dp,**kwargs)
+    elif order>npoints-1:
+       raise ValueError('order should be smaller than npoints-1')
+    else:    
+        dpa = numpy.linspace(-dpm, dpm, npoints)
+        qz = []
+        for dpi in dpa:
+            qz.append(get_tune(ring,method=method,dp=dp+dpi,**kwargs))
+        fit = numpy.polyfit(dpa, qz, order)[::-1]
+        fitx = fit[:,0]/factorial(numpy.arange(order+1))
+        fity = fit[:,1]/factorial(numpy.arange(order+1)) 
+        return numpy.array([fitx,fity]), dpa, numpy.array(qz)
+
+
+
+

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -30,10 +30,11 @@ def tunes_vs_amp(ring, amp=None, dim=0,
         partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
         return partx + 1j*partxp, party + 1j*partyp
 
-    orbit, _ = find_orbit4(ring, dp)
-    q0 = get_tune(ring)
+    l0, q0, _, _ = linopt(ring, dp=dp)
+    orbit = l0['closed_orbit']
     fmin = numpy.maximum([0, 0], q0 - window)
     fmax = numpy.minimum([1, 1], q0 + window)
+
     tunes = []
 
     if amp is not None:

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -25,10 +25,12 @@ def tunes_vs_amp(ring, amp=None, dim=0,
         part = lattice_pass(ring, part, nturns=nturns)
         sh = part.shape
         partx = numpy.reshape(part[0, :], (sh[1], sh[3]))
+        partxp = numpy.reshape(part[1, :], (sh[1], sh[3]))
         party = numpy.reshape(part[2, :], (sh[1], sh[3]))
-        return partx, party
+        partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
+        return partx+1j*partxp, party+1j*partyp
 
-    orbit, _ = find_orbit4(ring)
+    orbit, _ = find_orbit4(ring,dp)
     q0 = get_tune(ring)
     fmin = numpy.maximum([0,0],q0-window)
     fmax = numpy.minimum([1,1],q0+window)
@@ -88,7 +90,7 @@ def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,**kw
         dpa = numpy.linspace(-dpm, dpm, npoints)
         qz = []
         for dpi in dpa:
-            qz.append(get_tune(ring,method=method,dp=dp+dpi,**kwargs))
+            qz.append(get_tune(ring,method=method,dp=dp+dpi,remove_dc=True,**kwargs))
         fit = numpy.polyfit(dpa, qz, order)[::-1]
         fitx = fit[:,0]/factorial(numpy.arange(order+1))
         fity = fit[:,1]/factorial(numpy.arange(order+1)) 

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -28,12 +28,12 @@ def tunes_vs_amp(ring, amp=None, dim=0,
         partxp = numpy.reshape(part[1, :], (sh[1], sh[3]))
         party = numpy.reshape(part[2, :], (sh[1], sh[3]))
         partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
-        return partx+1j*partxp, party+1j*partyp
+        return partx + 1j*partxp, party + 1j*partyp
 
-    orbit, _ = find_orbit4(ring,dp)
+    orbit, _ = find_orbit4(ring, dp)
     q0 = get_tune(ring)
-    fmin = numpy.maximum([0,0],q0-window)
-    fmax = numpy.minimum([1,1],q0+window)
+    fmin = numpy.maximum([0, 0], q0 - window)
+    fmax = numpy.minimum([1, 1], q0 + window)
     tunes = []
 
     if amp is not None:
@@ -47,7 +47,8 @@ def tunes_vs_amp(ring, amp=None, dim=0,
     return numpy.array(tunes)
 
 
-def detuning(ring, xm=1.0e-4, ym=1.0e-4, npoints=3, dp=0, window=1, nturns=512):
+def detuning(ring, xm=1.0e-4, ym=1.0e-4, npoints=3, dp=0, window=1,
+             nturns=512):
     """
     This function uses tunes_vs_amp to compute the tunes for
     the specified amplitudes. Then it fits this data and returns
@@ -61,41 +62,41 @@ def detuning(ring, xm=1.0e-4, ym=1.0e-4, npoints=3, dp=0, window=1, nturns=512):
     x2 = x * x
     y2 = y * y
 
-    q_dx =  tunes_vs_amp(ring, amp=x, dim=0, dp=dp, window=window, nturns=nturns)
-    q_dy =  tunes_vs_amp(ring, amp=y, dim=2, dp=dp, window=window, nturns=nturns)
+    q_dx = tunes_vs_amp(ring, amp=x, dim=0, dp=dp, window=window,
+                        nturns=nturns)
+    q_dy = tunes_vs_amp(ring, amp=y, dim=2, dp=dp, window=window,
+                        nturns=nturns)
 
     fx = numpy.polyfit(x2, q_dx, 1)
     fy = numpy.polyfit(y2, q_dy, 1)
 
-    q0 = [[fx[1, 0], fx[1, 1]], 
+    q0 = [[fx[1, 0], fx[1, 1]],
           [fy[1, 0], fy[1, 1]]]
-    q1 = [[2 * fx[0, 0] / gamma[0],2 * fx[0, 1] / gamma[0]],
-          [2 * fy[0, 0] / gamma[1],2 * fy[0, 1] / gamma[1]]]
+    q1 = [[2 * fx[0, 0] / gamma[0], 2 * fx[0, 1] / gamma[0]],
+          [2 * fy[0, 0] / gamma[1], 2 * fy[0, 1] / gamma[1]]]
 
     return numpy.array(q0), numpy.array(q1), x, q_dx, y, q_dy
 
 
-def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,**kwargs):
+def chromaticity(ring, method='linopt', dpm=0.02, npoints=11, order=3, dp=0,
+                 **kwargs):
     """
     This function uses tunes_vs_amp to compute the tune for
     the specified amplitudes. Then it fits this data and returns
     the chromaticity up to the given order (npoints>order)
     Q'n = 1/n!*dQ/ddp
     """
-    if order ==0:
-       return get_chrom(ring,dp=dp,**kwargs)
-    elif order>npoints-1:
-       raise ValueError('order should be smaller than npoints-1')
-    else:    
+    if order == 0:
+        return get_chrom(ring, dp=dp, **kwargs)
+    elif order > npoints - 1:
+        raise ValueError('order should be smaller than npoints-1')
+    else:
         dpa = numpy.linspace(-dpm, dpm, npoints)
         qz = []
         for dpi in dpa:
-            qz.append(get_tune(ring,method=method,dp=dp+dpi,remove_dc=True,**kwargs))
+            qz.append(get_tune(ring, method=method, dp=dp+dpi, remove_dc=True,
+                      **kwargs))
         fit = numpy.polyfit(dpa, qz, order)[::-1]
-        fitx = fit[:,0]/factorial(numpy.arange(order+1))
-        fity = fit[:,1]/factorial(numpy.arange(order+1)) 
-        return numpy.array([fitx,fity]), dpa, numpy.array(qz)
-
-
-
-
+        fitx = fit[:, 0]/factorial(numpy.arange(order + 1))
+        fity = fit[:, 1]/factorial(numpy.arange(order + 1))
+        return numpy.array([fitx, fity]), dpa, numpy.array(qz)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -232,6 +232,49 @@ def test_linopt_no_refpts(dba_lattice):
     assert len(physics.linopt(dba_lattice, DP, get_chrom=True)) == 4
 
 
+def test_get_tune_chrom(hmba_lattice):
+    hmba_lattice.radiation_off(cavity_pass='IdentityPass',
+                               quadrupole_pass='auto')
+    qlin = hmba_lattice.get_tune()
+    qplin = hmba_lattice.get_chrom()
+    qharm = hmba_lattice.get_tune(method='laskar')
+    qpharm = hmba_lattice.get_chrom(method='laskar')
+    numpy.testing.assert_allclose(qlin, [0.38156245, 0.85437543], rtol=1e-5)
+    numpy.testing.assert_allclose(qharm, [0.38156245, 0.85437541], rtol=1e-5)
+    numpy.testing.assert_allclose(qplin, [0.17919002, 0.12242263], rtol=1e-5)
+    numpy.testing.assert_allclose(qpharm, [0.17919144, 0.12242624], rtol=1e-5)
+
+
+def test_nl_detuning_chromaticity(hmba_lattice):
+    hmba_lattice.radiation_off(cavity_pass='IdentityPass',
+                               quadrupole_pass='auto')
+    nlqplin, _, _ = at.nonlinear.chromaticity(hmba_lattice, npoints=11)
+    nlqpharm, _, _ = at.nonlinear.chromaticity(hmba_lattice,
+                                               method='laskar', npoints=11)
+    q0, q1, _, _, _, _ = at.nonlinear.detuning(hmba_lattice,
+                                               npoints=11, window=0.1)
+    numpy.testing.assert_allclose(nlqplin,
+                                  [[0.38156741, 0.17908186,
+                                    1.18655795, -16.47368184],
+                                   [0.8543741, 0.12240385,
+                                    2.01744297, -3.064094]],
+                                  rtol=1e-5)
+    numpy.testing.assert_allclose(nlqpharm,
+                                  [[0.38156741, 0.17908228,
+                                    1.18656178, -16.47370342],
+                                   [0.85437409, 0.12240619,
+                                   2.01744051, -3.06407046]],
+                                  rtol=1e-5)
+    numpy.testing.assert_allclose(q0,
+                                  [[0.38156263, 0.85437553],
+                                   [0.38156263, 0.85437553]],
+                                  rtol=1e-5)
+    numpy.testing.assert_allclose(q1,
+                                  [[3005.87694885, -3256.61063654],
+                                   [-3259.0625278, 1615.46553512]],
+                                  rtol=1e-5)
+
+
 @pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
 def test_ohmi_envelope(hmba_lattice, refpts):
     hmba_lattice.radiation_on()


### PR DESCRIPTION
Added some functions to easily compute the chromaticity (linear or non-linear). Please see below for an example on how to use it. I wrote it in such a way that the user has full control over each of the tune computations so all functionalities of get_tune can be used and also included tune tracking for the more difficult cases.

```
import numpy as np
import at

ring = at.load_mat('./betamodel.mat', mat_key='betamodel')
ring = at.Lattice(ring)
ring.radiation_off(quadrupole_pass='auto')

print(ring.get_chrom())
print(ring.get_chrom(method='scan'))
print(ring.get_chrom(method='scan', dp_range=np.linspace(-1e-3,1e-3,11), tune_method='laskar', nturns=512, ampl=5e-6, fmin_x=0, fmax_x=0.5, fmin_y=0, fmax_y=0.5, remove_dc=True) )

chrom_x, chrom_y = ring.get_chrom_nonlinear(fit_order=3, dp_range=np.linspace(-1e-2,1e-2,21))
print(chrom_x)
print(chrom_y)


chrom_x_sus, chrom_y_sus = ring.get_chrom_nonlinear(fit_order=3, dp_range=np.linspace(-2e-3,2e-3,21), tune_method='laskar', nturns=1024, ampl=30e-6, fmin_x=0, fmax_x=0.5, fmin_y=0, fmax_y=0.5, track_tune=True, window=0.05, remove_dc=True)
print(chrom_x_sus)
print(chrom_y_sus)

```

When debugging I found a need for the remove_DC flag as I found the DC component of the beam spectrum in the laskar method was larger than the tune, in this case by setting the remove_dc flag to True the mean TbT position is removed from the bunch TbT data before being sent for spectral analysis. 

Some PEP8ifying still do but wanted to wait until it was approved. 