### PR TITLE
Fix some integrators for OpenMP

### DIFF
--- a/atintegrators/BndMPoleSymplectic4Pass.c
+++ b/atintegrators/BndMPoleSymplectic4Pass.c
@@ -55,20 +55,24 @@ void BndMPoleSymplectic4Pass(double *r, double le, double irho, double *A, doubl
         double *KickAngle, int num_particles)
 {	
     int c;
-    double SL, L1, L2, K1, K2;
+    double SL = le/num_int_steps;
+    double L1 = SL*DRIFT1;
+    double L2 = SL*DRIFT2;
+    double K1 = SL*KICK1;
+    double K2 = SL*KICK2;
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
-    SL = le/num_int_steps;
-    L1 = SL*DRIFT1;
-    L2 = SL*DRIFT2;
-    K1 = SL*KICK1;
-    K2 = SL*KICK2;
 
     if (KickAngle) {   /* Convert corrector component to polynomial coefficients */
         B[0] -= sin(KickAngle[0])/le; 
         A[0] += sin(KickAngle[1])/le;
     }
-    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
+    irho,gap,A,B,L1,L2,K1,K2,max_order,num_int_steps,\
+    FringeBendEntrance,entrance_angle,fint1,FringeBendExit,exit_angle,fint2,\
+    FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0) \
+    private(c)
     for(c = 0;c<num_particles;c++)	/* Loop over particles  */
     {
         double *r6 = r+c*6;

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -54,10 +54,6 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
         double E0, int num_particles)
 {
     int c;
-    bool useT1 = (T1 != NULL);
-    bool useT2 = (T2 != NULL);
-    bool useR1 = (R1 != NULL);
-    bool useR2 = (R2 != NULL);
     double SL = le/num_int_steps;
     double L1 = SL*DRIFT1;
     double L2 = SL*DRIFT2;
@@ -73,7 +69,13 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
     double  pi = 3.14159265358979;
     double  alpha0 = qe*qe/(4*pi*epsilon0*hbar*clight);
     
-    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
+    irho,gap,A,B,L1,L2,K1,K2,max_order,num_int_steps,\
+    FringeBendEntrance,entrance_angle,fint1,FringeBendExit,exit_angle,fint2,\
+    FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0,\
+    emass,E0,hbar,clight,alpha0,qe,SL) \
+    private(c)
     for (c = 0; c<num_particles; c++) {	/* Loop over particles  */
         double *r6 = r+c*6;
         if (!atIsNaN(r6[0])) {
@@ -82,8 +84,8 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
             double NormL1 = L1*p_norm;
             double NormL2 = L2*p_norm;
             /*  misalignment at entrance  */
-            if(useT1) ATaddvv(r6,T1);
-            if(useR1) ATmultmv(r6,R1);
+            if (T1) ATaddvv(r6,T1);
+            if (R1) ATmultmv(r6,R1);
             /* Check physical apertures at the entrance of the magnet */
             if (RApertures) checkiflostRectangularAp(r6,RApertures);
             if (EApertures) checkiflostEllipticalAp(r6,EApertures);
@@ -157,8 +159,8 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
             if (RApertures) checkiflostRectangularAp(r6,RApertures);
             if (EApertures) checkiflostEllipticalAp(r6,EApertures);
             /* Misalignment at exit */
-            if(useR2) ATmultmv(r6,R2);
-            if(useT2) ATaddvv(r6,T2);
+            if(R2) ATmultmv(r6,R2);
+            if(T2) ATaddvv(r6,T2);
         }
     }
 }

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -29,7 +29,9 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
    		    }
 		}	
 	else
-        #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD*10) default(shared) shared(r_in,num_particles) private(c)
+        #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+        shared(r_in,num_particles,len,xkick,ykick) \
+        private(c)
         for(c = 0;c<num_particles;c++) {
             int c6 = c*6;
 		    if(!atIsNaN(r_in[c6])) {

--- a/atintegrators/CorrectorPass.c
+++ b/atintegrators/CorrectorPass.c
@@ -19,23 +19,22 @@ void CorrectorPass(double *r_in, double xkick, double ykick, double len,  int nu
    r - 6-by-N matrix of initial conditions reshaped into 
    1-d array of 6*N elements 
 */
-{	int c, c6;
-    double NormL, p_norm;
+{	int c;
 	if (len==0)
 	    for(c = 0;c<num_particles;c++) {
-	        c6 = c*6;
+	        int c6 = c*6;
 		    if(!atIsNaN(r_in[c6])) {
 		        r_in[c6+1] += xkick;
    		        r_in[c6+3] += ykick; 		    
    		    }
 		}	
 	else
-        #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD*10) default(shared) shared(r_in,num_particles) private(c,c6)
+        #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD*10) default(shared) shared(r_in,num_particles) private(c)
         for(c = 0;c<num_particles;c++) {
-            c6 = c*6;
+            int c6 = c*6;
 		    if(!atIsNaN(r_in[c6])) {
-		        p_norm = 1/(1+r_in[c6+4]);
-			    NormL  = len*p_norm;
+		        double p_norm = 1/(1+r_in[c6+4]);
+			    double NormL  = len*p_norm;
 	            r_in[c6+5] += NormL*p_norm*(xkick*xkick/3 + ykick*ykick/3 +
    		                r_in[c6+1]*r_in[c6+1] + r_in[c6+3]*r_in[c6+3] + 
    		                r_in[c6+1]*xkick + r_in[c6+3]*ykick)/2;

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -24,10 +24,7 @@ void QuantDiffPass(double *r_in, double* Lmatp , int Seed, int nturn, int num_pa
  * 1-d array of 6*N elements
  */
 {
-  double *r6;
-  int c, i, j;
-  double randnorm[6];
-  double diffusion[6] = {0.0,0.0,0.0,0.0,0.0,0.0};
+  int c;
   static int initSeed = 1;	/* 	If this variable is 1, then I initialize the seed
 				 * 	to the clock and I change the variable to 0*/
   
@@ -49,9 +46,14 @@ void QuantDiffPass(double *r_in, double* Lmatp , int Seed, int nturn, int num_pa
 #endif
       initSeed = 0;
   }
+
+  #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r_in,num_particles) private(c)
   for (c = 0; c<num_particles; c++)
   { /*Loop over particles  */
-      r6 = r_in+c*6;
+      int i, j;
+      double randnorm[6];
+      double diffusion[6];
+      double *r6 = r_in+c*6;
       for (i=0;i<6;i++)
       {
           diffusion[i]=0.0;

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -47,29 +47,27 @@ void QuantDiffPass(double *r_in, double* Lmatp , int Seed, int nturn, int num_pa
       initSeed = 0;
   }
 
-  #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r_in,num_particles) private(c)
-  for (c = 0; c<num_particles; c++)
-  { /*Loop over particles  */
+  #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+  shared(r_in,num_particles,Lmatp) \
+  private(c)
+  for (c = 0; c<num_particles; c++) {
+      /*Loop over particles  */
       int i, j;
       double randnorm[6];
       double diffusion[6];
       double *r6 = r_in+c*6;
-      for (i=0;i<6;i++)
-      {
+      for (i=0;i<6;i++) {
           diffusion[i]=0.0;
           /*randnorm[i]=random_normal();*/
           randnorm[i]= generateGaussian(0.0,1.0);
       }
       
-      for (i=0;i<6;i++)
-      {
-          for (j=0;j<=i;j++)
-          {
+      for (i=0;i<6;i++) {
+          for (j=0;j<=i;j++) {
               diffusion[i]+=randnorm[j]*Lmatp[i+6*j];
           }
       }
-      if(!atIsNaN(r6[0]))
-      {
+      if (!atIsNaN(r6[0])) {
           r6[0] += diffusion[0];
           r6[1] += diffusion[1];
           r6[2] += diffusion[2];

--- a/atintegrators/StrMPoleSymplectic4Pass.c
+++ b/atintegrators/StrMPoleSymplectic4Pass.c
@@ -38,9 +38,7 @@ void StrMPoleSymplectic4Pass(double *r, double le, double *A, double *B,
         double *R1, double *R2,
         double *RApertures, double *EApertures, 
         double *KickAngle, int num_particles)
-{	int c,m;
-    double norm, NormL1, NormL2;
-    double *r6;
+{	int c;
     double SL, L1, L2, K1, K2;
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
@@ -54,10 +52,14 @@ void StrMPoleSymplectic4Pass(double *r, double le, double *A, double *B,
         B[0] -= sin(KickAngle[0])/le; 
         A[0] += sin(KickAngle[1])/le;
     }
-    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c,r6,m,norm,NormL1,NormL2)
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
     for (c = 0;c<num_particles;c++)	{   /*Loop over particles  */
-        r6 = r+c*6;
+        double *r6 = r+c*6;
         if(!atIsNaN(r6[0])) {
+            int m;
+            double norm = 1.0/(1.0+r6[4]);
+            double NormL1 = L1*norm;
+            double NormL2 = L2*norm;
             /*  misalignment at entrance  */
             if (T1) ATaddvv(r6,T1);
             if (R1) ATmultmv(r6,R1);
@@ -72,10 +74,6 @@ void StrMPoleSymplectic4Pass(double *r, double le, double *A, double *B,
             }
             /*  integrator  */
             for (m=0; m < num_int_steps; m++) {  /*  Loop over slices */
-             	r6 = r+c*6;
-                norm = 1/(1+r6[4]);
-                NormL1 = L1*norm;
-                NormL2 = L2*norm;
                 fastdrift(r6, NormL1);
                 strthinkick(r6, A, B,  K1, max_order);
                 fastdrift(r6, NormL2);

--- a/atintegrators/StrMPoleSymplectic4Pass.c
+++ b/atintegrators/StrMPoleSymplectic4Pass.c
@@ -38,21 +38,25 @@ void StrMPoleSymplectic4Pass(double *r, double le, double *A, double *B,
         double *R1, double *R2,
         double *RApertures, double *EApertures, 
         double *KickAngle, int num_particles)
-{	int c;
-    double SL, L1, L2, K1, K2;
+{
+    int c;
+    double SL = le/num_int_steps;
+    double L1 = SL*DRIFT1;
+    double L2 = SL*DRIFT2;
+    double K1 = SL*KICK1;
+    double K2 = SL*KICK2;
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
-    SL = le/num_int_steps;
-    L1 = SL*DRIFT1;
-    L2 = SL*DRIFT2;
-    K1 = SL*KICK1;
-    K2 = SL*KICK2;
-    
+
     if (KickAngle) {   /* Convert corrector component to polynomial coefficients */
         B[0] -= sin(KickAngle[0])/le; 
         A[0] += sin(KickAngle[1])/le;
     }
-    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
+    A,B,L1,L2,K1,K2,max_order,num_int_steps,\
+    FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0) \
+    private(c)
     for (c = 0;c<num_particles;c++)	{   /*Loop over particles  */
         double *r6 = r+c*6;
         if(!atIsNaN(r6[0])) {

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -44,8 +44,12 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
         double *KickAngle, double E0,
         int num_particles)
 {
-    double SL, L1, L2, K1, K2;
     int c;
+    double SL = le/num_int_steps;
+    double L1 = SL*DRIFT1;
+    double L2 = SL*DRIFT2;
+    double K1 = SL*KICK1;
+    double K2 = SL*KICK2;
     double  qe = 1.60217733e-19;
     double  epsilon0 = 8.854187817e-12;
     double  clight = 2.99792458e8;
@@ -55,17 +59,17 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
     double  alpha0 = qe*qe/(4*pi*epsilon0*hbar*clight);
     bool useLinFrEleEntrance = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadEntrance==2);
     bool useLinFrEleExit = (fringeIntM0 != NULL && fringeIntP0 != NULL  && FringeQuadExit==2);
-    SL = le/num_int_steps;
-    L1 = SL*DRIFT1;
-    L2 = SL*DRIFT2;
-    K1 = SL*KICK1;
-    K2 = SL*KICK2;
-    
+
     if (KickAngle) {  /* Convert corrector component to polynomial coefficients */
         B[0] -= sin(KickAngle[0])/le;
         A[0] += sin(KickAngle[1])/le;
     }
-#pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
+    A,B,L1,L2,K1,K2,max_order,num_int_steps,\
+    FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0,\
+    emass,E0,hbar,clight,alpha0,qe,SL) \
+    private(c)
     for (c = 0;c<num_particles;c++)	{   /* Loop over particles  */
         double *r6 = r+c*6;
         if(!atIsNaN(r6[0])) {

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -44,12 +44,8 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
         double *KickAngle, double E0,
         int num_particles)
 {
-    double *r6;
     double SL, L1, L2, K1, K2;
-    double dpp0, ng, ec, de, energy, gamma, cstec, cstng;
-    double s0, ds, rho, dxp, dyp, xp0, yp0;
-    int c,m,i;
-    int nph;
+    int c;
     double  qe = 1.60217733e-19;
     double  epsilon0 = 8.854187817e-12;
     double  clight = 2.99792458e8;
@@ -69,10 +65,11 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
         B[0] -= sin(KickAngle[0])/le;
         A[0] += sin(KickAngle[1])/le;
     }
-#pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c,r6,m)
+#pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(shared) shared(r,num_particles) private(c)
     for (c = 0;c<num_particles;c++)	{   /* Loop over particles  */
-        r6 = r+c*6;
+        double *r6 = r+c*6;
         if(!atIsNaN(r6[0])) {
+            int m;
             /*  misalignment at entrance  */
             if (T1) ATaddvv(r6,T1);
             if (R1) ATmultmv(r6,R1);
@@ -87,11 +84,14 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
             }
             /* integrator */
             for (m=0; m < num_int_steps; m++) { /* Loop over slices */
-                r6 = r+c*6;
-                dpp0 = r6[4];
-                xp0 = r6[1]/(1+r6[4]);
-                yp0 = r6[3]/(1+r6[4]);
-                s0 = r6[5];
+                int i;
+                double ng, ec, de, energy, gamma, cstec, cstng;
+                double ds, rho, dxp, dyp;
+                int nph;
+                double dpp0 = r6[4];
+                double xp0 = r6[1]/(1+r6[4]);
+                double yp0 = r6[3]/(1+r6[4]);
+                double s0 = r6[5];
                 
                 ATdrift6(r6,L1);
                 strthinkickrad(r6, A, B, K1, E0, max_order);


### PR DESCRIPTION
Though the integrators have included for long the OpenMP directives, some were wrong, possibly due to evolution of the code since they were introduced. As a consequence, some gave wrong results when parallelised. The correction consists in moving some variables inside the parallel block so that they are considered "private".