### PR TITLE
Upgrade of the Lattice object

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -185,12 +185,19 @@ class Lattice(list):
         return uint32_refs(refpts, len(self))
 
     def bool_refpts(self, refpts):
-        """Return a boolean numpy array of length n_elements + 1 where True elements
-        are selected.
+        """Return a boolean numpy array of length n_elements + 1 where
+        True elements are selected.
         """
         if callable(refpts):
             refpts = [refpts(el) for el in self]
         return bool_refs(refpts, len(self))
+
+    def rotate(self, n):
+        """Return a new lattice rotated left by n elements"""
+        if len(self) == 0:
+            return self.copy()
+        n = n % len(self)      # works for n<0
+        return self[n:] + self[:n]
 
     def update(self, *args, **kwargs):
         """Update the element attributes with the given arguments
@@ -335,9 +342,9 @@ class Lattice(list):
             None if copy == False
 
         KEYWORDS
-            copy=True           Return a shallow copy of the lattice. Only the
-                                modified attributes are replaced. Otherwise
-                                modify the lattice in-place.
+            copy=True   If True, return a shallow copy of the lattice. Only the
+                        modified elements are copied.
+                        If False, the modification is done in-place
         """
 
         def lattice_modify():
@@ -412,9 +419,12 @@ class Lattice(list):
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
             wiggler_pass='auto'         PassMethod set on wigglers
-            copy=False                  Return a shallow copy of the lattice and
-                                        replace only the modified attributes
-                                        Otherwise modify the lattice in-place.
+            copy=False  If False, the modification is done in-place,
+                        If True, return a shallow copy of the lattice. Only the
+                        radiating elements are copied with PassMethod modified.
+                        CAUTION: a shallow copy means that all non-radiating
+                        elements are shared with the original lattice.
+                        Any further modification will affect in both lattices.
 
             For PassMethod names, the convention is:
                 None            no change
@@ -464,9 +474,12 @@ class Lattice(list):
             dipole_pass='auto'          PassMethod set on dipoles
             quadrupole_pass=None        PassMethod set on quadrupoles
             wiggler_pass='auto'         PassMethod set on wigglers
-            copy=False                  Return a shallow copy of the lattice and
-                                        replace only the modified attributes
-                                        Otherwise modify the lattice in-place.
+            copy=False  If False, the modification is done in-place,
+                        If True, return a shallow copy of the lattice. Only the
+                        radiating elements are copied with PassMethod modified.
+                        CAUTION: a shallow copy means that all non-radiating
+                        elements are shared with the original lattice.
+                        Any further modification will affect in both lattices.
 
             For PassMethod names, the convention is:
                 None            no change
@@ -670,4 +683,4 @@ Lattice.bool_refpts = _bool_refs
 Lattice.get_elements = get_elements
 Lattice.get_s_pos = get_s_pos
 Lattice.select = refpts_iterator
-Lattice.count = refpts_len
+Lattice.refcount = refpts_len

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -20,6 +20,8 @@ from at.lattice import AtError, AtWarning
 from at.lattice import uint32_refpts as uint32_refs, bool_refpts as bool_refs
 from at.lattice import refpts_iterator, refpts_len
 from at.lattice import elements, get_s_pos, get_elements
+# noinspection PyProtectedMember
+from .utils import _uint32_refs, _bool_refs
 
 TWO_PI_ERROR = 1.E-4
 
@@ -663,6 +665,8 @@ def params_filter(params, elem_iterator, *args):
         params['periodicity'] = periodicity
 
 
+Lattice.uint32_refpts = _uint32_refs
+Lattice.bool_refpts = _bool_refs
 Lattice.get_elements = get_elements
 Lattice.get_s_pos = get_s_pos
 Lattice.select = refpts_iterator

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -99,6 +99,20 @@ def uint32_refpts(refpts, n_elements):
     return refs
 
 
+# Private function accepting a callable for refpts
+def _uint32_refs(ring, refpts):
+    """"Return a uint32 numpy array containing the indices of the selected
+    elements. refpts may be:
+
+    1) a integer or a sequence of integers (0 indicating the first element)
+    2) a sequence of booleans marking the selected elements
+    3) a callable f such that f(elem) is True for selected elements
+    """
+    if callable(refpts):
+        refpts = [refpts(el) for el in ring]
+    return uint32_refpts(refpts, len(ring))
+
+
 def bool_refpts(refpts, n_elements):
     """
     Return a boolean numpy array of length n_elements + 1 where True elements
@@ -118,6 +132,20 @@ def bool_refpts(refpts, n_elements):
         brefpts = numpy.zeros(n_elements + 1, dtype=bool)
         brefpts[refs] = True
         return brefpts
+
+
+# Private function accepting a callable for refpts
+def _bool_refs(ring, refpts):
+    """Return a boolean numpy array of length n_elements + 1 where True elements
+    are selected. refpts may be:
+
+    1) a integer or a sequence of integers (0 indicating the first element)
+    2) a sequence of booleans marking the selected elements
+    3) a callable f such that f(elem) is True for selected elements
+    """
+    if callable(refpts):
+        refpts = [refpts(el) for el in ring]
+    return bool_refpts(refpts, len(ring))
 
 
 def checkattr(*args):
@@ -420,7 +448,7 @@ def get_s_pos(ring, refpts=None):
     s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
     # Prepend position at the start of the first element.
     s_pos = numpy.concatenate(([0.0], s_pos))
-    refpts = uint32_refpts(refpts, len(ring))
+    refpts = _uint32_refs(ring, refpts)
     return s_pos[refpts]
 
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -21,7 +21,8 @@ from fnmatch import fnmatch
 from at.lattice import elements
 
 __all__ = ['AtError', 'AtWarning', 'check_radiation', 'make_copy',
-           'uint32_refpts', 'bool_refpts', 'checkattr', 'checktype',
+           'uint32_refpts', 'bool_refpts',
+           'checkattr', 'checktype', 'checkname',
            'get_cells', 'get_elements', 'get_refpts', 'get_s_pos',
            'refpts_count', 'refpts_len', 'refpts_iterator',
            'set_shift', 'set_tilt', 'tilt_elem', 'shift_elem',


### PR DESCRIPTION
### Upgrade of the Lattice object:

#### New method and decorator
In preparation for a "copy" keyword in all functions functions modifying the lattice, the `Lattice` object has a new method:
`Lattice.replace(refpts)`
which returns a shallow copy of the lattice where the selected elements have been "deep copied" so that their modification will not affect the original lattice. Non-selected elements are common to both lattices.
Associated with that, a new decorator `make_copy(copy)` can be used to decorate any function like `func(ring,refpts,*args)` modifying the lattice so that it handles the copy keyword. See `set_value_refpts()` for an example.
As of today, the "copy" keyword is implemented on `Lattice.radiation_on()/off()` and `set_value_refpts()`. A series functions controlling the RF cavities is in preparation.

#### Upgraded methods
 A set of new or existing methods using `refpts` now accepts a 3rd way of specifying the points of interest:
1. integer or sequence of integer (sequence of indices)
2. sequence of booleans (logical mask)
3. filter function:  func(elem) returning True for selected elements. Such functions can be generated by the existing checktype, checkattr and check name functions.

`Lattice.select(refpts)`:  returns an iterator over the selected elements
_Example: `qp=ring.select(checktype(Quadrupole)` returns an iterator over all quadrupoles_
`Lattice.refcount(refpts)`: returns the number of selected elements
`Lattice.boolrefpts(refpts)`: conversion to a list of indices
`Lattice.uint32refpts(refpts)`: conversion to a logical mask
`Lattice.replace(refpts`): returns a new lattice with selected elements copied
'Lattice.get_s_pos(refpts): returns the location of selected elements
_Example: `s=ring.get_s_pos(checkname('MK*'))` returns the location of elements with name starting with MK_

This is also also valid for `get_value_refpts` and `set_value_refpts` `refpts_iterator`

#### Support for python 2 is removed
