### PR TITLE
[MPI] add AT parameter sweep script

### DIFF
--- a/utils/mpi_sweep/README.md
+++ b/utils/mpi_sweep/README.md
@@ -1,0 +1,6 @@
+`mpi_sweep.py` script allows parameter sweeping on computational clusters via MPI.
+
+You may run example script locally `mpi_sweep_example.py`:
+```bash
+mpirun --host localhost:$(nproc) -n 3 ./mpi_sweep_example.py
+```

--- a/utils/mpi_sweep/mpi_sweep.py
+++ b/utils/mpi_sweep/mpi_sweep.py
@@ -1,0 +1,28 @@
+from mpi4py import MPI
+import numpy
+
+def mpi_sweep(generator, worker, collector):
+    """
+    Evaluate function on multiple MPI nodes and collect the result.
+    generator: function returning list of worker arguments
+    worker: worker function
+    collector: function collecting calculation results
+    """
+    comm = MPI.COMM_WORLD
+    size = comm.Get_size()
+    rank = comm.Get_rank()
+    name = MPI.Get_processor_name()
+
+    data = None
+    if rank == 0:
+        data = numpy.array_split(generator(), size)
+
+    chunk = comm.scatter(data)
+
+    output = [worker(par, name=name, rank=rank, size=size)
+              for par in chunk]
+
+    data = comm.gather(list(zip(chunk, output)))
+
+    if rank == 0:
+        return collector([d for sublist in data for d in sublist])

--- a/utils/mpi_sweep/mpi_sweep_example.py
+++ b/utils/mpi_sweep/mpi_sweep_example.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import at
+import numpy
+from mpi_sweep import mpi_sweep
+
+# this code will run on all MPI nodes
+d1 = at.elements.Drift('DR01', 3)
+qf = at.elements.Quadrupole('QF', 1, 0.2)
+d2 = at.elements.Drift('DR02', 3)
+qd = at.elements.Quadrupole('QD', 1, -0.2)
+fodocell = numpy.array([d1, qf, d2, qd])
+thering = at.lattice.Lattice(fodocell, energy=1e6)
+
+def generator():
+    """
+    Generate input parameter list for worker function.
+    It will only be executed on node 0 to save on allocations.
+    """
+    return [(0.1,-0.1), (0.2,-0.2), (0.3,-0.3)]
+
+def worker(arg, **kwargs):
+    """
+    Function to run on multiple MPI nodes with argument arg provided
+    by the generator function.
+    This function may run multiple times on one node.
+    """
+    # additional arguments may be used
+    # kwargs['name']  # name of the processor
+    # kwargs['rank']  # rank (id) of the node
+    # kwargs['size']  # total number of nodes
+    qf.K = arg[0]
+    qd.K = arg[0]
+    return at.find_m44(thering)[0]
+
+def collector(args):
+    """
+    Collect computed data.
+    This function will only be executed on node 0.
+    """
+    with open('output.csv', 'w') as f:
+        f.write('Kqf,Kdf')
+        [f.write(f',m{i}{j}') for i in range(0, 5) for j in range(0, 5)]
+        f.write('\n')
+        for case in args:
+            params, output = case
+            f.write(f'{params[0]},{params[1]}')
+            [f.write(f',{output[i,j]}') for i in range(0, 4) for j in range(0, 4)]
+            f.write('\n')
+
+mpi_sweep(generator, worker, collector)

--- a/utils/mpi_sweep/mpi_sweep_example.py
+++ b/utils/mpi_sweep/mpi_sweep_example.py
@@ -30,7 +30,7 @@ def worker(arg, **kwargs):
     # kwargs['rank']  # rank (id) of the node
     # kwargs['size']  # total number of nodes
     qf.K = arg[0]
-    qd.K = arg[0]
+    qd.K = arg[1]
     return at.find_m44(thering)[0]
 
 def collector(args):
@@ -39,8 +39,8 @@ def collector(args):
     This function will only be executed on node 0.
     """
     with open('output.csv', 'w') as f:
-        f.write('Kqf,Kdf')
-        [f.write(f',m{i}{j}') for i in range(0, 5) for j in range(0, 5)]
+        f.write('Kqf,Kqd')
+        [f.write(f',m{i}{j}') for i in range(0, 4) for j in range(0, 4)]
         f.write('\n')
         for case in args:
             params, output = case

--- a/utils/mpi_sweep/mpi_sweep_octave.m
+++ b/utils/mpi_sweep/mpi_sweep_octave.m
@@ -1,0 +1,74 @@
+function mpi_sweep_octave(generator, worker, collector)
+
+  pkg load mpi
+
+  if not (MPI_Initialized ())
+    MPI_Init ();
+  endif
+
+  comm = MPI_COMM_WORLD;
+  info.rank = MPI_Comm_rank(comm);
+  info.size = MPI_Comm_size(comm);
+  info.name = MPI_Get_processor_name();
+
+  N = 0;
+
+  if info.rank == 0
+    input = feval(generator);
+    N = size(input)(2);
+    array = split_array(input, info.size);
+    for i=1:info.size
+      MPI_Send(array{i}, i-1, 0, comm);
+    endfor
+  endif
+
+  MPI_Barrier(comm);
+
+  chunk = MPI_Recv(0, 0, comm);
+
+  output = cell(1, size(chunk));
+  for i=1:(size(chunk)(2))
+    output{1, i} = {chunk{i}, worker(chunk{i}, info)};
+  endfor
+
+  MPI_Barrier(comm);
+
+  MPI_Send(output, 0, 1, comm);
+
+  MPI_Barrier(comm);
+
+  if info.rank == 0
+    array = cell(1, N);
+    current = 1;
+    for i=1:info.size
+      chunk = MPI_Recv(i-1, 1, comm);
+      for j=1:size(chunk)(2)
+	array{current} = chunk{j};
+	current = current + 1;
+      endfor
+    endfor
+    collector(array)
+  endif
+
+  if not (MPI_Finalized)
+    MPI_Finalize;
+  endif
+
+  function output=split_array(arr, num)
+    indexes = zeros(num+1, 1);
+    step = floor(size(arr)(2) / num);
+    additional = size(arr)(2) - num * step;
+    indexes(1) = 1;
+    for i=2:num+1
+      indexes(i) = indexes(i-1) + step;
+      if additional > 0
+	indexes(i) = indexes(i) + 1;
+	additional = additional - 1;
+      endif
+    endfor
+    output = cell(1, num);
+    for i=1:num
+      output{1,i} = arr(indexes(i):indexes(i+1)-1);
+    endfor
+  end
+end

--- a/utils/mpi_sweep/mpi_sweep_octave_example.m
+++ b/utils/mpi_sweep/mpi_sweep_octave_example.m
@@ -1,0 +1,74 @@
+#!/usr/bin/env octave
+
+function mpi_sweep_octave_example
+
+  ## Make sure that AT source files are in path.
+  ## For this go to atoctave folder and run
+  ## > octave --eval 'bootstrap;savepath'
+
+  ## this code will run on all MPI nodes
+  D1.FamName = 'DR01';
+  D1.Length  = 3;
+  D1.PassMethod = 'DriftPass';
+
+  QF.FamName = 'QF';
+  QF.Length = 1;
+  QF.K = 0.2;
+  QF.PassMethod= 'QuadLinearPass';
+
+  D2.FamName = 'DR02';
+  D2.Length  = 3;
+  D2.PassMethod = 'DriftPass';
+
+  QD.FamName = 'QD';
+  QD.Length = 1;
+  QD.K = -0.2;
+  QD.PassMethod= 'QuadLinearPass';
+
+  FODOCELL = {D1 QF D2 QD};
+  THERING = [FODOCELL];
+
+  function output=generator()
+    ## Generate input parameter list for worker function.
+    ## It will only be executed on node 0 to save on allocations.
+    output = {{0.1,-0.1}, {0.2,-0.2}, {0.3,-0.3}};
+  end
+
+  function output=worker(input, info)
+    ## additional arguments may be used
+    ## info.name;  # name of the processor
+    ## info.rank;  # rank (id) of the node
+    ## info.size;  # total number of nodes
+    THERING{findcells(THERING,'FamName','QF')}.K = input{1,1};
+    THERING{findcells(THERING,'FamName','QD')}.K = input{1,2};
+    output = findm44(THERING,0);
+  end
+
+  function collector(input)
+    ## Collect computed data.
+    ## This function will only be executed on node 0.
+    fid = fopen("output.csv", "w");
+    fprintf(fid, "Kqf,Kqd");
+    for i=1:4
+      for j=1:4
+        fprintf(fid, ",m%d%d", i, j);
+      endfor
+    endfor
+    fprintf(fid, "\n");
+    for ind=1:size(input)(2)
+      params = input{1,ind}{1,1};
+      output = input{1,ind}{1,2};
+      fprintf(fid, "%d,%d", params{1,1}, params{1,2});
+      for i=1:4
+        for j=1:4
+          fprintf(fid, ",%d", output(i,j));
+        endfor
+      endfor
+      fprintf(fid, "\n");
+    endfor
+    fclose(fid);
+  end
+
+  mpi_sweep_octave(@generator, @worker, @collector);
+
+end


### PR DESCRIPTION
There's a common pattern to spawn multiple instances of AT on computational clusters for parameter sweep. I've heard that people usually do this using script interfacing with [slurm](https://slurm.schedmd.com/overview.html) itself. An easier solution is to use MPI. I think it would make sense to maintain a generic sweep script in this repo.

This PR adds rather trivial script `mpi_sweep.py` that allows distributing processing jobs across computational cluster. 
`mpi_sweep_example.py` is a simple example of its use. It runs simulations and dumps data into `output.csv` file.

Similar function may be created for Octave using [mpi plugin](https://octave.sourceforge.io/mpi/), I'll try to write it a bit later.
Matlab probably has something similar.