### PR TITLE
Chromatic functions in linopt

### DIFF
--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -258,7 +258,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
             print('Mu not found in twiss_in, setting to zero')
             tune = numpy.zeros((2,))
 
-    if get_w:
+    if get_chrom:
         # noinspection PyUnboundLocalVariable
         kwup = dict(orbit=orbit_up, twiss_in=twiss_in)
         # noinspection PyUnboundLocalVariable

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -103,7 +103,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
         orbit           avoids looking for the closed orbit if is already known
                         ((6,) array)
         get_chrom=False compute dispersion and chromaticities. Needs computing
-                        the tune and orbit at 2 different momentum deviations 
+                        the tune and orbit at 2 different momentum deviations
                         around the central one.
         keep_lattice    Assume no lattice change since the previous tracking.
                         Defaults to False
@@ -117,8 +117,8 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
                         only the beta and alpha are required other quatities
                         set to 0 if absent
         get_w=False     computes chromatic amplitude functions (W) [4], need to
-                        compute the optics at 2 different momentum deviations around
-                        the central one.
+                        compute the optics at 2 different momentum deviations
+                        around the central one.
     OUTPUT
         lindata0        linear optics data at the entrance/end of the ring
         tune            [tune_A, tune_B], linear tunes for the two normal modes

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -258,7 +258,8 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
             print('Mu not found in twiss_in, setting to zero')
             tune = numpy.zeros((2,))
 
-    if get_chrom:
+    # Get initial chromatic functions and dispersion
+    if get_w:
         # noinspection PyUnboundLocalVariable
         kwup = dict(orbit=orbit_up, twiss_in=twiss_in)
         # noinspection PyUnboundLocalVariable
@@ -271,7 +272,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, orbit=None,
                             XYStep=xy_step, **kwdown)
         param_up_down = param_up+param_down
         chrom, dispersion, w0, w = _chromfunc(dp_step, *param_up_down)
-    elif get_w:
+    elif get_chrom:
         # noinspection PyUnboundLocalVariable
         kwup = dict(orbit=orbit_up, twiss_in=twiss_in)
         # noinspection PyUnboundLocalVariable


### PR DESCRIPTION
This branch fixes a bug left after the matching development where chromatic function were computed but never used.
These are expensive computation and should be done on request only.

Chromatic function are defined in Brian W. Montague Report LEP Note 165, CERN, 1979

A flag get_w=False is added in linopt, the default behavior is back to the standard one.

Computing times for the ESRF-HMBA lattice:
default: 0.1440258026123047
get_chrom=True: 0.24343562126159668
get_w=True: 0.4185199737548828

Without this fix all case are 0.42

We are unfortunately accumulating flags and tests in linopt...any suggestions?