### PR TITLE
Add Github Action for building pyat wheels.

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -1,0 +1,68 @@
+# See the Python documentation: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# and cibuildwheel: https://cibuildwheel.readthedocs.io/en/stable/
+name: Build and upload wheels and sdist
+
+on:
+  push:
+    tags:
+      - pyat-*
+
+defaults:
+  run:
+    working-directory: pyat
+
+jobs:
+  build_wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.7.4
+
+      - name: Install Visual C++ for Python 2.7
+        if: runner.os == 'Windows'
+        run: choco install vcpython27 -f -y
+
+      - name: Prepare source
+        run: |
+          python -m pip install numpy==1.14.3
+          python setup.py build
+
+      - name: Remove built files
+        if: (! contains(matrix.os, 'windows'))
+        run: rm -rf build
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          # Skip Python 3.9 since it won't compile with numpy 1.14.3.
+          CIBW_SKIP: 'cp39-*'
+          CIBW_BEFORE_BUILD: pip install numpy==1.14.3
+          CIBW_BUILD_VERBOSITY: 1
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./pyat/wheelhouse/*.whl
+          if-no-files-found: error
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: tar.gz
+          path: ./pyat/dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,47 +1,55 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Build Python extension and run tests
 
 on:
   push:
   pull_request:
 
+defaults:
+  run:
+    working-directory: pyat
+
 jobs:
-  build:
+  build_and_run_tests:
 
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: pyat
-    
+
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
+
     - uses: actions/checkout@v2
+
     - name: Install VS for Python 2.7
       if: contains(matrix.os, 'windows')
       run: choco install vcpython27
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
         python -m pip install -r requirements.txt
+        python -m pip install pytest-cov
+
     - name: Build and install at
       run: python -m pip install -e .
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        python -m pytest test
+
+    - name: Test with pytest and coverage
+      run: python -m pytest test --cov-report term-missing --cov=at

--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -1,113 +1,41 @@
 pyAT
 ====
 
-pyAT is a Python interface to the pass methods defined in Accelerator Toolbox,
-implemented by compiling the C code used in the AT 'integrators' plus a Python
-extension.
+Introduction
+------------
 
-It supports Python 2.7 (deprecated) and 3.5 to 3.8.
+Accelerator Toolbox is a code used for simulating particle accelerators, used
+particularly for synchrotron light sources. It is hosted on `Github
+<https://github.com/atcollab>`_. Its original implementation is in Matlab.
 
-For some examples of how to use pyAT, see pyat_examples.rst.
+pyAT is a Python interface to Accelerator Toolbox. It uses the 'pass methods'
+defined in Accelerator Toolbox, implemented by compiling the C code used in the
+AT 'integrators' into a Python extension. These pass methods are used by
+higher-level functions to provide physics results.
 
+pyAT supports Python 2.7 (deprecated) and 3.5 to 3.8.
 
-Installation preparation (Windows)
-----------------------------------
+Installation
+------------
 
-Download Microsoft Visual C++ Compiler for Python 2.7 (`here
-<https://www.microsoft.com/en-us/download/details.aspx?id=44266>`_), and use
-the Visual C++ Command Prompt of the correct architecture to build pyat.
+Install accelerator-toolbox from PyPI::
 
-For newer versions of Python you need the appropriate version of Visual C++.
+    pip install accelerator-toolbox
 
+Usage
+-----
 
-Installation (all platforms)
-----------------------------
+Example usage::
 
-All the binaries should be built when building the Python extension.
+    >>> from at.load import loadmat
+    >>> from at.physics import linopt
+    >>> ring = load_mat('test_matlab/hmba.mat')
+    >>> linopt(ring, refpts=range(5))
 
-It is easiest to do this using a virtualenv. inside pyat:
+For more examples of how to use pyAT, see ``pyat_examples.rst``.
 
-We recommend using Python 3. If you are still using Python 2, you need virtualenv installed:
+Developer Notes
+---------------
 
-* ``virtualenv --no-site-packages venv``
+Developer notes are in ``developers.rst``.
 
-If you are using Python 3, you can use the built-in venv module:
-
-* ``python3 -m venv venv``
-
-Then:
-
-* ``source venv/bin/activate  # or venv\Scripts\activate on Windows``
-* ``pip install -r requirements.txt``
-* ``pip install -e .``
-
-Finally, you should be able to run the tests:
-
-* ``python -m pytest test``
-
-
-Comparing results with Matlab
------------------------------
-
-There is a second set of tests that require a Matlab licence and allows
-comparing results directly with a Matlab session.  See test_matlab/README
-for information.
-
-
-Debugging
----------
-
-Print statements in the C code will work once the integrators are
-recompiled.  To force recompilation, remove the build directory:
-
-* ``rm -rf build``
-
-Any changes to .py files are automatically reinstalled in the build, but to
-ensure any changes to .c files are reinstalled rerun:
-
-* ``python setup.py develop``
-
-If you get strange behaviour even after running setup.py develop again, then
-running the following, inside pyat, should fix it:
-
-* ``rm -rf build``
-* ``find at -name "*.pyc" -exec rm '{}' \;``
-* ``find at -name "*.so" -exec rm '{}' \;``
-* ``python setup.py develop``
-
-N.B. setup.py develop needs to be run with the same version of Python (and
-numpy) that you are using to run pyAT.
-
-Releasing a version to PyPI
----------------------------
-
-Because pyAT compiles C code, releasing a version is not simple. The code
-must be compiled for different operating systems and Python versions.
-
-To do this, we use the continuous integration services Travis CI (for Linux
-and Mac) and Appveyor (for Windows). When a tag of the form pyat-x.y.z is
-pushed to Github, wheels for each of the different platforms will be built
-and automatically uploaded to
-https://test.pypi.org/project/accelerator-toolbox/. Once there, someone
-should manually test that the wheels are working correctly, then they can
-manually download the files and upload them to PyPI itself. Note that this
-was 46 different files for pyat-0.0.4 covering different platforms and
-architectures.
-
-The configuration for this is in .travis.yml and .appveyor.yml, where for tags
-of the correct format the wheels are built using only one of the builds for
-each platform (MacOS, Linux and Windows). This logic may need updating from time
-to time - for example, the wheels are being built and uploaded using the Python
-3.7 build at present.
-
-For Travis to be authenticated to Test PyPI, someone must set the variables
-TWINE_USERNAME and TWINE_PASSWORD in the Travis CI project settings. These
-are not public so it is possible to use personal details; it may be best
-not to use the same password for PyPI.
-
-A similar process is necessary for the Appveyor settings. You can click the
-little lock to keep the variable values private.
-
-Because there are complications putting special characters into these
-environment variables it may be simpler to ensure your Test PyPI password
-contains only alphanumeric characters.

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -430,17 +430,3 @@ MOD_INIT(atpass)
 
     return MOD_SUCCESS_VAL(m);
 }
-
-#if PY_MAJOR_VERSION < 3
-int main(int argc, char *argv[]) {
-    /* Pass argv[0] to the Python interpreter */
-    Py_SetProgramName(argv[0]);
-
-    /* Initialize the Python interpreter.  Required. */
-    Py_Initialize();
-
-    /* Add a static module */
-    initatpass();
-    return 0;
-}
-#endif

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -234,7 +234,9 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
     if check:
         sanitise_class(index, cls, elem_dict)
     # Remove mandatory attributes from the keyword arguments.
-    elem_args = (elem_dict.pop(attr, None) for attr in cls.REQUIRED_ATTRIBUTES)
+    # Create list rather than generator to ensure that elements are removed
+    # from elem_dict.
+    elem_args = [elem_dict.pop(attr, None) for attr in cls.REQUIRED_ATTRIBUTES]
     element = cls(*(arg for arg in elem_args if arg is not None), **elem_dict)
     return element
 

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -1,0 +1,91 @@
+pyAT Developer Notes
+====================
+
+See also README.rst.
+
+
+Installation preparation (Windows)
+----------------------------------
+
+Download Microsoft Visual C++ Compiler for Python 2.7 (`here
+<https://www.microsoft.com/en-us/download/details.aspx?id=44266>`_), and use
+the Visual C++ Command Prompt of the correct architecture to build pyat.
+
+For newer versions of Python you need the appropriate version of Visual C++.
+
+
+Installation (all platforms)
+----------------------------
+
+All the binaries should be built when building the Python extension.
+
+It is easiest to do this using a virtualenv. inside pyat:
+
+Python 2 support will be removed soon. If you are still using Python 2, you
+need virtualenv installed:
+
+* ``virtualenv --no-site-packages venv``
+
+If you are using Python 3, you can use the built-in venv module:
+
+* ``python3 -m venv venv``
+
+Then:
+
+* ``source venv/bin/activate  # or venv\Scripts\activate on Windows``
+* ``pip install -r requirements.txt``
+* ``pip install -e .``
+
+Finally, you should be able to run the tests:
+
+* ``python -m pytest test``
+
+
+Comparing results with Matlab
+-----------------------------
+
+There is a second set of tests that require a Matlab licence and allows
+comparing results directly with a Matlab session.  See test_matlab/README
+for information.
+
+
+Debugging
+---------
+
+Print statements in the C code will work once the integrators are
+recompiled.  To force recompilation, remove the build directory:
+
+* ``rm -rf build``
+
+Any changes to .py files are automatically reinstalled in the build, but to
+ensure any changes to .c files are reinstalled rerun:
+
+* ``python setup.py develop``
+
+If you get strange behaviour even after running setup.py develop again, then
+running the following, inside pyat, should fix it:
+
+* ``rm -rf build``
+* ``find at -name "*.pyc" -exec rm '{}' \;``
+* ``find at -name "*.so" -exec rm '{}' \;``
+* ``python setup.py develop``
+
+N.B. setup.py develop needs to be run with the same version of Python (and
+numpy) that you are using to run pyAT.
+
+Releasing a version to PyPI
+---------------------------
+
+Because pyAT compiles C code, releasing a version is not simple. The code
+must be compiled for different operating systems and Python versions.
+
+To do this, we use the continuous integration service Github Actions.
+When a tag of the form pyat-x.y.z is pushed to Github, wheels for each
+supported platform will be built and automatically uploaded as an 'artifact'.
+
+Once there, someone should manually test that the wheels are working correctly,
+then they can manually download the files and upload them to PyPI itself.
+Note that this was 46 different files for pyat-0.0.4 covering different platforms and
+architectures.
+
+The configuration for this is in .github/workflows/build-wheels.yml.

--- a/pyat/pyat_examples.rst
+++ b/pyat/pyat_examples.rst
@@ -17,12 +17,13 @@ Initialisation:
     Python 2.7.3 (default, Nov  9 2013, 21:59:00)
     [GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
+    >>> import at
     >>>
 
 - Load a pyAT ring from a .mat file::
 
-    >>> import at
-    >>> ring = at.load.load_mat('test_matlab/hmba.mat')
+    >>> from at.load import load_mat
+    >>> ring = load_mat('test_matlab/hmba.mat')
 
 Basic Use:
 ----------

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -87,12 +87,12 @@ diffmatrix = Extension(
 
 setup(
     name='accelerator-toolbox',
-    version='0.0.4',
+    version='0.1.0',
     description='Accelerator Toolbox',
     long_description=long_description,
     author='The AT collaboration',
     author_email='atcollab-general@lists.sourceforge.net',
-    url='https://pypi.org/project/accelerator-toolbox/',
+    url='https://github.com/atcollab/at',
     # Numpy 1.14.3 is the oldest version that builds with Python 3.7.
     install_requires=['numpy>=1.14.3', 'scipy>=0.16'],
     packages=find_packages(),


### PR DESCRIPTION
Each time a tag of the form pyat-* is pushed, all wheels
will be built and uploaded to Github as 'artifacts'. These
wheels may be downloaded, tested and uploaded to PyPI. In
future we could automatically upload wheels directly to PyPI.

Other changes:

* refactor Python testing workflow
* add tests on Python 3.9 and fix associated bug
* remove unnecessary function from at.c
* improve pyat README files
* update pyat version to 0.1.0 in preparation for release