### PR TITLE
OpenMP on macOS

### DIFF
--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -215,9 +215,9 @@ warning(oldwarns.state,oldwarns.identifier);
     end
 
     function include=select_omp()
-        if exist('/usr/local/include/omp.h', 'file')
+        if exist('/usr/local/include/omp.h', 'file')        % Homebrew
             include='-I/usr/local/include';
-        elseif exist('/opt/local/include/omp.h', 'file')
+        elseif exist('/opt/local/include/omp.h', 'file')    % MacPorts
             include='-I/opt/local/include';
         else
             error('AT:MissingLibrary', strjoin({'', ...

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -215,9 +215,9 @@ warning(oldwarns.state,oldwarns.identifier);
     end
 
     function include=select_omp()
-        if exist('/usr/local/include/omp.h', 'file')
+        if exist('/usr/local/include/omp.h', 'file')            % Homebrew
             include='-I/usr/local/include';
-        elseif exist('/opt/local/include/libomp/omp.h', 'file')
+        elseif exist('/opt/local/include/libomp/omp.h', 'file') % MacPorts
             include='-I/opt/local/include/libomp';
         else
             error('AT:MissingLibrary', strjoin({'', ...

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -41,8 +41,9 @@ if openmp
         cflags={'/openmp'};
         ompflags={};
     elseif ismac()
+        ompinc = select_omp();
         cflags={'-Xpreprocessor', '-fopenmp'};
-        ompflags={'-I/usr/local/include',...
+        ompflags={ompinc,...
             sprintf('-L"%s"',fullfile(matlabroot,'sys','os',computer('arch'))),...
             '-liomp5'};
     else
@@ -210,6 +211,20 @@ warning(oldwarns.state,oldwarns.identifier);
         function d=getdate(f)
             dt=dir(f);
             d=dt.datenum;
+        end
+    end
+
+    function include=select_omp()
+        if exist('/usr/local/include/omp.h', 'file')
+            include='-I/usr/local/include';
+        elseif exist('/opt/local/include/omp.h', 'file')
+            include='-I/opt/local/include';
+        else
+            error('AT:MissingLibrary', strjoin({'', ...
+                'libomp.dylib must be installed with your favourite package manager:', '', ...
+                'Use "$ brew install libomp"', ...
+                'Or  "$ sudo port install libomp"'...
+                }, '\n'));
         end
     end
 end

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -14,9 +14,9 @@ except ImportError:
 
 
 def select_omp():
-    if exists('/usr/local/include/omp.h'):
+    if exists('/usr/local/include/omp.h'):      # Homebrew
         return '-I/usr/local/include', '/usr/local/lib'
-    elif exists('/opt/local/include/omp.h'):
+    elif exists('/opt/local/include/omp.h'):    # MacPorts
         return '-I/opt/local/include', '/opt/local/lib'
     else:
         raise FileNotFoundError('\n'.join(('',

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -16,9 +16,9 @@ if sys.version_info[0] < 3:
     FileNotFoundError = IOError
 
 def select_omp():
-    if exists('/usr/local/include/omp.h'):
+    if exists('/usr/local/include/omp.h'):              # Homebrew
         return '-I/usr/local/include', '/usr/local/lib'
-    elif exists('/opt/local/include/libomp/omp.h'):
+    elif exists('/opt/local/include/libomp/omp.h'):     # MacPorts
         return '-I/opt/local/include/libomp', '/opt/local/lib/libomp'
     else:
         raise FileNotFoundError('\n'.join(('',

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -13,6 +13,21 @@ except ImportError:
     sys.exit()
 
 
+def select_omp():
+    if exists('/usr/local/include/omp.h'):
+        return '-I/usr/local/include', '/usr/local/lib'
+    elif exists('/opt/local/include/omp.h'):
+        return '-I/opt/local/include', '/opt/local/lib'
+    else:
+        raise FileNotFoundError('\n'.join(('',
+          'libomp.dylib must be installed with your favourite package manager:',
+          '',
+          'Use "$ brew install libomp"',
+          'Or  "$ sudo port install libomp"',
+          ''
+        )))
+
+
 here = abspath(dirname(__file__))
 macros = [('PYAT', None)]
 with_openMP = False
@@ -35,9 +50,10 @@ else:
         omp_cflags = ['/openmp']
         omp_lflags = []
     elif sys.platform.startswith('darwin'):
-        omp_cflags = ['-Xpreprocessor', '-fopenmp']
+        omp_inc, omp_lib = select_omp()
+        omp_cflags = ['-Xpreprocessor', '-fopenmp', omp_inc]
         if omp_path is None:
-            omp_lflags = ['-lomp']
+            omp_lflags = ['-L' + omp_lib, '-Wl,-rpath,' + omp_lib, '-lomp']
         else:
             omp_lflags = ['-L' + omp_path, '-Wl,-rpath,' + omp_path, '-liomp5']
     else:


### PR DESCRIPTION
The OpenMP option on MacOS requires that `libomp` has been previously installed. This branch adds an error with information on how to do it if this has not been done.