### PR TITLE
Wiggler creation methods

### DIFF
--- a/atintegrators/DriftPass.m
+++ b/atintegrators/DriftPass.m
@@ -1,5 +1,5 @@
-% DriftPass.m Help file for DriftPass.c
-%  DriftPass.c - Integrator for Drift spaces
+function varargout=DriftPass(varargin)
+%  DriftPass - Integrator for Drift spaces
 % 
 %  The transformation performed is:
 % 
@@ -60,4 +60,8 @@
 %   >> ELEMENT=atdrift('DRIFT',L);
 %   >> outcoord=DriftPass(ELEMENT,[0 0 0 0 0 0]')
 %
-%see also: atdrift, ringpass, linepass, DriftPass.c  
+%see also: atdrift, ringpass, linepass, DriftPass.c
+
+error('AT:MissingMexFile','"%s.%s" is missing. Did you run "atmexall" ?',...
+    mfilename,mexext);
+end

--- a/atintegrators/GWigSymplecticPass.m
+++ b/atintegrators/GWigSymplecticPass.m
@@ -1,5 +1,52 @@
-% GWigSymplecticRadPass.m Help file for GWigSymplecticRadPass.c
-%  GWigSymplecticRadPass.c - generic symplectic integrator for wigglers
-%  including radiation
+function varargout=GWigSymplecticPass(varargin) %#ok<STOUT>
+%GWigSymplecticPass - generic symplectic integrator for wigglers
 % 
-%see also: GWigSymplecticRadPass.c, GWigSymplecticPass.m  
+% Integrator based on:
+%
+%   "Explicit symplectic integrator for s-dependent static magnetic field"
+%   by Wu, Y. K. and Forest, E. and Robin, D. S.
+%   PhysRevE.68.046502
+%   https://link.aps.org/doi/10.1103/PhysRevE.68.046502
+%
+%The field of an horizontal wiggler is represented by a sum of harmonics,
+%each being described by a 6x1 column vector B such as:
+%
+%   Bx/Bmax =  B2 * B3/B4 * sin(B3*kw*x) sinh(B4*kw*z) cos(B5*kw*s + B6)
+%   Bz/Bmax = -B2 * cos(B3*kw*x) cosh(B4*kw*z) cos(B5*kw*s + B6)
+%   Bs/Bmax =  B2 * B5/B4 * cos(B3*kw*x) sinh(B4*kw*z) sin(B5*kw*s + B6)
+%
+%   with kw = 2*Pi/Lw   and   B4^2 = B3^2 + B5^2
+%
+% Bmax: Peak wiggler field
+% Lw:   Period length
+% B2:   Fraction of Bmax for the given harmonic
+% B3:   Field dependence on x
+% B4:   Field dependence on z
+% B5:   Harmonic number
+% B6:   Longitudinal phase of the given harmonic
+%
+%So the horizontal wiggler component is described by a 6 x NHharm matrix 'By'
+%
+%As an example, the fundamental of an infinitely wide horizontal wiggler
+%(no horizontal dependence of the vertical field) is represented by:
+%
+%                By=[1;1;0;1;1;0]
+%
+%Similarly, the field of an harmonic of a vertical wiggler is:
+%
+%   Bx/Bmax =  B2 * cosh(B3*kw*x) cos(B4*kw*z) cos(B5*kw*s + B6)
+%   Bz/Bmax = -B2 * B4/B3 * sinh(B3*kw*x) sin(B4*kw*y) cos(B5*kw*s + B6)
+%   Bs/Bmax = -B2 * B5/B3 * sinh(B3*kw*x) cos(B4*kw*z) sin(B5*kw*s + B6)
+%
+%   with kw = 2*Pi/Lw   and   B3^2 = B4^2 + B5^2
+%
+%And the vertical wiggler component is described by a 6 x NVharm matrix 'Bx'
+%
+%An arbitralily polarized wiggler is described be the combination of
+%horizontal and vertical wiggler fields with an adjustable phasing.
+%
+%see also: GWigSymplecticRadPass
+
+error('AT:MissingMexFile','"%s.%s" is missing. Did you run "atmexall" ?',...
+    mfilename,mexext);
+end

--- a/atintegrators/GWigSymplecticRadPass.m
+++ b/atintegrators/GWigSymplecticRadPass.m
@@ -1,4 +1,12 @@
-% GWigSymplecticPass.m Help file for GWigSymplecticPass.c
-%  GWigSymplecticPass.c - generic symplectic integrator for wigglers
-% 
-%see also: GWigSymplecticPass.c, GWigSymplecticRadPass.m  
+function varargout=GWigSymplecticRadPass(varargin) %#ok<STOUT>
+%GWigSymplecticRadPass - generic symplectic integrator for wigglers
+%
+% Similar to GWigSymplecticPass but with radiation included
+%
+% For documentation on the integrator, see GWigSymplecticPass
+%
+%see also: GWigSymplecticRadPass
+
+error('AT:MissingMexFile','"%s.%s" is missing. Did you run "atmexall" ?',...
+    mfilename,mexext);
+end

--- a/atmat/lattice/element_creation/atwiggler.m
+++ b/atmat/lattice/element_creation/atwiggler.m
@@ -1,79 +1,80 @@
 function elem=atwiggler(fname,varargin)
-% wiggler(fname, Ltot, Lw, Bmax, Nstep, Nmeth, By, Bx, method)
+% ATWIGGLER Creates a wiggler
 %
-% FamName	family name
-% Ltot		total length of the wiggle
-% Lw		total length of the wiggle
-% Bmax	 	peak wiggler field [Tesla]
-% Nstep		num of integration steps per period
-% Nmeth		symplectic integration method, 2nd or 4th order: 2 or 4
-% By		wiggler harmonics for horizontal wigglers
-% Bx		wiggler harmonics for vertical wigglers
-% method        name of the function to use for tracking
+%ELEM=ATWIGGLER(FAMNAME, LENGTH, LW, BMAX, ENERGY, PASSMETHOD)
 %
-% returns assigned address in the FAMLIST that is uniquely identifies
-% the family
+% FAMNAME       family name
+% LENGTH        total length
+% LW            Period length
+% BMAX          Peak magnetic field [T]
+% ENERGY        Beam energy [eV]
+% PASSMETHOD    Tracking function. Default 'GWigSymplecticPass'
+%
+%ELEM=ATWIGGLER(...,'keyword',value...)
+%
+% Keywords:
+% Nstep		number of integration steps per period (default 5)
+% Nmeth		symplectic integration method, 2nd or 4th order: 2 or 4 (default 4)
+% By		harmonics of the horizontal wiggler. Default [1;1;0;1;1;0]
+%               6xNH matrix, with NH number of harmonics
+% Bx		harmonics of the vertical wigglers. Default []
+%               6xNV matrix, with NV number of harmonics
+%
+%see also: GWigSymplecticPass
 
 %---------------------------------------------------------------------------
 % Modification Log:
 % -----------------
-% .04  2018-07-30   A.Mash'al, Iranian Light Source Facility 
+% .04  2018-07-30   A.Mash'al, Iranian Light Source Facility
 %                               Add energy to ElemData
 % .03  2003-06-19	YK Wu, Duke University, wu@fel.duke.edu
 %                               Add checks for input arguments
 % .02  2003-06-18	YK Wu, Duke University
 %				Add checks for inputs, add comments
 %
-% .01  2003-04-20	YK Wu, J. Li, Duke University  
+% .01  2003-04-20	YK Wu, J. Li, Duke University
 %				Define a wiggler element
 %
 %---------------------------------------------------------------------------
 %  Accelerator Physics Group, Duke FEL Lab, www.fel.duke.edu
 %
-[rsrc,Ltot,Lw,Bmax,Nstep,Nmeth,By,Bx,method] = decodeatargs({0,0,0,5,4,[],[],'WiggLinearPass'},varargin);
+[rsrc,Ltot,Lw,Bmax,energy,method] = decodeatargs({0,0,0,0,'GWigSymplecticPass'},varargin);
 [Ltot,rsrc] = getoption(rsrc,'Ltot',Ltot);
 [Lw,rsrc] = getoption(rsrc,'Lw',Lw);
 [Bmax,rsrc] = getoption(rsrc,'Bmax',Bmax);
-[Nstep,rsrc] = getoption(rsrc,'Nstep',Nstep);
-[Nmeth,rsrc] = getoption(rsrc,'Nmeth',Nmeth);
-[Bx,rsrc] = getoption(rsrc,'Bx',Bx);
-[By,rsrc] = getoption(rsrc,'By',By);
+[Nstep,rsrc] = getoption(rsrc,'Nstep',5);
+[Nmeth,rsrc] = getoption(rsrc,'Nmeth',4);
+[Bx,rsrc] = getoption(rsrc,'Bx',[]);
+[By,rsrc] = getoption(rsrc,'By',[1;1;0;1;1;0]);
 [method,rsrc] = getoption(rsrc,'PassMethod',method);
 [cl,rsrc] = getoption(rsrc,'Class','Wiggler');
 GWIG_EPS = 1e-6;
 dNw = abs(mod(Ltot/Lw, 1));
 if dNw > GWIG_EPS
-  error(' Wiggler: Ltot/Lw is not an integer.');
+    error(' Wiggler: Ltot/Lw is not an integer.');
 end
 
-if ~isempty(By)
-  NHharm = length(By(1,:));
-  for i=1:NHharm
+By=reshape(By,6,[]);
+NHharm = size(By,2);
+for i=1:NHharm
     kx = By(3,i); ky = By(4,i); kz = By(5,i);
     dk = sqrt(abs(ky*ky - kz*kz - kx*kx))/abs(kz);
-    if ( dk > GWIG_EPS ) 
-      error([' Wiggler (H): kx^2 + kz^2 - ky^2 != 0!, i = ', num2str(i,3)]);
+    if ( dk > GWIG_EPS )
+        error([' Wiggler (H): kx^2 + kz^2 - ky^2 != 0!, i = ', num2str(i,3)]);
     end
-  end
-else
-  NHharm = 0;
 end
 
-if ~isempty(Bx)
-  NVharm = length(Bx(1,:));
-  for i=1:NVharm
+Bx=reshape(Bx,6,[]);
+NVharm = size(Bx,2);
+for i=1:NVharm
     kx = Bx(3,i); ky = Bx(4,i); kz = Bx(5,i);
     dk = sqrt(abs(kx*kx - kz*kz - ky*ky))/abs(kz);
-    if ( dk > GWIG_EPS ) 
-      error([' Wiggler (V): ky^2 + kz^2 - kx^2 != 0!, i = ', num2str(i,3)]);
+    if ( dk > GWIG_EPS )
+        error([' Wiggler (V): ky^2 + kz^2 - kx^2 != 0!, i = ', num2str(i,3)]);
     end
-  end
-else
-  NVharm = 0;
 end
 
-
 elem = atbaselem(fname,method,'Class',cl,'Length',Ltot,'Lw',Lw,...
-    'Bmax',Bmax,'Nstep',Nstep,'Nmeth',Nmeth,'Bx',Bx,'By',By,...
+    'Bmax',Bmax,'Energy',energy,'Nstep',Nstep,'Nmeth',Nmeth,'Bx',Bx,'By',By,...
     'NHharm',NHharm','NVharm',NVharm,rsrc{:});
 end

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -102,7 +102,7 @@ class Element(object):
         >>> Drift('dr', 0.5).divide([0.2, 0.6, 0.2])
         [Drift('dr', 0.1), Drift('dr', 0.3), Drift('dr', 0.1)]
         """
-        # by default, the element is indivisible
+        # Bx default, the element is indivisible
         return [self]
 
     def update(self, *args, **kwargs):
@@ -559,17 +559,17 @@ class Wiggler(LongElement):
                         Nstep=int, Nmeth=int, NHharm=int, NVharm=int)
 
     def __init__(self, family_name, length, wiggle_period, b_max, energy,
-                 n_step=5, n_meth=4, by=(1, 1, 0, 1, 1, 0), bx=(), **kwargs):
+                 Nstep=5, Nmeth=4, By=(1, 1, 0, 1, 1, 0), Bx=(), **kwargs):
         """
         Args:
             length: total length of the wiggler
             wiggle_period: length must be a multiple of this
             b_max: peak wiggler field [Tesla]
         Available keywords:
-            n_step: number of integration steps.
-            n_meth: symplectic integration order: 2 or 4
-            by: harmonics for horizontal wiggler: (6,nHharm) array-like object
-            bx: harmonics for vertical wiggler (6,nHharm) array-like object
+            Nstep: number of integration steps.
+            Nmeth: symplectic integration order: 2 or 4
+            Bx: harmonics for horizontal wiggler: (6,nHharm) array-like object
+            By: harmonics for vertical wiggler (6,nHharm) array-like object
 
         """
         kwargs.setdefault('PassMethod', 'GWigSymplecticPass')
@@ -580,8 +580,8 @@ class Wiggler(LongElement):
                                                              wiggle_period,
                                                              n_wiggles))
         super(Wiggler, self).__init__(family_name, length, Lw=wiggle_period,
-                                      Bmax=b_max, Nstep=n_step, Nmeth=n_meth,
-                                      By=by, Bx=bx, Energy=energy, **kwargs)
+                                      Bmax=b_max, Nstep=Nstep, Nmeth=Nmeth,
+                                      By=By, Bx=Bx, Energy=energy, **kwargs)
 
         for i, b in enumerate(self.By.T):
             dk = abs(b[3]**2 - b[4]**2 - b[2]**2) / abs(b[4])

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -565,6 +565,8 @@ class Wiggler(LongElement):
             length: total length of the wiggler
             wiggle_period: length must be a multiple of this
             b_max: peak wiggler field [Tesla]
+            energy: beam energy [eV]
+
         Available keywords:
             Nstep: number of integration steps.
             Nmeth: symplectic integration order: 2 or 4

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -551,72 +551,52 @@ class Wiggler(LongElement):
     See atwiggler.m
     """
     REQUIRED_ATTRIBUTES = LongElement.REQUIRED_ATTRIBUTES + ['Lw', 'Bmax',
-                                                             'Nstep', 'Nmeth',
-                                                             'By', 'Bx',
                                                              'Energy']
-    _conversions = dict(Element._conversions, Lw=float, Bmax=float, Nstep=int,
-                        Nmeth=int, NHharm=int, NVharm=int, By=_array,
-                        Bx=_array, Energy=float)
+    _conversions = dict(Element._conversions, Lw=float, Bmax=float,
+                        Energy=float,
+                        Bx=lambda v: _array(v, (6, -1)),
+                        By=lambda v: _array(v, (6, -1)),
+                        Nstep=int, Nmeth=int, NHharm=int, NVharm=int)
 
-    def __init__(self, family_name, length, wiggle_period, b_max, n_step,
-                 n_meth, by, bx, energy, **kwargs):
+    def __init__(self, family_name, length, wiggle_period, b_max, energy,
+                 n_step=5, n_meth=4, by=(1, 1, 0, 1, 1, 0), bx=(), **kwargs):
         """
-
         Args:
             length: total length of the wiggler
             wiggle_period: length must be a multiple of this
             b_max: peak wiggler field [Tesla]
+        Available keywords:
             n_step: number of integration steps.
             n_meth: symplectic integration order: 2 or 4
-            by: harmonics for horizontal wiggler: example [1, 1, 0, 1, 1, 0]
-            bx: harmonics for vertical wiggler: example []
-        Available keywords:
-            NHharm    Number of horizontal harmonics
-            NVharm    Number of vertical harmonics
+            by: harmonics for horizontal wiggler: (6,nHharm) array-like object
+            bx: harmonics for vertical wiggler (6,nHharm) array-like object
+
         """
+        kwargs.setdefault('PassMethod', 'GWigSymplecticPass')
         n_wiggles = length / wiggle_period
         if abs(round(n_wiggles) - n_wiggles) > 1e-6:
             raise ValueError("Wiggler: length / wiggle_period is not an "
                              "integer. ({0}/{1}={2})".format(length,
                                                              wiggle_period,
                                                              n_wiggles))
-        nh = kwargs.pop('NHharm', None)
-        nv = kwargs.pop('NVharm', None)
-        if nh is None:
-            try:
-                nh = len(by[0])
-            except TypeError:
-                nh = 1
-            except IndexError:
-                nh = 0
-        if nv is None:
-            try:
-                nv = len(bx[0])
-            except TypeError:
-                nv = 1
-            except IndexError:
-                nv = 0
-        for i in range(nh):
-            if i == 0:
-                dk = abs(by[3]**2 - by[4]**2 - by[2]**2) / abs(by[4])
-            else:
-                dk = abs(by[3, i]**2 - by[4, i]**2 - by[2, i]**2) / abs(by[4])
+        super(Wiggler, self).__init__(family_name, length, Lw=wiggle_period,
+                                      Bmax=b_max, Nstep=n_step, Nmeth=n_meth,
+                                      By=by, Bx=bx, Energy=energy, **kwargs)
+
+        for i, b in enumerate(self.By.T):
+            dk = abs(b[3]**2 - b[4]**2 - b[2]**2) / abs(b[4])
             if dk > 1e-6:
                 raise ValueError("Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = "
                                  "{0}".format(i))
-        for i in range(nv):
-            if i == 0:
-                dk = abs(bx[2]**2 - bx[4]**2 - bx[3]**2) / abs(bx[4])
-            else:
-                dk = abs(bx[2, i]**2 - bx[4, i]**2 - bx[3, i]**2) / abs(bx[4])
+
+        for i, b in enumerate(self.Bx.T):
+            dk = abs(b[2]**2 - b[4]**2 - b[3]**2) / abs(b[4])
             if dk > 1e-6:
-                raise ValueError("Wiggler(H): ky^2 + kz^2 -kx^2 !=0, i = "
+                raise ValueError("Wiggler(V): ky^2 + kz^2 -kx^2 !=0, i = "
                                  "{0}".format(i))
-        kwargs.setdefault('PassMethod', 'GWigSymplecticPass')
-        super(Wiggler, self).__init__(family_name, length, Lw=wiggle_period,
-                                      Bmax=b_max, Nstep=n_step, Nmeth=n_meth,
-                                      NHharm=nh, NVharm=nv, By=by, Bx=bx,
-                                      Energy=energy, **kwargs)
+
+        self.NHharm = self.By.shape[1]
+        self.NVharm = self.Bx.shape[1]
 
 
 CLASS_MAP = dict((k, v) for k, v in locals().items()

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -344,8 +344,7 @@ def test_wiggler(rin):
     periods = 23
     bmax = 1
     by = numpy.array([1, 1, 0, 1, 1, 0], dtype=numpy.float64)
-    bx = numpy.array([])
-    c = elements.Wiggler('wiggler', period * periods, period, bmax, 3e9, by=by)
+    c = elements.Wiggler('wiggler', period * periods, period, bmax, 3e9, By=by)
     assert abs(c.Length - 1.15) < 1e-10
     lattice = [c]
     # Expected value from Matlab AT.

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -345,7 +345,7 @@ def test_wiggler(rin):
     bmax = 1
     by = numpy.array([1, 1, 0, 1, 1, 0], dtype=numpy.float64)
     bx = numpy.array([])
-    c = elements.Wiggler('wiggler', period * periods, period, bmax, 5, 4, by, bx, 3e9)
+    c = elements.Wiggler('wiggler', period * periods, period, bmax, 3e9, by=by)
     assert abs(c.Length - 1.15) < 1e-10
     lattice = [c]
     # Expected value from Matlab AT.

--- a/pyat/test/test_integrators.py
+++ b/pyat/test/test_integrators.py
@@ -32,7 +32,7 @@ def test_exact_hamiltonian_pass_with_dls_dipole(rin):
 @pytest.mark.parametrize('passmethod', ('GWigSymplecticPass', 'GWigSymplecticRadPass'))
 def test_gwig_symplectic_pass(rin, passmethod):
     # Parameters copied from one of the Diamond wigglers.
-    wiggler = elements.Wiggler('w', 1.15, 0.05, 0, 5, 4, [1, 1, 0, 1, 1, 0], [], 3e9)
+    wiggler = elements.Wiggler('w', 1.15, 0.05, 0.8, 3e9)
     wiggler.PassMethod = passmethod
     l = Lattice([wiggler], name='lat', energy=3e9)
     atpass(l, rin, 1)


### PR DESCRIPTION
The `GWigSymplecticPass` integrator is now documented in the` GWigSymplecticPass.m` file (for Matlab).
It is not clear to be what is the equivalent for integrator documentation in Python…

Looking at the `GWigSymplecticPass` integrator, it appears that the wiggler creation functions (Python and Matlab) can be made simpler.

For simple planar horizontal wigglers, the mandatory parameters can be reduced to:
Name,  Length,  Period_length, Bmax, Energy

All other parameters can be set with keywords. As for other element creation functions, keyword names are set identical to the attribute names of the created element, so we have:

`PassMethod` (default: 'GWigSimplecticPass')
`Nstep` (default: 5)
`Nmeth` (default: 4)
`By` (default: [1, 1, 0, 1, 1, 0])
`Bx` (default: [])

The declaration of wigglers is then simpler (for instance creating an arbitrary horizontal wiggler only needs specifying explicitly `By`). But this new argument list is incompatible with the initial one since the energy parameter is now moved to the 5th location.  However since the wiggler has just been released, I think this is worth the effort.