### PR TITLE
Control the number of threads in lattice_pass

### DIFF
--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -4,7 +4,7 @@ Helper functions for working with AT lattices.
 A lattice as understood by pyAT is any sequence of elements.  These functions
 are useful for working with these sequences.
 """
-
+from .options import DConstant
 from .elements import *
 from .utils import *
 from .lattice_object import *

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -1,4 +1,4 @@
-"""Global set of constants for numerical differentiation"""
+"""Global set of constants"""
 import os
 
 class _Dst(object):

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -1,7 +1,6 @@
 """
 Accelerator physics functions
 """
-
 from math import sqrt, pi
 from scipy.constants import physical_constants as cst
 
@@ -12,7 +11,8 @@ e_mass = 1.0e+06 * cst['electron mass energy equivalent in MeV'][0]  # eV
 Cgamma = 4.0 * pi * _e_radius / 3.0 / pow(e_mass, 3)                 # m/eV^3
 Cq = 55 / 32 / sqrt(3) * _hbar / e_mass * 1.0e-9                     # m
 
-from .diff_constants import *
+# noinspection PyUnresolvedReferences
+from ..lattice import DConstant     # For backward compatibility
 from .orbit import *
 from .amat import *
 from .matrix import *

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -4,9 +4,9 @@ Coupled or non-coupled 4x4 linear motion
 import numpy
 from math import sqrt, atan2, pi
 from at.lattice import Lattice, check_radiation, uint32_refpts, get_s_pos, \
-    bool_refpts
+    bool_refpts, DConstant
 from at.tracking import lattice_pass
-from at.physics import find_orbit4, find_m44, jmat, DConstant
+from at.physics import find_orbit4, find_m44, jmat
 from .harmonic_analysis import get_tunes_harmonic
 
 __all__ = ['linopt', 'avlinopt', 'get_mcf', 'get_tune',

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -5,10 +5,10 @@ A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 
 import numpy
-from at.lattice import Lattice, uint32_refpts, get_refpts
+from at.lattice import Lattice, uint32_refpts, get_refpts, DConstant
 from at.lattice.elements import Bend, M66
 from at.tracking import lattice_pass, element_pass
-from at.physics import find_orbit4, find_orbit6, jmat, symplectify, DConstant
+from at.physics import find_orbit4, find_orbit6, jmat, symplectify
 
 __all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'gen_m66_elem']
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,10 +4,9 @@ Closed orbit related functions
 
 import numpy
 import scipy.constants as constants
-from at.lattice import AtWarning, AtError, check_radiation
+from at.lattice import AtWarning, AtError, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
-from at.physics import DConstant
 import warnings
 
 __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6']


### PR DESCRIPTION
Though `atpass` was modified to allow the control of the number of threads, the interface on `lattice_pass` was missing.
Here it is.