### PR TITLE
Fixes in at.lattice.utils.py

### DIFF
--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -59,11 +59,9 @@ def uint32_refpts(refpts, n_elements):
     Return a uint32 numpy array with contents as the indices of the selected
     elements.  This is used for indexing a lattice using explicit indices.
     """
-    refs = numpy.asarray(refpts).reshape(-1)
+    refs = numpy.ravel(refpts)
     if (refpts is None) or (refs.size == 0):
         return numpy.array([], dtype=numpy.uint32)
-    elif refs.size > n_elements+1:
-        raise ValueError('too many reftps given')
     elif numpy.issubdtype(refs.dtype, numpy.bool_):
         return numpy.flatnonzero(refs).astype(numpy.uint32)
 
@@ -91,8 +89,11 @@ def bool_refpts(refpts, n_elements):
     are selected. This is used for indexing a lattice using True or False
     values.
     """
-    if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
-        diff = 1 + n_elements - refpts.size
+    refs = numpy.ravel(refpts)
+    if (refpts is None) or (refs.size == 0):
+        return numpy.zeros(n_elements + 1, dtype=bool)
+    elif refs.dtype == bool:
+        diff = 1 + n_elements - refs.size
         if diff == 0:
             return refpts
         elif diff > 0:
@@ -101,7 +102,7 @@ def bool_refpts(refpts, n_elements):
             return refpts[:n_elements+1]
     else:
         brefpts = numpy.zeros(n_elements + 1, dtype=bool)
-        brefpts[refpts] = True
+        brefpts[refs] = True
         return brefpts
 
 
@@ -196,12 +197,15 @@ def refpts_iterator(ring, refpts):
     2) a numpy array of booleans as long as ring where selected elements
        are true
     """
-    if isinstance(refpts, numpy.ndarray) and refpts.dtype == bool:
-        for el, tst in zip(ring, refpts):
+    refs = numpy.ravel(refpts)
+    if (refpts is None) or (refs.size == 0):
+        return
+    elif refs.dtype == bool:
+        for el, tst in zip(ring, refs):
             if tst:
                 yield el
     else:
-        for i in refpts:
+        for i in refs:
             yield ring[i]
 
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -99,10 +99,10 @@ def bool_refpts(refpts, n_elements):
         elif diff > 0:
             return numpy.append(refpts, numpy.zeros(diff, dtype=bool))
         else:
-            return refpts[:n_elements+1]
+            return refpts[:n_elements + 1]
     else:
         brefpts = numpy.zeros(n_elements + 1, dtype=bool)
-        brefpts[refs] = True
+        brefpts[refs[:n_elements + 1]] = True
         return brefpts
 
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -225,6 +225,15 @@ def refpts_iterator(ring, refpts):
         for i in refs:
             yield ring[i]
 
+def refpts_count(refpts):
+    refs = numpy.ravel(refpts)
+    if (refpts is None) or (refs.size == 0):
+        return 0
+    elif refs.dtype == bool:
+        return numpy.count_nonzero(refs)
+    else:
+        return len(refs)
+
 
 def get_refpts(ring, key, quiet=True):
     """Get the elements refpts of a family or class (type) from the lattice.
@@ -345,7 +354,7 @@ def set_value_refpts(ring, refpts, var, values, order=None, increment=False):
     if increment:
         values = values + get_value_refpts(ring, refpts, var, order=order)
     else:
-        values = values + numpy.zeros(len(refpts))
+        values = values + numpy.zeros(refpts_count(refpts))
 
     for elm, val in zip(refpts_iterator(ring, refpts), values):
         setf(elm, val)

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -49,17 +49,17 @@ def test_uint32_refpts_throws_ValueError_correctly(ref_in):
         uint32_refpts(ref_in, 2)
 
 
-def test_bool_refpts():
-    bool_rps1 = numpy.ones(5, dtype=bool)
-    bool_rps1[3] = False
-    numpy.testing.assert_equal(bool_rps1, bool_refpts(bool_rps1, 4))
-    numpy.testing.assert_equal(bool_refpts([0, 1, 2, 4], 4), bool_rps1)
-    bool_rps3 = numpy.ones(12, dtype=bool)
-    bool_rps3[3] = False
-    numpy.testing.assert_equal(bool_rps1, bool_refpts(bool_rps3, 4))
-    bool_rps2 = numpy.ones(4, dtype=bool)
-    numpy.testing.assert_equal(numpy.array([True, True, True, True, False]),
-                               bool_refpts(bool_rps2, 4))
+@pytest.mark.parametrize('ref_in, expected', (
+    [[True], numpy.array([True, False, False, False], dtype=numpy.bool)],
+    [[], numpy.array([False, False, False, False], dtype=numpy.bool)],
+    [None, numpy.array([False, False, False, False], dtype=numpy.bool)],
+    [2, numpy.array([False, False, True, False], dtype=numpy.bool)],
+    [[1, 2], numpy.array([False, True, True, False], dtype=numpy.bool)],
+    [numpy.arange(0, 100, 1), numpy.array([True, True, True, True], dtype=numpy.bool)],
+    [range(100), numpy.array([True, True, True, True], dtype=numpy.bool)],
+))
+def test_bool_refpts(ref_in, expected):
+    numpy.testing.assert_equal(bool_refpts(ref_in, 3), expected)
 
 
 def test_checkattr(simple_ring):

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -55,12 +55,14 @@ def test_uint32_refpts_throws_ValueError_correctly(ref_in):
     [None, numpy.array([False, False, False, False], dtype=numpy.bool)],
     [2, numpy.array([False, False, True, False], dtype=numpy.bool)],
     [[1, 2], numpy.array([False, True, True, False], dtype=numpy.bool)],
-    [numpy.arange(0, 100, 1), numpy.array([True, True, True, True], dtype=numpy.bool)],
-    [range(100), numpy.array([True, True, True, True], dtype=numpy.bool)],
 ))
 def test_bool_refpts(ref_in, expected):
     numpy.testing.assert_equal(bool_refpts(ref_in, 3), expected)
 
+@pytest.mark.parametrize('ref_in', (10, range(100)))
+def test_bool_refpts_throws_IndexErrorrs(ref_in):
+    with pytest.raises(IndexError):
+        bool_refpts(ref_in, 3)
 
 def test_checkattr(simple_ring):
     assert checkattr('Length')(simple_ring[0]) is True

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -41,7 +41,7 @@ def test_no_bending_in_the_cell_warns_correctly():
         assert params['periodicity'] == 1
 
 
-def test__non_integer_number_of_cells_warns_correctly():
+def test_non_integer_number_of_cells_warns_correctly():
     d = elements.Dipole('d1', 1, BendingAngle=0.195)
     with pytest.warns(AtWarning):
         params = _matlab_scanner([d], energy=3.e+9)


### PR DESCRIPTION
- This makes `bool_refpts` accept integer scalars, empty list (`[]`) and `None`.
- A few functions are simplified,
- a new function `checkname` is added: it generates a filter function selecting elements with `FamName` matching a given pattern. This complements the existing function `checktype` and `checkattr`.