### PR TITLE
Cavity access

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atSetCavityPhase.m
+++ b/atmat/atphysics/LongitudinalDynamics/atSetCavityPhase.m
@@ -31,6 +31,9 @@ warning('AT:CavityTimeLag',...
     ['\nThis function modifies the time reference\n',...
        'This should be avoided, you have been warned\n']);
 U0=atgetU0(ring,'periods',1,varargs);
+if U0 > rfv
+    error('AT:NoEnoughRFVoltage','Not enough RF voltage, unstable ring.');
+end
 timelag=clight / (2*pi*freq) * asin(U0/rfv);
 newring=atsetfieldvalues(ring,cavities,'TimeLag',timelag);
 end

--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -1,58 +1,135 @@
-function newring = atsetcavity(ring,rfv,radflag,HarmNumber)
-%ATSECAVITY Sets the synchronous phase of the cavity assuming radiation
+function ring = atsetcavity(ring,varargin)
+%ATSECAVITY Set the cavity parameters
 %
-%  newring = atsetcavity(ring,rfv, radflag,HarmNumber)
+%ATSETCAVITY may be used in two modes:
 %
-%  INPUTS
-%  1. ring       - Ring structure
-%  2. rfv        - RF-voltage in volts
-%  3. radflag    - 0/1: activat/desactivate radiation (atradon/atradoff)
-%  4. HarmNumber - Harmonic number
+%Upgrade mode
+%===================================================
+%NEWRING=ATSETCAVITY(RING,...,'Frequency',FREQUENCY,...)
+%   Set the cavity frequency [Hz].
 %
-%  OUTPUTS
-%  1. newring - Updated ring structure with nw RF parameters
+%NEWRING=ATSETCAVITY(RING,...,'Frequency','nominal',...)
+%   Set the cavity frequency to the nominal value according to
+%   circumference and harmonic number
+%
+%NEWRING=ATSETCAVITY(RING,...,'HarmNumber',HARM_NUMBER,...)
+%   Set the cavity harmonic number of the full ring (all cells)
+%   The harmonic number of each cavity is HARM_NUMBER / N_CELLS
+%
+%NEWRING=ATSETCAVITY(RING,...,'Voltage',VOLTAGE,...)
+%   Set the total voltage (all cells) [V]
+%   The voltage of each cavity is VOLTAGE / N_CAVITIES / N_CELLS
+%
+%NEWRING=ATSETCAVITY(RING,...,'TimeLag',TIMELAG,...)
+%   Set the time lag [m]
+%
+%NEWRING=ATSETCAVITY(RING,...,'refpts',CAVPTS)
+%   CAVPTS is the location of RF cavities. This allows to ignore harmonic
+%   cavities. The default is to use all cavities
 %
 %  NOTES
-%  1. All the N cavities will have a voltage rfv/N
-%  2. sets the synchronous phase of the cavity assuming radiation is turned
+%  1. In this mode, the radiation state of the lattice is not modified.
+%
+%
+%Compatibility mode
+%===================================================
+%NEWRING = ATSETCAVITY(RING,RFV,RADFLAG,HARM_NUMBER)
+%  RING         Ring structure
+%  RFV          RF voltage [V]
+%  RADFLAG      0/1: activate/desactivate radiation (atradon/atradoff)
+%  HARMNUMBER 	Harmonic number
+%
+%  NOTES
+%  1. This mode is deprecated and should be replaced by
+%       RING=ATSETCAVITY(RING,'Frequency','nominal',...
+%           'HarmNumber',HARM_NUMBER, 'Voltage',RFV)
+%       RING=atSetCavityPhase(RING) (optional)
+%       RING=atradon(RING)          (optional)
+%  2. All the N cavities will have a voltage RFV/N
+%  3. sets the synchronous phase of the cavity assuming radiation is turned
 %     on radflag says whether or not we want radiation on, which affects
 %     synchronous phase.
 %
-%  See also atsetRFcavity, atradon, atradoff, atgetU0
-
+%  See also atSetCavityPhase, atsetRFcavity, atradon, atradoff, atgetU0
 
 % Speed of light
 CLIGHT=PhysConstant.speed_of_light_in_vacuum.value;
-% me_EV=510998.928;
 
-newring = ring;
+[refpts,varargs]=getoption(varargin, 'refpts', atgetcells(ring, 'Frequency'));
+[frequency,varargs]=getoption(varargs, 'Frequency', []);
+[voltage,varargs]=getoption(varargs, 'Voltage', []);
+[harmnumber,varargs]=getoption(varargs, 'HarmNumber', []);
+[timelag,varargs]=getoption(varargs, 'TimeLag', []);
+
+if islogical(refpts)
+    refpts=find(refpts);
+end
 
 [~,ncells]=atenergy(ring);
-% gamma0=E0/me_EV;
-% beta0=sqrt(gamma0^2-1)/gamma0;
+cavities=ring(refpts);
+ncavs=length(cavities);
 
-L=findspos(ring,length(ring)+1);
-circ=L*ncells;
-%freq=(beta0*clight/circ)*HarmNumber;
-freq=(CLIGHT/circ)*HarmNumber;
-
-%now set cavity frequencies, Harmonic Number and RF Voltage
-indrfc=findcells(ring,'Class','RFCavity');
-for j=indrfc
-    newring{j}.Frequency=freq;
-    newring{j}.HarmNumber=HarmNumber;
-    newring{j}.Voltage=rfv/length(indrfc);
+if isempty(varargs)             % New syntax
+    if ncavs == 0
+        error('AT:NoCavity', 'No cavity found in the lattice');
+    end
+    if ~isempty(harmnumber)
+        cavities=atsetfieldvalues(cavities, 'HarmNumber', harmnumber/ncells);
+    end
+    if ~isempty(frequency)
+        if (ischar(frequency) || isstring(frequency)) && strcmp(frequency, 'nominal')
+            if isempty(harmnumber)
+                harmnumber=ncells*getfield(cavities,'HarmNumber');
+            end
+            circ=ncells*findspos(ring,length(ring)+1);
+            frequency = (CLIGHT/circ)*harmnumber;
+        end
+        cavities=atsetfieldvalues(cavities, 'Frequency', frequency);
+    end
+    if ~isempty(voltage)
+        cavities=atsetfieldvalues(cavities, 'Voltage', voltage/ncells/ncavs);
+    end
+    if ~isempty(timelag)
+        cavities=atsetfieldvalues(cavities, 'TimeLag', timelag);
+    end
+    ring(refpts)=cavities;
+else                            % Old syntax, for compatibility
+    % me_EV=510998.928;
+    
+    % gamma0=E0/me_EV;
+    % beta0=sqrt(gamma0^2-1)/gamma0;
+    [rfv,radflag,HarmNumber]=deal(varargin{:});
+    L=findspos(ring,length(ring)+1);
+    circ=L*ncells;
+    %freq=(beta0*clight/circ)*HarmNumber;
+    freq=(CLIGHT/circ)*HarmNumber;
+    
+    %now set cavity frequencies, Harmonic Number and RF Voltage
+    cavities=atsetfieldvalues(cavities, 'Frequency', freq);
+    cavities=atsetfieldvalues(cavities, 'HarmNumber', HarmNumber);
+    cavities=atsetfieldvalues(cavities, 'Voltage', rfv/ncavs);
+    ring(refpts)=cavities;
+    
+    %now set phaselags in cavities
+    if radflag
+        warning('AT:CavityTimeLag',...
+            ['\nThis function modifies the time reference\n',...
+            'This should be avoided, you have been warned\n']);
+        U0=atgetU0(ring);
+        timelag= (circ/(2*pi*HarmNumber))*asin(U0/(rfv));
+        ring=atradon(ring);  % set radiation on. nothing if radiation is already on
+    else
+        ring=atradoff(ring,'CavityPass');  % set radiation off. nothing if radiation is already off
+        timelag=0;
+    end
+    ring=atsetfieldvalues(ring, refpts, 'TimeLag', timelag);
 end
 
-%now set phaselags in cavities
-if radflag
-    U0=atgetU0(ring);
-    timelag= (circ/(2*pi*HarmNumber))*asin(U0/(rfv));
-    newring=atradon(newring);  % set radiation on. nothing if radiation is already on    
-else
-    newring=atradoff(newring,'CavityPass');  % set radiation off. nothing if radiation is already off
-    timelag=0;
-end
-
-newring=setcellstruct(newring,'TimeLag',indrfc,timelag);
+    function values=getfield(ring,attr)
+        values = unique(atgetfieldvalues(ring,attr));
+        if length(values) > 1
+            error('AT:IncompatibleValues','%s not equal for all cavities', attr);
+        end
+    end
+        
 end

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -8,3 +8,4 @@ from .options import DConstant
 from .elements import *
 from .utils import *
 from .lattice_object import *
+from .cavity_access import *

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import numpy
 from scipy.constants import c as clight
 from at.lattice import elements, AtError, checktype, make_copy, get_cells
@@ -5,7 +6,12 @@ from at.lattice import Lattice
 
 __all__ = ['get_rf_frequency', 'get_rf_harmonic_number', 'get_rf_voltage',
            'set_rf_frequency', 'set_rf_harmonic_number', 'set_rf_voltage',
-           'get_rf_timelag', 'set_rf_timelag', 'set_cavity']
+           'get_rf_timelag', 'set_rf_timelag', 'set_cavity', 'Frf']
+
+
+class Frf(Enum):
+    """Enum class for frequency setting"""
+    NOMINAL = 1
 
 
 def _get_rf_attr(ring, attr, cavpts=None):
@@ -69,9 +75,9 @@ def set_rf_frequency(ring, frequency, cavpts=None, copy=False):
 
     PARAMETERS
         ring                lattice description
-        frequency           RF frequency. The special value 'nominal' sets the
-                            frequency to the nominal value, given ring length
-                            and harmonic number.
+        frequency           RF frequency. The special enum value Frf.NOMINAL
+                            sets the frequency to the nominal value, given
+                            ring length and harmonic number.
 
     KEYWORDS
         cavpts=None         Cavity location. If None, use all cavities.
@@ -138,9 +144,9 @@ def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
         ring                lattice description
 
     KEYWORDS
-        Frequency=None      RF frequency. The special value 'nominal' sets the
-                            frequency to the nominal value, given ring length
-                            and harmonic number.
+        Frequency=None      RF frequency. The special enum value Frf.NOMINAL
+                            sets the frequency to the nominal value, given
+                            ring length and harmonic number.
         Voltage=None        RF voltage for the full ring.
         HarmNumber=None     Harmonic number for the full ring.
         TimeLag=None
@@ -157,14 +163,14 @@ def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
 
     if cavpts is None:
         cavpts = get_cells(ring, checktype(elements.RFCavity))
-    n_cavities = ring.count(cavpts)
+    n_cavities = ring.refcount(cavpts)
     if n_cavities < 1:
         raise AtError('No cavity found in the lattice')
     n_periods = ring.periodicity
 
     modif = {}
     if Frequency is not None:
-        if Frequency == 'nominal':
+        if Frequency is Frf.NOMINAL:
             Frequency = (clight / ring.circumference) * get_harm(HarmNumber)
         modif['Frequency'] = Frequency
     if HarmNumber is not None:

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -50,6 +50,7 @@ def get_rf_voltage(ring, cavpts=None):
         cavpts=None     location of RF cavities. If None, take all cavities.
                         This allows to ignore harmonic cavities
     """
+    _ = get_rf_frequency(ring, cavpts=cavpts)   # check single frequency
     vcell = sum(_get_rf_attr(ring, 'Voltage', cavpts=cavpts))
     return ring.periodicity * vcell
 

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -1,0 +1,200 @@
+import numpy
+from scipy.constants import c as clight
+from at.lattice import elements, AtError, checktype, make_copy, get_cells
+from at.lattice import Lattice
+
+__all__ = ['get_rf_frequency', 'get_rf_harmonic_number', 'get_rf_voltage',
+           'set_rf_frequency', 'set_rf_harmonic_number', 'set_rf_voltage',
+           'get_rf_timelag', 'set_rf_timelag', 'set_cavity']
+
+
+def _get_rf_attr(ring, attr, refpts=None):
+    if refpts is None:
+        refpts = checktype(elements.RFCavity)
+    cavities = ring.select(refpts)
+    return numpy.array([getattr(cavity, attr) for cavity in cavities])
+
+
+def _get_rf_unique_attr(ring, attr, refpts=None):
+    freq = numpy.unique(_get_rf_attr(ring, attr, refpts=refpts))
+    if len(freq) == 0:
+        raise AtError('No cavity found in the lattice')
+    elif len(freq) > 1:
+        raise AtError('{0} not equal for all cavities'.format(attr))
+    else:
+        return freq[0]
+
+
+def get_rf_frequency(ring, refpts=None):
+    """Return the RF frequency
+    KEYWORDS
+        refpts=None     location of RF cavities. If None, take all cavities.
+                        This allows to ignore harmonic cavities
+    """
+    return _get_rf_unique_attr(ring, 'Frequency', refpts=refpts)
+
+
+def get_rf_harmonic_number(ring, refpts=None):
+    """Return the RF harmonic number for the full ring
+    KEYWORDS
+        refpts=None     location of RF cavities. If None, take all cavities.
+                        This allows to ignore harmonic cavities
+    """
+    hcell = _get_rf_unique_attr(ring, 'HarmNumber', refpts=refpts)
+    return ring.periodicity * hcell
+
+
+def get_rf_voltage(ring, refpts=None):
+    """Return the total RF voltage for the full ring
+    KEYWORDS
+        refpts=None     location of RF cavities. If None, take all cavities.
+                        This allows to ignore harmonic cavities
+    """
+    vcell = sum(_get_rf_attr(ring, 'Voltage', refpts=refpts))
+    return ring.periodicity * vcell
+
+
+def get_rf_timelag(ring, refpts=None):
+    """Return the RF frequency
+    KEYWORDS
+        refpts=None     location of RF cavities. If None, take all cavities.
+                        This allows to ignore harmonic cavities
+    """
+    return _get_rf_unique_attr(ring, 'TimeLag', refpts=refpts)
+
+
+def set_rf_frequency(ring, frequency, refpts=None, copy=False):
+    """Set the RF frequency
+
+    PARAMETERS
+        ring                lattice description
+        frequency           RF frequency. The special value 'nominal' sets the
+                            frequency to the nominal value, given ring length
+                            and harmonic number.
+
+    KEYWORDS
+        refpts=None         Cavity location. If None, use all cavities.
+                            This allows to ignore harmonic cavities.
+        copy=False          If True, returns a shallow copy of ring with new
+                            cavity elements. Otherwise, modify ring in-place
+    """
+    return set_cavity(ring, Frequency=frequency, refpts=refpts, copy=copy)
+
+
+def set_rf_harmonic_number(ring, harm_number, refpts=None, copy=False):
+    """Set the RF harmonic number
+
+    PARAMETERS
+        ring                lattice description
+        harm_number         Harmonic number for the full ring
+
+    KEYWORDS
+        refpts=None         Cavity location. If None, use all cavities.
+                            This allows to ignore harmonic cavities.
+        copy=False          If True, returns a shallow copy of ring with new
+                            cavity elements. Otherwise, modify ring in-place
+    """
+    return set_cavity(ring, HarmNumber=harm_number, refpts=refpts, copy=copy)
+
+
+def set_rf_voltage(ring, voltage, refpts=None, copy=False):
+    """Set the RF voltage
+
+    PARAMETERS
+        ring                lattice description
+        voltage             Total RF voltage for the full ring
+
+    KEYWORDS
+        refpts=None         Cavity location. If None, use all cavities.
+                            This allows to ignore harmonic cavities.
+        copy=False          If True, returns a shallow copy of ring with new
+                            cavity elements. Otherwise, modify ring in-place
+    """
+    return set_cavity(ring, Voltage=voltage, refpts=refpts, copy=copy)
+
+
+def set_rf_timelag(ring, timelag, refpts=None, copy=False):
+    """Set the RF time lag
+
+    PARAMETERS
+        ring                lattice description
+        timelag
+
+    KEYWORDS
+        refpts=None         Cavity location. If None, use all cavities.
+                            This allows to ignore harmonic cavities.
+        copy=False          If True, returns a shallow copy of ring with new
+                            cavity elements. Otherwise, modify ring in-place
+    """
+    return set_cavity(ring, TimeLag=timelag, refpts=refpts, copy=copy)
+
+
+# noinspection PyPep8Naming
+def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
+               TimeLag=None, refpts=None, copy=False):
+    """
+    PARAMETERS
+        ring                lattice description
+
+    KEYWORDS
+        Frequency=None      RF frequency. The special value 'nominal' sets the
+                            frequency to the nominal value, given ring length
+                            and harmonic number.
+        Voltage=None        RF voltage for the full ring.
+        HarmNumber=None     Harmonic number for the full ring.
+        TimeLag=None
+        refpts=None         Cavity location. If None, use all cavities.
+                            This allows to ignore harmonic cavities.
+        copy=False          If True, returns a shallow copy of ring with new
+                            cavity elements. Otherwise, modify ring in-place
+    """
+    def get_harm(hcell):
+        if hcell is not None:
+            return hcell*n_periods
+        else:
+            return ring.get_rf_harmonic_number(refpts=refpts)
+
+    if refpts is None:
+        refpts = get_cells(ring, checktype(elements.RFCavity))
+    n_cavities = ring.count(refpts)
+    if n_cavities < 1:
+        raise AtError('No cavity found in the lattice')
+    n_periods = ring.periodicity
+
+    modif = {}
+    if Frequency is not None:
+        if Frequency == 'nominal':
+            Frequency = (clight / ring.circumference) * get_harm(HarmNumber)
+        modif['Frequency'] = Frequency
+    if HarmNumber is not None:
+        modif['HarmNumber'] = HarmNumber / n_periods
+    if TimeLag is not None:
+        modif['TimeLag'] = TimeLag
+    if Voltage is not None:
+        modif['Voltage'] = Voltage / n_periods / n_cavities
+
+    # noinspection PyShadowingNames
+    @make_copy(copy)
+    def apply(ring, refpts, modif):
+        for cavity in ring.select(refpts):
+            cavity.update(modif)
+
+    return apply(ring, refpts, modif)
+
+
+Lattice.get_rf_voltage = get_rf_voltage
+Lattice.get_rf_frequency = get_rf_frequency
+Lattice.get_rf_harmonic_number = get_rf_harmonic_number
+Lattice.get_rf_timelag = get_rf_timelag
+Lattice.set_rf_voltage = set_rf_voltage
+Lattice.set_rf_frequency = set_rf_frequency
+Lattice.set_rf_harmonic_number = set_rf_harmonic_number
+Lattice.set_rf_timelag = set_rf_timelag
+Lattice.set_cavity = set_cavity
+Lattice.voltage = property(get_rf_voltage, set_rf_voltage,
+                           doc="Total RF voltage of the full ring [V]")
+Lattice.harmonic_number = property(get_rf_harmonic_number,
+                                   set_rf_harmonic_number,
+                                   doc="Harmonic number of the full ring")
+Lattice.frequency = property(get_rf_frequency, set_rf_frequency,
+                             doc="RF frequency [Hz]")

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -8,15 +8,15 @@ __all__ = ['get_rf_frequency', 'get_rf_harmonic_number', 'get_rf_voltage',
            'get_rf_timelag', 'set_rf_timelag', 'set_cavity']
 
 
-def _get_rf_attr(ring, attr, refpts=None):
-    if refpts is None:
-        refpts = checktype(elements.RFCavity)
-    cavities = ring.select(refpts)
+def _get_rf_attr(ring, attr, cavpts=None):
+    if cavpts is None:
+        cavpts = checktype(elements.RFCavity)
+    cavities = ring.select(cavpts)
     return numpy.array([getattr(cavity, attr) for cavity in cavities])
 
 
-def _get_rf_unique_attr(ring, attr, refpts=None):
-    freq = numpy.unique(_get_rf_attr(ring, attr, refpts=refpts))
+def _get_rf_unique_attr(ring, attr, cavpts=None):
+    freq = numpy.unique(_get_rf_attr(ring, attr, cavpts=cavpts))
     if len(freq) == 0:
         raise AtError('No cavity found in the lattice')
     elif len(freq) > 1:
@@ -25,45 +25,45 @@ def _get_rf_unique_attr(ring, attr, refpts=None):
         return freq[0]
 
 
-def get_rf_frequency(ring, refpts=None):
+def get_rf_frequency(ring, cavpts=None):
     """Return the RF frequency
     KEYWORDS
-        refpts=None     location of RF cavities. If None, take all cavities.
+        cavpts=None     location of RF cavities. If None, take all cavities.
                         This allows to ignore harmonic cavities
     """
-    return _get_rf_unique_attr(ring, 'Frequency', refpts=refpts)
+    return _get_rf_unique_attr(ring, 'Frequency', cavpts=cavpts)
 
 
-def get_rf_harmonic_number(ring, refpts=None):
+def get_rf_harmonic_number(ring, cavpts=None):
     """Return the RF harmonic number for the full ring
     KEYWORDS
-        refpts=None     location of RF cavities. If None, take all cavities.
+        cavpts=None     location of RF cavities. If None, take all cavities.
                         This allows to ignore harmonic cavities
     """
-    hcell = _get_rf_unique_attr(ring, 'HarmNumber', refpts=refpts)
+    hcell = _get_rf_unique_attr(ring, 'HarmNumber', cavpts=cavpts)
     return ring.periodicity * hcell
 
 
-def get_rf_voltage(ring, refpts=None):
+def get_rf_voltage(ring, cavpts=None):
     """Return the total RF voltage for the full ring
     KEYWORDS
-        refpts=None     location of RF cavities. If None, take all cavities.
+        cavpts=None     location of RF cavities. If None, take all cavities.
                         This allows to ignore harmonic cavities
     """
-    vcell = sum(_get_rf_attr(ring, 'Voltage', refpts=refpts))
+    vcell = sum(_get_rf_attr(ring, 'Voltage', cavpts=cavpts))
     return ring.periodicity * vcell
 
 
-def get_rf_timelag(ring, refpts=None):
+def get_rf_timelag(ring, cavpts=None):
     """Return the RF frequency
     KEYWORDS
-        refpts=None     location of RF cavities. If None, take all cavities.
+        cavpts=None     location of RF cavities. If None, take all cavities.
                         This allows to ignore harmonic cavities
     """
-    return _get_rf_unique_attr(ring, 'TimeLag', refpts=refpts)
+    return _get_rf_unique_attr(ring, 'TimeLag', cavpts=cavpts)
 
 
-def set_rf_frequency(ring, frequency, refpts=None, copy=False):
+def set_rf_frequency(ring, frequency, cavpts=None, copy=False):
     """Set the RF frequency
 
     PARAMETERS
@@ -73,15 +73,15 @@ def set_rf_frequency(ring, frequency, refpts=None, copy=False):
                             and harmonic number.
 
     KEYWORDS
-        refpts=None         Cavity location. If None, use all cavities.
+        cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.
         copy=False          If True, returns a shallow copy of ring with new
                             cavity elements. Otherwise, modify ring in-place
     """
-    return set_cavity(ring, Frequency=frequency, refpts=refpts, copy=copy)
+    return set_cavity(ring, Frequency=frequency, cavpts=cavpts, copy=copy)
 
 
-def set_rf_harmonic_number(ring, harm_number, refpts=None, copy=False):
+def set_rf_harmonic_number(ring, harm_number, cavpts=None, copy=False):
     """Set the RF harmonic number
 
     PARAMETERS
@@ -89,15 +89,15 @@ def set_rf_harmonic_number(ring, harm_number, refpts=None, copy=False):
         harm_number         Harmonic number for the full ring
 
     KEYWORDS
-        refpts=None         Cavity location. If None, use all cavities.
+        cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.
         copy=False          If True, returns a shallow copy of ring with new
                             cavity elements. Otherwise, modify ring in-place
     """
-    return set_cavity(ring, HarmNumber=harm_number, refpts=refpts, copy=copy)
+    return set_cavity(ring, HarmNumber=harm_number, cavpts=cavpts, copy=copy)
 
 
-def set_rf_voltage(ring, voltage, refpts=None, copy=False):
+def set_rf_voltage(ring, voltage, cavpts=None, copy=False):
     """Set the RF voltage
 
     PARAMETERS
@@ -105,15 +105,15 @@ def set_rf_voltage(ring, voltage, refpts=None, copy=False):
         voltage             Total RF voltage for the full ring
 
     KEYWORDS
-        refpts=None         Cavity location. If None, use all cavities.
+        cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.
         copy=False          If True, returns a shallow copy of ring with new
                             cavity elements. Otherwise, modify ring in-place
     """
-    return set_cavity(ring, Voltage=voltage, refpts=refpts, copy=copy)
+    return set_cavity(ring, Voltage=voltage, cavpts=cavpts, copy=copy)
 
 
-def set_rf_timelag(ring, timelag, refpts=None, copy=False):
+def set_rf_timelag(ring, timelag, cavpts=None, copy=False):
     """Set the RF time lag
 
     PARAMETERS
@@ -121,17 +121,17 @@ def set_rf_timelag(ring, timelag, refpts=None, copy=False):
         timelag
 
     KEYWORDS
-        refpts=None         Cavity location. If None, use all cavities.
+        cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.
         copy=False          If True, returns a shallow copy of ring with new
                             cavity elements. Otherwise, modify ring in-place
     """
-    return set_cavity(ring, TimeLag=timelag, refpts=refpts, copy=copy)
+    return set_cavity(ring, TimeLag=timelag, cavpts=cavpts, copy=copy)
 
 
 # noinspection PyPep8Naming
 def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
-               TimeLag=None, refpts=None, copy=False):
+               TimeLag=None, cavpts=None, copy=False):
     """
     PARAMETERS
         ring                lattice description
@@ -143,7 +143,7 @@ def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
         Voltage=None        RF voltage for the full ring.
         HarmNumber=None     Harmonic number for the full ring.
         TimeLag=None
-        refpts=None         Cavity location. If None, use all cavities.
+        cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.
         copy=False          If True, returns a shallow copy of ring with new
                             cavity elements. Otherwise, modify ring in-place
@@ -152,11 +152,11 @@ def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
         if hcell is not None:
             return hcell*n_periods
         else:
-            return ring.get_rf_harmonic_number(refpts=refpts)
+            return ring.get_rf_harmonic_number(cavpts=cavpts)
 
-    if refpts is None:
-        refpts = get_cells(ring, checktype(elements.RFCavity))
-    n_cavities = ring.count(refpts)
+    if cavpts is None:
+        cavpts = get_cells(ring, checktype(elements.RFCavity))
+    n_cavities = ring.count(cavpts)
     if n_cavities < 1:
         raise AtError('No cavity found in the lattice')
     n_periods = ring.periodicity
@@ -175,11 +175,11 @@ def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
 
     # noinspection PyShadowingNames
     @make_copy(copy)
-    def apply(ring, refpts, modif):
-        for cavity in ring.select(refpts):
+    def apply(ring, cavpts, modif):
+        for cavity in ring.select(cavpts):
             cavity.update(modif)
 
-    return apply(ring, refpts, modif)
+    return apply(ring, cavpts, modif)
 
 
 Lattice.get_rf_voltage = get_rf_voltage

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -11,7 +11,7 @@ __all__ = ['get_rf_frequency', 'get_rf_harmonic_number', 'get_rf_voltage',
 
 class Frf(Enum):
     """Enum class for frequency setting"""
-    NOMINAL = 1
+    NOMINAL = 'nominal'
 
 
 def _get_rf_attr(ring, attr, cavpts=None):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -297,20 +297,6 @@ class Lattice(list):
         return self.periodicity * self.get_s_pos(len(self))[0]
 
     @property
-    def voltage(self):
-        """Total accelerating voltage"""
-        volts = [elem.Voltage for elem in self if
-                 isinstance(elem, elements.RFCavity)]
-        return self.periodicity * sum(volts)
-
-    @property
-    def harmonic_number(self):
-        """Harmonic number"""
-        harms = [elem.HarmNumber for elem in self if
-                 isinstance(elem, elements.RFCavity)]
-        return self.periodicity * harms[0] if harms else None
-
-    @property
     def radiation(self):
         """If True, at least one element modifies the beam energy"""
         try:

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -1,4 +1,5 @@
 import sys
+from enum import Enum
 from warnings import warn
 from math import sqrt, pi
 import numpy
@@ -7,21 +8,28 @@ from at.lattice import check_radiation, set_cavity, AtError
 from at.tracking import lattice_pass
 from at.physics import clight, Cgamma, e_mass
 
-__all__ = ['get_energy_loss', 'set_cavity_phase']
+__all__ = ['get_energy_loss', 'set_cavity_phase', 'ELossMethod']
 
 
-def get_energy_loss(ring, method='integral'):
+class ELossMethod(Enum):
+    """Enum class for energy loss methods"""
+    INTEGRAL = 1
+    TRACKING = 2
+
+
+def get_energy_loss(ring, method=ELossMethod.INTEGRAL):
     """Compute the energy loss per turn [eV]
 
     PARAMETERS
         ring                        lattice description
 
     KEYWORDS
-        method='integral'           method for energy loss computation
-            'integral': The losses are obtained from
+        method=ELossMethod.INTEGRAL method for energy loss computation
+            The enum class ELossMethod declares 2 values
+            INTEGRAL: The losses are obtained from
                 Losses = Cgamma / 2pi * EGeV^4 * i2
                 Takes into account bending magnets and wigglers.
-            'tracking': The losses are obtained by tracking without cavities.
+            TRACKING: The losses are obtained by tracking without cavities.
                 Needs radiation ON, takes into account all radiating elements.
     """
     def integral(ring):
@@ -62,15 +70,19 @@ def get_energy_loss(ring, method='integral'):
         o6 = numpy.squeeze(lattice_pass(ringtmp, o0, refpts=len(ringtmp)))
         return -o6[4] * ring.energy
 
-    if method == 'integral':
+    if isinstance(method, str):
+        method = ELossMethod[method.upper()]
+        warn(FutureWarning('You should use {0!s}'.format(method)))
+    if method is ELossMethod.INTEGRAL:
         return ring.periodicity * integral(ring)
-    elif method == 'tracking':
+    elif method == ELossMethod.TRACKING:
         return ring.periodicity * tracking(ring)
     else:
         raise AtError('Invalid method: {}'.format(method))
 
 
-def set_cavity_phase(ring, method='integral', refpts=None, cavpts=None, copy=False):
+def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
+                     refpts=None, cavpts=None, copy=False):
     """
    Adjust the TimeLag attribute of RF cavities based on frequency,
    voltage and energy loss per turn, so that the synchronous phase is zero.
@@ -80,7 +92,8 @@ def set_cavity_phase(ring, method='integral', refpts=None, cavpts=None, copy=Fal
         ring        lattice description
 
     KEYWORDS
-        method='integral'   method for energy loss computation.
+        method=ELossMethod.INTEGRAL
+                            method for energy loss computation.
                             See "get_energy_loss".
         cavpts=None         Cavity location. If None, use all cavities.
                             This allows to ignore harmonic cavities.

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -92,6 +92,8 @@ def set_cavity_phase(ring, method='integral', refpts=None, copy=False):
           "This should be avoided, you have been warned!\n",
           file=sys.stderr)
     u0 = get_energy_loss(ring, method=method)
+    if u0 > rfv:
+        raise AtError('Nor enough RF voltage: unstable ring')
     timelag = clight / (2*pi*freq) * numpy.arcsin(u0/rfv)
     set_cavity(ring, TimeLag=timelag, refpts=refpts, copy=copy)
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -8,7 +8,7 @@ import scipy.constants as constants
 from at.lattice import AtWarning, AtError, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
-from at.physics import get_energy_loss
+from at.physics import get_energy_loss, ELossMethod
 import warnings
 
 __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6']
@@ -283,7 +283,10 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
         keep_lattice    Assume no lattice change since the previous tracking.
                         Default: False
         guess           Initial value for the closed orbit. It may help
-                        convergence. Default: (0, 0, 0, 0)
+                        convergence. The default is computed from the energy
+                        loss of the ring
+        method          Method for energy loss computation (see get_energy_loss)
+                        default: ELossMethod.TRACKING
         convergence     Convergence criterion. Default: 1.e-12
         max_iterations  Maximum number of iterations. Default: 20
         XYStep          Step size. Default: DConstant.XYStep
@@ -296,7 +299,7 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
-    method = kwargs.pop('method', 'tracking')
+    method = kwargs.pop('method', ELossMethod.TRACKING)
 
     # Get revolution period
     l0 = get_s_pos(ring, len(ring))

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -315,6 +315,7 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
         try:
             rfv = ring.get_rf_voltage(cavpts=cavpts)
         except AtError:
+            # Cannot compute synchronous phase: keep zeros(6,)
             pass
         else:
             u0 = get_energy_loss(ring, method=method)

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -232,7 +232,7 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     return ref_in, all_points
 
 
-def find_orbit6(ring, refpts=None, guess=None, **kwargs):
+def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
     """find_orbit6 finds the closed orbit in the full 6-D phase space
     by numerically solving  for a fixed point of the one turn
     map M calculated with lattice_pass
@@ -298,7 +298,7 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     method = kwargs.pop('method', 'tracking')
 
-    # Get evolution period
+    # Get revolution period
     l0 = get_s_pos(ring, len(ring))
     cavities = [elem for elem in ring if isinstance(elem, elements.RFCavity)]
     if len(cavities) == 0:
@@ -308,12 +308,16 @@ def find_orbit6(ring, refpts=None, guess=None, **kwargs):
     harm_number = cavities[0].HarmNumber
 
     if guess is None:
-        rfv = ring.periodicity * sum(elem.Voltage for elem in cavities)
-        u0 = get_energy_loss(ring, method=method)
-        if u0 > rfv:
-            raise AtError('Missing RF voltage: unstable ring')
         ref_in = numpy.zeros((6,), order='F')
-        ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
+        try:
+            rfv = ring.get_rf_voltage(cavpts=cavpts)
+        except AtError:
+            pass
+        else:
+            u0 = get_energy_loss(ring, method=method)
+            if u0 > rfv:
+                raise AtError('Missing RF voltage: unstable ring')
+            ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
     else:
         ref_in = guess
 


### PR DESCRIPTION
### New functions and methods for cavity access:

#### Global control:

**In Python**, a new method `Lattice.set_cavity()` sets the frequency, voltage, harmonic number and time lag, individually or simultaneously, on all cavities or optionally on a subset of cavities:
```
def set_cavity(ring, Voltage=None, Frequency=None, HarmNumber=None,
               TimeLag=None, refpts=None, copy=False)
```
A special value for the frequency: `'nominal'` (string) sets the frequency to the nominal value.

**In Matlab**, the existing function `atsetcavity()` is upgraded in the following way:
- the existing behaviour is kept unchanged, for backward compatibility:
```
NEWRING = ATSETCAVITY(RING,RFV,RADFLAG,HARM_NUMBER)
```
- a new mode is created, similar to the python syntax, which gives a choice of parameters:
```
%NEWRING=ATSETCAVITY(RING,...,'Frequency',FREQUENCY,...)
%   Set the cavity frequency [Hz].
%
%NEWRING=ATSETCAVITY(RING,...,'Voltage',VOLTAGE,...)
%   Set the total voltage (all cells) [V]
```

#### Single parameter control:

- New methods for the Lattice object:
`Lattice.get_rf_frequency(refpts=None)`, `Lattice.set_rf_frequency(frequency, refpts=None, copy=False)`, ...
give access to single parameters with the optional choice of a subset of cavities and the possibility of returning a new copy of the lattice,

- New Lattice properties:
`Lattice.frequency`, `Lattice.voltage`,...
give an easier syntax for the simple case of a single RF system. These properties raise exceptions if all cavities do not have the same frequency or harmonic number