### PR TITLE
New Matlab syntax

### DIFF
--- a/atmat/atutils/getflag.m
+++ b/atmat/atutils/getflag.m
@@ -1,4 +1,4 @@
-function [flag,opts] = getflag(opts,optname)
+function [flag,opts] = getflag(opts,key)
 %GETFLAG Check the presence of a flag in an argument list
 %
 %OPTION=GETFLAG(ARGS,OPTNAME)
@@ -21,8 +21,7 @@ function [flag,opts] = getflag(opts,optname)
 %
 %Dee also GETOPTION, GETARGS
 
-ok=strcmpi(optname,opts);
-flag=any(ok);
+ok = cellfun(@(v) (ischar(v) || isstring(v)) && strcmpi(v, key),opts);
+flag = any(ok);
 opts=opts(~ok);
 end
-

--- a/atmat/atutils/getoption.m
+++ b/atmat/atutils/getoption.m
@@ -39,7 +39,8 @@ else
         value=atoptions.instance().(key);
     end
     if iscell(opts)
-        ok=[strcmpi(key,opts(1:end-1)) false];  % option name cannot be the last argument
+        ok=[cellfun(@(v) (ischar(v) || isstring(v)) && strcmpi(v, key), ...
+            opts(1:end-1)) false];  % option name cannot be the last argument
         if any(ok)
             okval=circshift(ok,[0,1]);
             value=opts{find(okval,1,'last')};

--- a/atoctave/isstring.m
+++ b/atoctave/isstring.m
@@ -1,0 +1,10 @@
+function ok = isstring(~)
+%ISSTRING Determine whether input is string array
+%
+%The STRING type is not implemented in Octave
+%
+%   See also STRING, ISCHAR, ISCELLSTR.
+
+ok = false;
+end
+


### PR DESCRIPTION
Matlab 2021a accepts a new syntax for (key, value) argument pairs:

`>> val=func(…, 'key', value, )`
can now be written as:
`>> val=func(…, key=value, …)`

`getoption` and `getflag` are modified to accept this.
