### PR TITLE
Improvement of the initial orbit guess in find_orbit6

### DIFF
--- a/atmat/attrack/atpass.c
+++ b/atmat/attrack/atpass.c
@@ -281,7 +281,13 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     else {
         lhist=0;
     }
-
+    if (!mxIsDouble(INITCONDITIONS) || mxIsComplex(INITCONDITIONS)) {
+        mexErrMsgIdAndTxt("Atpass:WrongType","RIN must be real");
+    }
+    if (mxGetM(INITCONDITIONS) != 6) {
+        mexErrMsgIdAndTxt("Atpass:WrongSize","RIN must have 6 rows");
+    }
+    
     mexAtExit(cleanup);
 
     if (new_lattice) {

--- a/atmat/attrack/linepass.m
+++ b/atmat/attrack/linepass.m
@@ -71,10 +71,6 @@ function [Rout,varargout] = linepass(line,Rin,varargin)
 %
 % See also: RINGPASS
 
-% Check input arguments
-if size(Rin,1)~=6
-    error('Matrix of initial conditions, the second argument, must have 6 rows');
-end
 [keeplattice,args]=getflag(varargin, 'KeepLattice');
 [dummy,args]=getflag(args,'reuse');	%#ok<ASGLU> % Kept for compatibility and ignored
 [nhist,args]=getoption(args,'nhist',1);

--- a/atmat/attrack/ringpass.m
+++ b/atmat/attrack/ringpass.m
@@ -64,11 +64,6 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 %
 % See also: LINEPASS
 
-% Check input arguments
-if size(Rin,1)~=6
-    error('Matrix of initial conditions, the second argument, must have 6 rows');
-end
-
 [keeplattice,args]=getflag(varargin, 'KeepLattice');
 [dummy,args]=getflag(args,'reuse');	%#ok<ASGLU> % Kept for compatibility and ignored
 [silent,args]=getflag(args, 'silent');

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -2,6 +2,8 @@
 Accelerator physics functions
 """
 from math import sqrt, pi
+# noinspection PyUnresolvedReferences
+from scipy.constants import c as clight
 from scipy.constants import physical_constants as cst
 
 _e_radius = cst['classical electron radius'][0]
@@ -13,8 +15,9 @@ Cq = 55 / 32 / sqrt(3) * _hbar / e_mass * 1.0e-9                     # m
 
 # noinspection PyUnresolvedReferences
 from ..lattice import DConstant     # For backward compatibility
-from .orbit import *
 from .amat import *
+from .energy_loss import *
+from .orbit import *
 from .matrix import *
 from .linear import *
 from .ring_parameters import *

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -1,0 +1,103 @@
+import sys
+from math import sqrt, pi
+import numpy
+from at.lattice import Lattice, Dipole, Wiggler, RFCavity
+from at.lattice import check_radiation, AtError
+from at.tracking import lattice_pass
+from at.physics import clight, Cgamma, e_mass
+
+__all__ = ['get_energy_loss', 'set_cavity_phase']
+
+
+def get_energy_loss(ring, method='integral'):
+    """Compute the energy loss per turn [eV]
+
+    PARAMETERS
+        ring                        lattice description
+
+    KEYWORDS
+        method='integral'           method for energy loss computation
+            'integral': The losses are obtained from
+                Losses = Cgamma / 2pi * EGeV^4 * i2
+                Takes into account bending magnets and wigglers.
+            'tracking': The losses are obtained by tracking without cavities.
+                Needs radiation ON, takes into account all radiating elements.
+    """
+    def integral(ring):
+        """Losses = Cgamma / 2pi * EGeV^4 * i2
+        """
+
+        def wiggler_i2(wiggler):
+            rhoinv = wiggler.Bmax / Brho
+            coefh = wiggler.By[1, :]
+            coefv = wiggler.Bx[1, :]
+            return wiggler.Length * (numpy.sum(coefh * coefh) + numpy.sum(
+                coefv*coefv)) * rhoinv ** 2 / 2
+
+        def dipole_i2(dipole):
+            return dipole.BendingAngle ** 2 / dipole.Length
+
+        Brho = sqrt(ring.energy**2 - e_mass**2) / clight
+        i2 = 0.0
+        for el in ring:
+            if isinstance(el, Dipole):
+                i2 += dipole_i2(el)
+            elif isinstance(el, Wiggler) and el.PassMethod != 'DriftPass':
+                i2 += wiggler_i2(el)
+        e_loss = Cgamma / 2.0 / pi * ring.energy ** 4 * i2
+        return e_loss
+
+    @check_radiation(True)
+    def tracking(ring):
+        """Losses from tracking
+        """
+        ringtmp = ring.radiation_off(dipole_pass=None,
+                                     quadrupole_pass=None,
+                                     wiggler_pass=None,
+                                     sextupole_pass=None,
+                                     octupole_pass=None,
+                                     copy=True)
+        o0 = numpy.zeros(6)
+        o6 = numpy.squeeze(lattice_pass(ringtmp, o0, refpts=len(ringtmp)))
+        return -o6[4] * ring.energy
+
+    if method == 'integral':
+        return ring.periodicity * integral(ring)
+    elif method == 'tracking':
+        return ring.periodicity * tracking(ring)
+    else:
+        raise AtError('Invalid method: {}'.format(method))
+
+
+def set_cavity_phase(ring, method='integral', refpts=None):
+    """
+   Adjust the TimeLag attribute of RF cavities based on frequency,
+   voltage and energy loss per turn, so that the synchronous phase is zero.
+   An error occurs if all cavities do not have the same frequency.
+
+    PARAMETERS
+        ring        lattice description
+
+    KEYWORDS
+        refpts=None Cavity location. This allows to ignore harmonic cavities
+    """
+    if refpts is None:
+        cavities = [elem for elem in ring if isinstance(elem, RFCavity)]
+    else:
+        cavities = ring[refpts]
+    rfv = ring.periodicity*sum(elem.Voltage for elem in cavities)
+    freq = numpy.unique(numpy.array([elem.Frequency for elem in cavities]))
+    if len(freq) > 1:
+        raise AtError('RF frequency not equal for all cavities')
+    print("\nThis function modifies the time reference\n"
+          "This should be avoided, you have been warned!\n",
+          file=sys.stderr)
+    u0 = get_energy_loss(ring, method=method)
+    timelag = clight / (2*pi*freq) * numpy.arcsin(u0/rfv)
+    for elem in cavities:
+        elem.TimeLag = timelag
+
+
+Lattice.get_energy_loss = get_energy_loss
+Lattice.energy_loss = property(get_energy_loss)
+Lattice.set_cavity_phase = set_cavity_phase

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -1,19 +1,18 @@
 """
 Radiation and equilibrium emittances
 """
-import sys
 from math import sin, cos, tan, sqrt, sinh, cosh, pi
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
-from scipy.constants import c as clight
 from at.lattice import Lattice, check_radiation, uint32_refpts
-from at.lattice import elements, AtError
+from at.lattice import Element, Dipole, Wiggler
 from at.tracking import lattice_pass
-from at.physics import find_orbit6, find_m66, find_elem_m66, get_tunes_damp
-from at.physics import Cgamma, linopt, find_mpole_raddiff_matrix, e_mass
+from at.physics import clight, e_mass, get_tunes_damp
+from at.physics import find_orbit6, find_m66, find_elem_m66
+from at.physics import linopt, find_mpole_raddiff_matrix
 
 __all__ = ['ohmi_envelope', 'get_radiation_integrals', 'quantdiffmat',
-           'get_energy_loss', 'gen_quantdiff_elem', 'set_cavity_phase']
+           'gen_quantdiff_elem']
 
 _NSTEP = 60  # nb slices in a wiggler period
 
@@ -338,71 +337,11 @@ def get_radiation_integrals(ring, dp=0.0, twiss=None):
         raise ValueError('length of Twiss data should be {0}'
                          .format(len(ring) + 1))
     for (el, vini, vend) in zip(ring, twiss[:-1], twiss[1:]):
-        if isinstance(el, elements.Dipole) and el.BendingAngle != 0.0:
+        if isinstance(el, Dipole) and el.BendingAngle != 0.0:
             integrals += dipole_radiation(el, vini, vend)
-        elif isinstance(el, elements.Wiggler) and el.PassMethod != 'DriftPass':
+        elif isinstance(el, Wiggler) and el.PassMethod != 'DriftPass':
             integrals += wiggler_radiation(el, vini)
     return tuple(integrals)
-
-
-def get_energy_loss(ring, method='integral'):
-    """Compute the energy loss per turn [eV]
-
-    PARAMETERS
-        ring                        lattice description
-
-    KEYWORDS
-        method='integral'           method for energy loss computation
-            'integral': The losses are obtained from
-                Losses = Cgamma / 2pi * EGeV^4 * i2
-                Takes into account bending magnets and wigglers.
-            'tracking': The losses are obtained by tracking without cavities.
-                Needs radiation ON, takes into account all radiating elements.
-    """
-    def integral(ring):
-        """Losses = Cgamma / 2pi * EGeV^4 * i2
-        """
-
-        def wiggler_i2(wiggler):
-            rhoinv = wiggler.Bmax / Brho
-            coefh = wiggler.By[1, :]
-            coefv = wiggler.Bx[1, :]
-            return wiggler.Length * (numpy.sum(coefh * coefh) + numpy.sum(
-                coefv*coefv)) * rhoinv ** 2 / 2
-
-        def dipole_i2(dipole):
-            return dipole.BendingAngle ** 2 / dipole.Length
-
-        Brho = sqrt(ring.energy**2 - e_mass**2) / clight
-        i2 = 0.0
-        for el in ring:
-            if isinstance(el, elements.Dipole):
-                i2 += dipole_i2(el)
-            elif isinstance(el, elements.Wiggler) and el.PassMethod != 'DriftPass':
-                i2 += wiggler_i2(el)
-        e_loss = Cgamma / 2.0 / pi * ring.energy ** 4 * i2
-        return e_loss
-
-    @check_radiation(True)
-    def tracking(ring):
-        """Losses from tracking
-        """
-        ringtmp = ring.radiation_off(dipole_pass=None,
-                                     quadrupole_pass=None,
-                                     wiggler_pass=None,
-                                     sextupole_pass=None,
-                                     octupole_pass=None,
-                                     copy=True)
-        o0 = numpy.zeros(6)
-        o6 = numpy.squeeze(lattice_pass(ringtmp, o0, refpts=len(ringtmp)))
-        return -o6[4] * ring.energy
-
-    if method == 'integral':
-        return ring.periodicity * integral(ring)
-    elif method == 'tracking':
-        return ring.periodicity * tracking(ring)
-    else:
-        raise AtError('Invalid method: {}'.format(method))
 
 
 @check_radiation(True)
@@ -429,43 +368,9 @@ def gen_quantdiff_elem(ring, orbit=None):
     """
     dmat = quantdiffmat(ring, orbit=orbit)
     lmat = numpy.asfortranarray(_lmat(dmat))
-    diff_elem = elements.Element('Diffusion', Lmatp=lmat,
-                                 PassMethod='QuantDiffPass')
+    diff_elem = Element('Diffusion', Lmatp=lmat, PassMethod='QuantDiffPass')
     return diff_elem
-
-
-def set_cavity_phase(ring, method='integral', refpts=None):
-    """
-   Adjust the TimeLag attribute of RF cavities based on frequency,
-   voltage and energy loss per turn, so that the synchronous phase is zero.
-   An error occurs if all cavities do not have the same frequency.
-
-    PARAMETERS
-        ring        lattice description
-
-    KEYWORDS
-        refpts=None Cavity location. This allows to ignore harmonic cavities
-    """
-    if refpts is None:
-        cavities = [elem for elem in ring if
-                    isinstance(elem, elements.RFCavity)]
-    else:
-        cavities=ring[refpts]
-    rfv = ring.periodicity*sum(elem.Voltage for elem in cavities)
-    freq = numpy.unique(numpy.array([elem.Frequency for elem in cavities]))
-    if len(freq) > 1:
-        raise AtError('RF frequency not equal for all cavities')
-    print("\nThis function modifies the time reference\n"
-          "This should be avoided, you have been warned!\n",
-          file=sys.stderr)
-    u0 = get_energy_loss(ring, method=method)
-    timelag = clight / (2*pi*freq) * numpy.arcsin(u0/rfv)
-    for elem in cavities:
-        elem.TimeLag = timelag
 
 
 Lattice.ohmi_envelope = ohmi_envelope
 Lattice.get_radiation_integrals = get_radiation_integrals
-Lattice.get_energy_loss = get_energy_loss
-Lattice.energy_loss = property(get_energy_loss)
-Lattice.set_cavity_phase = set_cavity_phase

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -351,5 +351,6 @@ def test_ohmi_envelope(hmba_lattice, refpts):
                  atol=1E-8)
     assert_close(obs['orbit6'], [-2.63520320e-09, -1.45845186e-10, 0.00000000e+00, 0.00000000e+00, -6.69677955e-06, -5.88436653e-02],
                  atol=1E-20)
-    assert_close(obs['emitXY'], [1.320388928842210e-10, 0.0], atol=1e-20)
-    assert_close(obs['emitXYZ'], [1.322274370195967e-10, 0.0, 2.858474905044153e-06], atol=1e-20)
+    # Matlab results:
+    assert_close(obs['emitXY'], [1.320388935445164e-10, 0.0], atol=1e-20)
+    assert_close(obs['emitXYZ'], [1.322274374826649e-10, 0.0, 2.858473194929233e-06], atol=1e-20)


### PR DESCRIPTION
The initial orbit guess on `findorbit6` (Matlab) and `find_orbit6` (Python) can be easily improved by using the energy loss per turn to derive the time lag. By default, this energy loss is computing with tracking to ensure that the right radiating elements are taken into account.
This improvement should eliminate one of the bad reasons to modify the TimeLag attribute of the main cavities.

Additionally this revealed a naughty Matlab crash occurring when tracking complex trajectories. This is now properly rejected.