### PR TITLE
Change NAFF license

### DIFF
--- a/doc/licenseFiles/NaffLicense.txt
+++ b/doc/licenseFiles/NaffLicense.txt
@@ -2,24 +2,43 @@
 !-------------------------------------------------------------------------
 !   NAFF.0.84 NUMERICAL ANALYSIS OF FUNDAMENTAL FREQUENCIES
 !            (27 JANVIER 1996)
-!  
-!   (C) JACQUES LASKAR 
+!
+!   (C) JACQUES LASKAR
 !       ASTRONOMIE ET SYSTEMES DYNAMIQUES
 !       BUREAU DES LONGITUDES
 !       75006 PARIS
 !       EMAIL : LASKAR@BDL.FR
 !
-!    MAIN REFERENCES : 
+!    MAIN REFERENCES :
 !    LASKAR, J.: THE CHAOTIC MOTION OF THE SOLAR SYSTEM. A NUMERICAL
 !    ESTIMATE OF THE SIZE OF THE CHAOTIC ZONES,ICARUS,88,(1990),266--291
 !
 !   (NAFF.MAC.1.6 - 27/5/98)
 !
 !**************************************************************************
-!  THIS PROGRAMM  CANNOT BE COPIED, 
-!  DISTRIBUTED NOR MODIFIED WITHOUT THE AGREEMENT OF THE AUTHOR.
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are
+! met:
+
+!     * Redistributions of source code must retain the above copyright
+!       notice, this list of conditions and the following disclaimer.
+!     * Redistributions in binary form must reproduce the above copyright
+!       notice, this list of conditions and the following disclaimer in
+!       the documentation and/or other materials provided with the distribution
+
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
 !**************************************************************************
-! 
+!
 !                        PROGRAMME D'ANALYSE DE FOURIER AUTOMATIQUE
 !   -- NAFF --           CALCULE UN TERME A LA FOIS ET LE RETRANCHE
 !                        A TABS
@@ -40,7 +59,7 @@
 !  16/4/91   COMPILATION SEPAREE DE NAFF EN UNE BIBLIOTHEQUE
 !  30/4/91   TRAITEMENT DU CAS OU ON RETROUVE LA MEME FREQUENCE
 !  27/1/96   PLUSIEURS FENETRES
-!  27/2/97   MODIF POUR DIMENSIONNER TOUT EXPLICITEMENT AVEC 
+!  27/2/97   MODIF POUR DIMENSIONNER TOUT EXPLICITEMENT AVEC
 !            INCLUDE NAFF.INC POUR LES PARAMETRES
 !  23/45/1997    CORRECTION DE MAXIQUA.F (F. JOUTEL)
 !  22/4/1998 MODIF POUR QUADRUPLE PRECISION (J. LASKAR)


### PR DESCRIPTION
As was mentioned in #197, current NUFF license is overly restrictive (https://github.com/atcollab/at/issues/197#issuecomment-735644050). It could be a deal-breaker when trying to use this software on computational clusters with strict licensing policies.
This PR applies the same license terms to NAFF as for the rest of the AT.