### PR TITLE
Wiggler detection in old-style lattices

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -30,7 +30,11 @@ newring = ring;
 % Indices of all cavity
 indrfc=findcells(ring,'Class','RFCavity');
 
-[E0,ncells,~,~,U0]=atenergy(ring); %#ok<ASGLU>
+if radflag
+    [~,ncells,~,~,U0]=atenergy(ring);
+else
+    [~,ncells]=atenergy(ring);
+end
 % gamma0=E0/me_EV;
 % beta0=sqrt(gamma0^2-1)/gamma0;
 

--- a/atmat/atphysics/Radiation/WigglerRadiation.m
+++ b/atmat/atphysics/Radiation/WigglerRadiation.m
@@ -19,7 +19,8 @@ nstep=60;
 e_mass=PhysConstant.electron_mass_energy_equivalent_in_MeV.value*1e6;	% eV
 cspeed = PhysConstant.speed_of_light_in_vacuum.value;                   % m/s
 
-iswiggler=@(elem) strcmp(elem.Class,'Wiggler') && ~strcmp(elem.PassMethod,'DriftPass');
+iswiggler=@(elem) isfield(elem,'Class') && strcmp(elem.Class,'Wiggler') ...
+              && ~strcmp(elem.PassMethod,'DriftPass');
 wigglers=cellfun(iswiggler, ring);
 if any(wigglers)
     energy=unique(atgetfieldvalues(ring(wigglers),'Energy'));

--- a/atmat/atphysics/Radiation/atenergy.m
+++ b/atmat/atphysics/Radiation/atenergy.m
@@ -101,7 +101,8 @@ if nargout >= 5
     lendp=atgetfieldvalues(ring(dipoles),'Length');
     I2d=sum(abs(theta.*theta./lendp));
     % Wiggler radiation
-    iswiggler=@(elem) strcmp(elem.Class,'Wiggler') && ~strcmp(elem.PassMethod,'DriftPass');
+    iswiggler=@(elem) isfield(elem,'Class') && strcmp(elem.Class,'Wiggler') ...
+                   && ~strcmp(elem.PassMethod,'DriftPass');
     wigglers=cellfun(iswiggler, ring);
     I2w=sum(cellfun(@wiggler_i2,ring(wigglers)));
     % Additional radiation


### PR DESCRIPTION
`atenergy` and the computation of energy loss crash for lattices where wiggler don't have a 'Class' attribute. Now wigglers will be ignored for energy loss computation if they don't have a class attribute 