### PR TITLE
find_m66 with radiation off

### DIFF
--- a/atmat/atphysics/LinearOptics/findm66.m
+++ b/atmat/atphysics/LinearOptics/findm66.m
@@ -47,7 +47,12 @@ if length(varargs) >= 2	% FINDM66(RING,REFPTS,ORBITIN)
 end
 
 if  isempty(R0)
-    R0 = findorbit6(LATTICE,'XYStep',XYStep,'DPStep',DPStep);
+    cavities = atgetcells(LATTICE, 'PassMethod', @(elem,pass) endsWith(pass, 'CavityPass'));
+    if any(cavities)
+        R0 = findorbit6(LATTICE,'XYStep',XYStep,'DPStep',DPStep);
+    else
+        [~, R0] = findorbit4(LATTICE,0.0,'XYStep',XYStep);
+    end
 end
 
 if length(varargs) >= 1	% FINDM66(RING,REFPTS)

--- a/atmat/atphysics/LinearOptics/findm66.m
+++ b/atmat/atphysics/LinearOptics/findm66.m
@@ -47,8 +47,7 @@ if length(varargs) >= 2	% FINDM66(RING,REFPTS,ORBITIN)
 end
 
 if  isempty(R0)
-    cavities = atgetcells(LATTICE, 'PassMethod', @(elem,pass) endsWith(pass, 'CavityPass'));
-    if any(cavities)
+    if check_radiation(LATTICE)
         R0 = findorbit6(LATTICE,'XYStep',XYStep,'DPStep',DPStep);
     else
         [~, R0] = findorbit4(LATTICE,0.0,'XYStep',XYStep);

--- a/atmat/atphysics/NonLinearDynamics/atnuampl.m
+++ b/atmat/atphysics/NonLinearDynamics/atnuampl.m
@@ -15,6 +15,7 @@ function varargout=atnuampl(ring,ampl,xz,varargin)
 %ATNUAMPL(...,Name,Value)
 %   Uses additional options specified by one or more Name,Value pairs.
 %   Possible values are:
+%       orbit:  initial closed orbit
 %       nturns: specify the number of turns for tracking (default 256)
 %       method: specify the method for tune determination
 %               1: Highest peak in fft
@@ -26,23 +27,28 @@ function varargout=atnuampl(ring,ampl,xz,varargin)
 
 lab={'x^2','p_x^2','z^2','p_z^2'};
 if nargin < 3, xz=1; end
-if ~isempty(varargin) && isnumeric(varargin{1})
-    orbit=varargin{1};
-    varargin(1)=[];
-else
-    warning off MATLAB:singularMatrix
-    orbit=findorbit6(ring);
-    warning on MATLAB:singularMatrix
-    if ~all(isfinite(orbit))
-        orbit=zeros(6,1);
-        orbit(1:5)=findsyncorbit(ring,0);
+[nturns,varargs]=getoption(varargin,'nturns',256);
+[method,varargs]=getoption(varargs,'method',3);
+[orbit,varargs]=getoption(varargs,'orbit',[]);
+
+if ~isempty(varargs) && isnumeric(varargs{1})	% ATNUAMPL(RING,AMPLITUDE,XZ,ORBIT)
+    orbit = varargs{1};
+    varargs(1)=[];
+end
+
+if isempty(orbit)
+    cavities = atgetcells(LATTICE, 'PassMethod', @(elem,pass) endsWith(pass, 'CavityPass'));
+    if any(cavities)
+        orbit=findorbit6(ring);
+        dp=orbit(5);
+    else
+        dp=0.0;
+        [~, orbit]=findorbit4(ring, dp);
     end
 end
-[nturns,varargin]=getoption(varargin,'nturns',256);
-[method,varargin]=getoption(varargin,'method',3);
 
 [~,nbper]=atenergy(ring);
-[lindata,fractune0]=atlinopt(ring,0,1:length(ring)+1);
+[lindata,fractune0]=atlinopt(ring,dp,1:length(ring)+1, 'orbit', orbit);
 tune0=nbper*lindata(end).mu/2/pi;
 offs=[nbper -nbper];
 siza=size(ampl);
@@ -61,7 +67,7 @@ if nargout > 0
     varargout={reshape(tunetrack(:,1),siza),reshape(tunetrack(:,2),siza)};
 else
     inttunes=floor(tune0);
-    plot((ampl.*ampl)',tunetrack-inttunes(ones(nampl,1),:),'o-',varargin{:});
+    plot((ampl.*ampl)',tunetrack-inttunes(ones(nampl,1),:),'o-',varargs{:});
     legend('\nu_x','\nu_z');
     xlabel(lab{xz});
     ylabel('\nu');

--- a/atmat/atphysics/Orbit/check_radiation.m
+++ b/atmat/atphysics/Orbit/check_radiation.m
@@ -1,0 +1,46 @@
+function [radon,ring]=check_radiation(ring,onoff,varargin)
+%CHECK_RADIATION	Check the radiation state of a ring
+%
+%RAD=CHECK_RADIATION(RING) Return the radiation state of RING (true/false)
+%
+%RAD=CHECK_RADIATION(RING,ONOFF) Generate an error if RAD is different of ONOFF
+%
+% ONOFF:    Desired radiation state
+%
+%[RAD,NEWRING]=CHECK_RADIATION(RING,ONOFF,'force')
+%   Convert RING to the desired state using default options
+%
+% ONOFF:    Desired radiation state
+
+force=getflag(varargin,'force');
+radon=false;
+for i=1:length(ring)
+    passmethod=ring{i}.PassMethod;
+    if endsWith(passmethod, {'RadPass', 'CavityPass', 'QuantDiffPass'})
+        radon=true;
+        break;
+    end
+end
+
+if nargin >= 2
+    if xor(radon,onoff)
+        if force
+            if onoff
+                ring=atradon(ring);
+            else
+                ring=atradoff(ring);
+            end
+        else
+            error('AT:Radiation',['Radiation must be ' boolstring(onoff)])
+        end
+    end
+end
+
+    function bstr=boolstring(onoff)
+        if onoff
+            bstr='ON';
+        else
+            bstr='OFF';
+        end
+    end
+end

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -143,8 +143,7 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     if orbit is None:
-        cavities = get_cells(ring, iscavity)
-        if numpy.any(cavities):
+        if ring.radiation:
             orbit, _ = find_orbit6(ring, keep_lattice=keep_lattice,
                                    XYStep=xy_step, DPStep=dp_step)
         else:

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -5,7 +5,7 @@ A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 
 import numpy
-from at.lattice import Lattice, uint32_refpts, get_refpts, DConstant
+from at.lattice import Lattice, uint32_refpts, get_cells, get_refpts, DConstant
 from at.lattice.elements import Bend, M66
 from at.tracking import lattice_pass, element_pass
 from at.physics import find_orbit4, find_orbit6, jmat, symplectify
@@ -137,11 +137,19 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
 
     See also find_m44, find_orbit6
     """
+    def iscavity(elem):
+        return elem.PassMethod.endswith('CavityPass')
+
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     if orbit is None:
-        orbit, _ = find_orbit6(ring, keep_lattice=keep_lattice,
-                               XYStep=xy_step, DPStep=dp_step)
+        cavities = get_cells(ring, iscavity)
+        if numpy.any(cavities):
+            orbit, _ = find_orbit6(ring, keep_lattice=keep_lattice,
+                                   XYStep=xy_step, DPStep=dp_step)
+        else:
+            orbit, _ = find_orbit4(ring, 0.0, keep_lattice=keep_lattice,
+                                   XYStep=xy_step)
         keep_lattice = True
 
     # Construct matrix of plus and minus deltas


### PR DESCRIPTION
`find_m66` should work with or without radiation. The reference orbit is now chosen depending on the presence of a RF cavity: if there is at least one cavity, orbit6 is used. Otherwise, orbit4 is used.