### PR TITLE
Argument checking in Matlab

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
@@ -24,7 +24,7 @@ Cgamma=4.0E27*pi*e_radius/3/e_mass^3;                                   % [m/GeV
 
 [nodisp,varargs]=getflag(varargin,'NoDisplay');
 [disp,varargs]=getflag(varargs,'Display');
-ring=getargs(varargs,{THERING});
+ring=getargs(varargs,THERING);
 DisplayFlag=(~nodisp) || disp;
 
 energy=atenergy(ring);

--- a/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
@@ -41,7 +41,7 @@ cspeed = PhysConstant.speed_of_light_in_vacuum.value;                   % m/s
 
 Cq=55/32/sqrt(3)*hbar/e_mass*1E-9;   % m
 
-[ring,Ux]=getargs(varargin,{THERING},[]);
+[ring,Ux]=getargs(varargin,THERING,[]);
 try
     % Set values for 1 superperiod
     [energy,periods,Vrf0,harm0,U00]=atenergy(ring);

--- a/atmat/atphysics/ParameterSummaryFunctions/twissring.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/twissring.m
@@ -53,7 +53,7 @@ function [TD, varargout] = twissring(RING,DP,varargin)
 NE=length(RING);
 % Process input arguments
 [CHROMFLAG,args]=getflag(varargin,'chrom');
-[REFPTS,DDP]=getargs(args,{NE+1,1.e-8});
+[REFPTS,DDP]=getargs(args,NE+1,1.e-8);
 CHROMFLAG=CHROMFLAG || (nargout == 3);
 
 % Include the endpoint if it is not already in REFPTS

--- a/atmat/atphysics/nafflib/calcnaff.m
+++ b/atmat/atphysics/nafflib/calcnaff.m
@@ -55,7 +55,7 @@ nitermax = 10;
 [whann,args]=getflag(args,'Hanning');
 [dbg,args]=getflag(args,'Debug');
 [DisplayFlag,args]=getflag(args,'Display');
-[WindowType,nfreq,DebugFlag]=getargs(args,{0,10,double(dbg)});
+[WindowType,nfreq,DebugFlag]=getargs(args,0,10,double(dbg));
 if whann, WindowType=1; end
 
 

--- a/atmat/atutils/getargs.m
+++ b/atmat/atutils/getargs.m
@@ -12,7 +12,14 @@ function varargout = getargs(args,varargin)
 %[...]=GETARGS(ARGIN,...,'check',checkfun)
 %   Check each input arguments using checkfun(arg) and stops processing
 %   at the first failing argument. Remaining arguments are available in
-%   REMARGS.
+%   REMARGS. "checkfun" may either:
+%      - return "false": the function continues using the default value,
+%      - throw an exception: the function aborts, control is returned to
+%        the keyboard or an enclosing try/catch block. The default value
+%        is never used but must be specified.
+%
+%        Matlab R2020b introduces a series of function "mustBe*" that can
+%        be used for checkfun.
 %
 %Example 1:
 %
@@ -24,9 +31,21 @@ function varargout = getargs(args,varargin)
 %
 %global THERING
 %[ring,args]=getargs(varargin,THERING,'check',@iscell)
-%   if the 1st argument is a cell array, it will be used as "ring",
-%   otherwise, THERING will be used. In any case, the remaining
-%   arguments are availble in "args".
+%   If the 1st argument is a cell array, it will be used as "ring",
+%   otherwise, THERING will be used. In both cases, the remaining
+%   arguments are available in "args".
+%
+%Example 3:
+%
+%function checkcell(arg)
+%if ~iscell(A)
+%    throwAsCaller(MException('AT:WrongType','Argument must be a cell array'));
+%end
+%
+%[ring,args]=getargs(varargin,{},'check',@checkcell)
+%   If the 1st argument is a cell array, it will be used as "ring" and the
+%   remaining arguments are available in "args". Otherwise, the function
+%   aborts with an error message.
 %
 %See also GETFLAG, GETOPTION
 

--- a/atmat/atutils/getargs.m
+++ b/atmat/atutils/getargs.m
@@ -1,18 +1,11 @@
-function varargout = getargs(args,default,varargin)
+function varargout = getargs(args,varargin)
 %GETARGS Process positional arguments from the input arguments
 %
-%VALUES=GETARGS(ARGIN,DEFAULT_VALUES) processes input arguments (typically
-% from VARARGIN), by replacing DEFAULT_VALUES by valid ARGIN items
-% (items different from [], the empty numeric array)
+%Processes input arguments (typically from VARARGIN), by replacing default values
+%by valid ARGIN items (items different from [], the empty numeric array)
 %
-%VALUES: all the arguments in a cell array, possibly longer than DEFAULT_VALUES:
-%	length(ARGOUT)=max(length(ARGIN), length(DEFAULT_VALUES))
-%
-%[V1,V2,...,REMAIN]=GETARGS(ARGIN,DEFAULT_VALUES) returns arguments in
-%	as many separate variables as element in DEFAULT_VALUES and adds a cell
-%   array of remaining arguments, if any
-%
-%[...]=GETARGS(ARGIN,DEF1,DEF2,...) takes default values in separate arguments
+%[V1,V2,...,REMARGS]=GETARGS(ARGIN,DEF1,DEF2,...) returns as many variables
+% as default values plus a cell array of remaining arguments.
 %
 %Example:
 %
@@ -20,23 +13,21 @@ function varargout = getargs(args,default,varargin)
 %
 %[optflag,args]=getflag(varargin,'option');     % Extract an optional flag
 %[range,args]=getoption(args,'Range', 1:10);	% Extract a keyword argument
-%[dname,dvalue]=getargs(args,{'abcd',297});     % Extract positional arguments
-%or
 %[dname,dvalue]=getargs(args,'abcd',297);     % Extract positional arguments
 %
 %See also GETFLAG, GETOPTION
 
-if iscell(default)
-    default_values=[default varargin];
-else
-    default_values=[{default} varargin];
-end
+[check,default_values]=getoption(varargin,'check',@(arg) true);
 na=length(default_values);
-valid=~cellfun(@(arg) isempty(arg)&&isnumeric(arg),args);
+% Look for default args
+takedef = cellfun(@(arg) isempty(arg) && isnumeric(arg),args);
+% Look for valid arguments and stop at 1st non-valid
+checked =  takedef | cellfun(@(arg) check(arg),args);
+checked(find(~checked,1):end)=false;
+% Look for valid, non-default arguments
+valid = checked & ~takedef;
 default_values(valid)=args(valid);
-if nargout>=na
-    varargout=[default_values(1:na) {default_values(na+1:end)}];
-else
-    varargout{1}=default_values;
-end
+% Append non-valid arguments
+default_values=[default_values args(~checked)];
+varargout=[default_values(1:na) {default_values(na+1:end)}];
 end

--- a/atmat/atutils/getargs.m
+++ b/atmat/atutils/getargs.m
@@ -1,19 +1,32 @@
 function varargout = getargs(args,varargin)
 %GETARGS Process positional arguments from the input arguments
 %
-%Processes input arguments (typically from VARARGIN), by replacing default values
-%by valid ARGIN items (items different from [], the empty numeric array)
+%Process input arguments (typically from VARARGIN), replacing missing
+%arguments by default values. The default values is also used when an
+%argument is "[]" (empty numeric array).
 %
-%[V1,V2,...,REMARGS]=GETARGS(ARGIN,DEF1,DEF2,...) returns as many variables
-% as default values plus a cell array of remaining arguments.
+%[V1,V2,...,REMARGS]=GETARGS(ARGIN,DEF1,DEF2,...)
+%   Return as many variables as default values, plus a cell array of
+%   remaining arguments.
 %
-%Example:
+%[...]=GETARGS(ARGIN,...,'check',checkfun)
+%   Check each input arguments using checkfun(arg) and stops processing
+%   at the first failing argument. Remaining arguments are available in
+%   REMARGS.
 %
-%function testfunc(varargin)
+%Example 1:
 %
-%[optflag,args]=getflag(varargin,'option');     % Extract an optional flag
-%[range,args]=getoption(args,'Range', 1:10);	% Extract a keyword argument
+%[optflag,args]=getflag(varargin,'option');   % Extract an optional flag
+%[range,args]=getoption(args,'Range', 1:10);  % Extract a keyword argument
 %[dname,dvalue]=getargs(args,'abcd',297);     % Extract positional arguments
+%
+%Example 2:
+%
+%global THERING
+%[ring,args]=getargs(varargin,THERING,'check',@iscell)
+%   if the 1st argument is a cell array, it will be used as "ring",
+%   otherwise, THERING will be used. In any case, the remaining
+%   arguments are availble in "args".
 %
 %See also GETFLAG, GETOPTION
 

--- a/atmat/atutils/getflag.m
+++ b/atmat/atutils/getflag.m
@@ -17,7 +17,7 @@ function [flag,opts] = getflag(opts,key)
 %
 %[optflag,args]=getflag(varargin,'option');     % Extract an optional flag
 %[range,args]=getoption(args,'Range', 1:10);	% Extract a keyword argument
-%[width, height]=getargs(args,{210,297});       % Extract positional arguments
+%[width, height]=getargs(args, 210, 297);       % Extract positional arguments
 %
 %Dee also GETOPTION, GETARGS
 

--- a/atmat/atutils/getoption.m
+++ b/atmat/atutils/getoption.m
@@ -10,12 +10,15 @@ function [value,opts] = getoption(opts,key,value)
 % DEFAULT:  Value used if "key,value" is absent from the argument list
 %
 %VALUE=GETOPTION(ARGS,'KEY')
-%   The default value is taken from a list of predefined keys. See
-%   INITOPTIONS for the list of predefined keys
+%   The default value is taken from a list of predefined keys. Use
+%   GETOPTION() for the list of predefined keys
 %
 %VALUE=GETOPTION('KEY')
-%   Return the default value of a predefined key. See INITOPTIONS for
+%   Return the default value of a predefined key. Use GETOPTION() for
 %   the list of predefined keys
+%
+%VALUE=GETOPTION()
+%   Return all the default values
 %
 %[VALUE,REMARGS]=GETOPTION(ARGS,...)
 %  Return the remaining arguments after removing the processed ones
@@ -28,7 +31,7 @@ function [value,opts] = getoption(opts,key,value)
 %[range,args] = getoption(args, 'Range', 1:10); % Extract a keyword argument
 %[width, height] = getargs(args, 210, 297});    % Extract positional arguments
 %
-%See also GETFLAG, GETARGS, SETOPTION, INITOPTIONS
+%See also GETFLAG, GETARGS, SETOPTION, ATOPTIONS
 
 if nargin < 1
     value=atoptions.instance();

--- a/atmat/atutils/getoption.m
+++ b/atmat/atutils/getoption.m
@@ -5,6 +5,10 @@ function [value,opts] = getoption(opts,key,value)
 %   Extract a keyword argument, in the form of a pair "key,value" from
 %   input arguments ARGS (typically from VARARGIN).
 %   Return DEFAULT value if the keyword is absent
+%
+%VALUE=GETOPTION(ARGS,KEY=DEFAULT)
+%   Alternative syntax available in Matlab >= R2021a
+%
 % ARGS:     Argument list: cell array (usually VARARGIN) or structure
 % KEY:      Key name
 % DEFAULT:  Value used if "key,value" is absent from the argument list

--- a/atmat/atutils/parseargs.m
+++ b/atmat/atutils/parseargs.m
@@ -5,5 +5,5 @@ function varargout = parseargs(default_values,args)
 %
 % obsolete: see GETARGS
 
-[varargout{1:nargout}]=getargs(args,default_values);
+[varargout{1:nargout}]=getargs(args,default_values{:});
 end

--- a/atmat/atutils/setoption.m
+++ b/atmat/atutils/setoption.m
@@ -3,7 +3,7 @@ function setoption(name,value)
 %
 %SETOPTION('KEY',DEFAULT)
 %   Set the default value for the given KEY to DEFAULT. It is an error to set
-%   a default for a non-existing KEY. See ATINIPREFS for the list of
+%   a default for a non-existing KEY. Use GETOPTION() for the list of
 %   predefined keys.
 %
 % KEY:      Key name
@@ -11,9 +11,9 @@ function setoption(name,value)
 %
 %SETOPTION('KEY') Resets the default value for KEY to its inital setting
 %
-%SETOPTION()      Resets all values to the initial setting
+%SETOPTION()      Resets all values to their initial setting
 %
-%See also GETOPTION, INITOPTIONS
+%See also GETOPTION, ATOPTIONS
 
 opt=atoptions.instance();
 if nargin >= 2

--- a/atmat/lattice/atfastring.m
+++ b/atmat/lattice/atfastring.m
@@ -43,11 +43,8 @@ for i = 1:length(I_cav)
 end
 ring0 = ring_temp;
 
-[doplot,varargin]=getflag(varargin,'Plot');
-split=getargs(varargin,{[]});
-if nargin < 2
-    split=[];
-end
+[doplot,varargs]=getflag(varargin,'Plot');
+split=getargs(varargs,[]);
 if islogical(split)
     iend=[find(split) length(ring0)+1];
 else

--- a/atmat/lattice/element_creation/private/decodeatargs.m
+++ b/atmat/lattice/element_creation/private/decodeatargs.m
@@ -4,16 +4,16 @@ function [rsrc,varargout] = decodeatargs(default_values,args)
 %  [RSRC,ARGS]=decodeatargs(DEFARGS,ARGLIST)
 %
 %  INPUTS
-%    1. DEFARGS - Default values of mandatory argument
-%    2. ARGS    - Arguments
+%    1. DEFARGS - Default values for mandatory argument
+%    2. ARGLIST - Arguments
 %
 %  OUPUTS
-%    1. rsrc      - Optional arguments
-%    2. varargout - Mandatory arguments
+%    1. RSRC    - Optional arguments (all remaining arguments)
+%    2. ARGS    - Mandatory arguments
 %
 %  See also getoption, getflag
 
 na=length(default_values);
-mandatory = @(arg) ~ischar(arg) || isempty(arg) || endsWith(arg, 'Pass');
+mandatory = @(arg) ~ischar(arg) || endsWith(arg, 'Pass');
 [varargout{1:na},rsrc]=getargs(args,default_values{:},'check',mandatory);
 end

--- a/atmat/lattice/element_creation/private/decodeatargs.m
+++ b/atmat/lattice/element_creation/private/decodeatargs.m
@@ -4,26 +4,16 @@ function [rsrc,varargout] = decodeatargs(default_values,args)
 %  [RSRC,ARGS]=decodeatargs(DEFARGS,ARGLIST)
 %
 %  INPUTS
-%    1. DEFARGS - Values per default if not specify for mandatory
-%                 argument
-%    2. ARGS    - Other arugments
+%    1. DEFARGS - Default values of mandatory argument
+%    2. ARGS    - Arguments
 %
 %  OUPUTS
-%    1. rsrc      - Mandatory arguments
-%    2. varargout - Optional arguments
-%
-%  NOTES
-%    1. DEFARGS must have length >= 2
+%    1. rsrc      - Optional arguments
+%    2. varargout - Mandatory arguments
 %
 %  See also getoption, getflag
 
-% function to get the first string which is after the PassMethod
-nopass    = @(arg) ischar(arg) && ~isempty(arg) && isempty(regexp(arg,'.*Pass$','once'));
-% get index of first optional char Argument
-chararg   = find(cellfun(nopass,[args {'x'}]),1); 
-% get all optional argument (ressources)
-rsrc      = args(chararg:end);
-% output mandatory argument
-varargout = parseargs(default_values,args(1:chararg-1));
-
+na=length(default_values);
+mandatory = @(arg) ~ischar(arg) || isempty(arg) || endsWith(arg, 'Pass');
+[varargout{1:na},rsrc]=getargs(args,default_values{:},'check',mandatory);
 end


### PR DESCRIPTION
The utility functions `getflag`, `getoption`, `getargs` are updated to:
- add new possibilities for argument checking,
- provide a better documentation,
- be compatible with new features introduced in Matlab 2020b and 2021a. AT itself stays compatible with Matlab >= 2016b, but users may use these new features in their code.