### PR TITLE
Improved closed orbit functions

### DIFF
--- a/atmat/atphysics/Orbit/findorbit.m
+++ b/atmat/atphysics/Orbit/findorbit.m
@@ -36,7 +36,7 @@ if isempty(orbitin)
         if isfinite(dp) || isfinite(ct)
             warning('AT:linopt','In 6D, "dp" and "dct" are ignored');
         end
-        orbitin=x_orbit6(ring,varargs{:});
+        orbitin=xorbit_6(ring,varargs{:});
     else                        % Radiation OFF: 4D orbit
         [~,varargs]=getoption(varargs,'DPStep');   % Take it out because findorbit4 does not accept it
         [dp,varargs]=getoption(varargs,'dp',0);

--- a/atmat/atphysics/Orbit/findorbit.m
+++ b/atmat/atphysics/Orbit/findorbit.m
@@ -1,14 +1,59 @@
-function orbit  = findorbit(RING,D, varargin)
-%FINDORBIT Alias to the orbit search functions: (findorbit4, findsyncorbit,
-%          findorbit4 ...) 
-%  depending on the number of parameters, their types and argument options
-%  It can also return additional parameters.
-%  
-%  NOTES
-%  1. Temporary version of 7/18/00 - defaults to FINDORBIT4
+function [orbs,orbitin]  = findorbit(ring,varargin)
+%FINDORBIT find the closed orbit
+%
+%Depending on the lattice, FINDORBIT will:
+% - use findorbit6 if radiation is ON,
+% - use findsyncorbit if radiation is OFF and ct is specified,
+% - use findorbit4 otherwise
+%
+%[ORBIT,FIXEDPOINT]=FINDORBIT(RING,REFPTS)
+%
+% ORBIT:        6xNrefs, closed orbit at the selected reference points
+% FIXEDPOINT:   6x1 closed orbit at the entrance of the lattice
+%
+%[...]=FINDORBIT(RING,...,'dp',DP) Specify the momentum deviation when
+%   radiation is OFF (default: 0)
+%
+%[...]=FINDORBIT(RING,...,'dct',DCT) Specify the path lengthening when
+%   radiation is OFF (default: 0)
+%
+%[...]=FINDORBIT(RING,...,'orbit',ORBIT) Specify the orbit at the entrance
+%   of the ring, if known. FINDORBIT will then transfer it to the reference points
+%
+%[...]=FINDORBIT(RING,...,'guess',GUESS) The search will start with GUESS as
+%   initial conditions
+%
+%For other keywords, see the underlying functions.
 %
 % See also FINDORBIT4, FINDSYNCORBIT, FINDORBIT6.
 
-orbit = findorbit4(RING, D, varargin{:});
+[orbitin,varargs]=getoption(varargin,'orbit',[]);
+[refpts,varargs]=getargs(varargs,[],'check',@(arg) isnumeric(arg) || islogical(arg));
+if isempty(orbitin)
+    if check_radiation(ring)    % Radiation ON: 6D orbit
+        dp=getoption(varargs,'dp',NaN);
+        ct=getoption(varargs,'dct',NaN);
+        if isfinite(dp) || isfinite(ct)
+            warning('AT:linopt','In 6D, "dp" and "dct" are ignored');
+        end
+        orbitin=x_orbit6(ring,varargs{:});
+    else                        % Radiation OFF: 4D orbit
+        [~,varargs]=getoption(varargs,'DPStep');   % Take it out because findorbit4 does not accept it
+        [dp,varargs]=getoption(varargs,'dp',0);
+        orbitin=xorbit_dp(ring,dp,varargs{:});
+    end
+    args={'KeepLattice'};
+else
+    args={};
+end
 
-return
+if islogical(refpts)
+    refpts=find(refpts);
+end
+if isempty(refpts)
+    % return only the fixed point at the entrance of RING{1}
+    orbs=orbitin;
+else
+    orbs=linepass(RING,orbitin,refpts,args{:});
+end
+end

--- a/atmat/atphysics/Orbit/findorbit.m
+++ b/atmat/atphysics/Orbit/findorbit.m
@@ -54,6 +54,6 @@ if isempty(refpts)
     % return only the fixed point at the entrance of RING{1}
     orbs=orbitin;
 else
-    orbs=linepass(RING,orbitin,refpts,args{:});
+    orbs=linepass(ring,orbitin,refpts,args{:});
 end
 end

--- a/atmat/atphysics/Orbit/findsyncorbit.m
+++ b/atmat/atphysics/Orbit/findsyncorbit.m
@@ -1,4 +1,4 @@
-function [orb5, fixedpoint] = findsyncorbit(RING,dCT,varargin)
+function [orb5,orbitin] = findsyncorbit(ring,dct,varargin)
 %FINDSYNCORBIT finds closed orbit, synchronous with the RF cavity
 % and momentum deviation dP (first 5 components of the phase space vector)
 % by numerically solving  for a fixed point
@@ -20,86 +20,51 @@ function [orb5, fixedpoint] = findsyncorbit(RING,dCT,varargin)
 %    2. have any time dependence (localized impedance, fast kickers etc).
 %
 %
-% FINDSYNCORBIT(RING,dCT) is 5x1 vector - fixed point at the
+% FINDSYNCORBIT(RING,DCT) is 5x1 vector - fixed point at the
 %		entrance of the 1-st element of the RING (x,px,y,py,dP)
 %
-% FINDSYNCORBIT(RING,dCT,REFPTS) is 5-by-Length(REFPTS)
-%     array of column vectors - fixed points (x,px,y,py,dP)
-%     at the entrance of each element indexed in REFPTS array.
-%     REFPTS is an array of increasing indexes that  select elements
-%     from the range 1 to length(RING)+1.
-%     See further explanation of REFPTS in the 'help' for FINDSPOS
+% FINDSYNCORBIT(RING,DCT,REFPTS) is 5xLength(REFPTS)
+%   array of column vectors - fixed points (x,px,y,py,dP)
+%   at the entrance of each element indexed by the REFPTS array.
+%   REFPTS is an array of increasing indexes that  select elements
+%   from the range 1 to length(RING)+1.
+%   See further explanation of REFPTS in the 'help' for FINDSPOS
 %
-% FINDSYNCORBIT(RING,dCT,REFPTS,GUESS) - same as above but the search
-%     for the fixed point starts at the initial condition GUESS
-%     Otherwise the search starts from [0 0 0 0 0 0]'.
-%     GUESS must be a 6-by-1 vector;
+% FINDSYNCORBIT(RING,DCT,REFPTS,GUESS)
+% FINDSYNCORBIT(...,'guess',GUESS)     The search for the fixed point
+%   starts from initial condition GUESS. Otherwise the search starts from
+%   [0; 0; 0; 0; 0; 0]. GUESS must be a 6x1 vector.
+%
+% FINDSYNCORBIT(...,'orbit',ORBIT)     Specify the orbit at the entrance
+%   of the ring, if known. FINDSYNCORBIT will then transfer it to the
+%   reference points. ORBIT must be a 6x1 vector.
 %
 % [ORBIT, FIXEDPOINT] = FINDSYNCORBIT( ... )
-%     The optional second return parameter is
-%     a 6-by-1 vector of initial conditions
-%     on the close orbit at the entrance to the RING.
+%	The optional second return parameter is a 6x1 vector:
+%   closed orbit at the entrance of the RING.
 %
 % See also FINDORBIT4, FINDORBIT6.
 %
-if ~iscell(RING)
+if ~iscell(ring)
     error('First argument must be a cell array');
 end
-[XYStep,varargs]=getoption(varargin,'XYStep');	% Step size for numerical differentiation
-[dps,varargs]=getoption(varargs,'OrbConvergence');	% Convergence threshold
-[max_iterations,varargs]=getoption(varargs,'OrbMaxIter');	% Max. iterations
-
-if length(varargs) >= 1 && ~isequal(varargs{1},length(RING)+1)
-    refpts=varargs{1};
-    if islogical(refpts)
-        refpts=find(refpts);
-    end
-else
-    refpts=[];
-end
-if length(varargs) >= 2	% Check if guess argument was supplied
-    if isnumeric(varargs{2}) && isequal(size(varargs{2}),[6,1])
-        Ri=varargs{2};
-    else
-        error('The last argument GUESS must be a 6-by-1 vector');
-    end
-else
-    Ri = zeros(6,1);
-end
-
-scaling=XYStep*[1 1 1 1 1];
-D5 = [diag(scaling) zeros(5,1); zeros(1,6)];
-theta5 = [0 0 0 0  dCT]';
-
-args={};
-change=Inf;
-itercount = 0;
-while (change > dps) && (itercount < max_iterations)
-    RMATi= Ri(:,ones(1,6)) + D5;
-    RMATf = linepass(RING,RMATi,args{:});
-    Rf = RMATf(:,end);
-    % compute the transverse part of the Jacobian
-    J5 =  (RMATf([1:4,6],1:5)-RMATf([1:4,6],6*ones(1,5)))./scaling;
-    Ri_next = Ri +  [(diag([1 1 1 1 0]) - J5)\(Rf([1:4,6])-[Ri(1:4);0]-theta5);0];
-    change = norm(Ri_next - Ri);
-    Ri = Ri_next;
-    itercount = itercount+1;
+[orbitin,varargs]=getoption(varargin,'orbit',[]);
+[refpts,varargs]=getargs(varargs,[],'check',@(arg) isnumeric(arg) || islogical(arg));
+if isempty(orbitin)
+    orbitin=xorbit_ct(ring,dct,varargs);
     args={'KeepLattice'};
+else
+    args={};
 end
 
-if itercount == max_iterations
-    warning('Maximum number of iterations reached. Possible non-convergence')
+if islogical(refpts)
+    refpts=find(refpts);
 end
-
 if isempty(refpts)
     % return only the fixed point at the entrance of RING{1}
-    orb5=Ri(1:5,1);
-else            % 3-rd input argument - vector of reference points along the Ring
-    % is supplied - return orbit
-    orb6 = linepass(RING,Ri,varargin{1},'KeepLattice');
+    orb5=orbitin(1:5,1);
+else
+    orb6 = linepass(ring,orbitin,varargin{1},args{:});
     orb5 = orb6(1:5,:);
 end
-
-if nargout==2
-    fixedpoint=Ri;
 end

--- a/atmat/atphysics/Orbit/xorbit_6.m
+++ b/atmat/atphysics/Orbit/xorbit_6.m
@@ -1,0 +1,64 @@
+function Ri = xorbit_6(RING,varargin)
+%XORBIT_6	Private function used by findorbit6
+%ORBIT=XORBIT_6(RING)	Closed orbit for 6D motion
+[XYStep,varargs]=getoption(varargin,'XYStep');	% Step size for numerical differentiation	%1.e-8
+[DPStep,varargs]=getoption(varargs,'DPStep');	% Step size for numerical differentiation	%1.e-6
+[dps,varargs]=getoption(varargs,'OrbConvergence');	% Convergence threshold                 %1.e-12
+[max_iterations,varargs]=getoption(varargs,'OrbMaxIter');	% Max. iterations               %20
+[method,varargs]=getoption(varargs,'method','tracking');    % Method for Eloss computation
+[Ri,varargs]=getoption(varargs,'guess',[]);
+[Ri,varargs]=getargs(varargs,Ri,'check',@(arg) isnumeric(arg) && isequal(size(arg),[6,1])); %#ok<ASGLU>
+
+cavities=RING(atgetcells(RING,'Frequency'));
+
+if isempty(cavities)
+    error('AT:NoFrequency', 'The lattice has no Cavity element')
+end
+
+L0 = findspos(RING,length(RING)+1); % design length [m]
+C0 = PhysConstant.speed_of_light_in_vacuum.value; % speed of light [m/s]
+
+T0 = L0/C0;
+
+Frf = unique(atgetfieldvalues(cavities,'Frequency'));
+HarmNumber = unique(atgetfieldvalues(cavities,'HarmNumber'));
+if length(Frf) > 1 || length(HarmNumber) > 1
+    error('AT:NoFrequency','RF cavities are not identical');
+end
+
+if isempty(Ri)
+    Vcell=sum(atgetfieldvalues(cavities,'Voltage'));
+    U0cell=atgetU0(RING,'periods',1,'method',method);
+    if U0cell > Vcell
+        error('AT:MissingVoltage','Missing RF voltage: unstable ring');
+    end
+    Ri = zeros(6,1);
+    Ri(6) = -L0/(2*pi*HarmNumber) * asin(U0cell/Vcell);
+end
+
+theta = [0 0 0 0 0 C0*(HarmNumber/Frf - T0)]';
+
+scaling=XYStep*[1 1 1 1 0 0] + DPStep*[0 0 0 0 1 1];
+D = [diag(scaling) zeros(6,1)];
+
+change=Inf;
+itercount = 0;
+args={};
+while (change > dps) && (itercount < max_iterations)
+    RMATi= Ri(:,ones(1,7)) + D;
+    RMATf = linepass(RING,RMATi,args{:});
+    % compute the transverse part of the Jacobian
+    J6 = (RMATf(:,1:6)-RMATf(:,7))./scaling;
+    Rf = RMATf(:,end);
+    Ri_next = Ri + (eye(6)-J6)\(Rf-Ri-theta);
+    change = norm(Ri_next - Ri);
+    Ri = Ri_next;
+    itercount = itercount+1;
+    args={'KeepLattice'};
+end
+
+if itercount == max_iterations
+    warning('Maximum number of iterations reached. Possible non-convergence')
+end
+end
+

--- a/atmat/atphysics/Orbit/xorbit_ct.m
+++ b/atmat/atphysics/Orbit/xorbit_ct.m
@@ -1,0 +1,39 @@
+function Ri = xorbit_ct(ring,dct,varargin)
+%XORBIT_CT	Private function used by findsyncorbit
+%ORBIT=XORBIT_CT(RING,DCT)	Closed orbit for fixed path lengthening.
+[dp,varargs]=getoption(varargin,'dp',NaN);
+if isnan(dp)
+    [XYStep,varargs]=getoption(varargs,'XYStep');	% Step size for numerical differentiation
+    [dps,varargs]=getoption(varargs,'OrbConvergence');	% Convergence threshold
+    [max_iterations,varargs]=getoption(varargs,'OrbMaxIter');	% Max. iterations
+    [Ri,varargs]=getoption(varargs,'guess',zeros(6,1));
+    [Ri,varargs]=getargs(varargs,Ri,'check',@(arg) isnumeric(arg) && isequal(size(arg),[6,1])); %#ok<ASGLU>
+    
+    scaling=XYStep*[1 1 1 1 1];
+    D5 = [diag(scaling) zeros(5,1); zeros(1,6)];
+    theta5 = [0 0 0 0  dct]';
+    
+    change=Inf;
+    itercount = 0;
+    args={};
+    while (change > dps) && (itercount < max_iterations)
+        RMATi= Ri(:,ones(1,6)) + D5;
+        RMATf = linepass(ring,RMATi,args{:});
+        Rf = RMATf(:,end);
+        % compute the transverse part of the Jacobian
+        J5 =  (RMATf([1:4,6],1:5)-RMATf([1:4,6],6*ones(1,5)))./scaling;
+        Ri_next = Ri +  [(diag([1 1 1 1 0]) - J5)\(Rf([1:4,6])-[Ri(1:4);0]-theta5);0];
+        change = norm(Ri_next - Ri);
+        Ri = Ri_next;
+        itercount = itercount+1;
+        args={'KeepLattice'};
+    end
+    
+    if itercount == max_iterations
+        warning('Maximum number of iterations reached. Possible non-convergence')
+    end
+else
+    Ri=xorbit_dp(ring,dp,varargs{:});
+end
+end
+

--- a/atmat/atphysics/Orbit/xorbit_dp.m
+++ b/atmat/atphysics/Orbit/xorbit_dp.m
@@ -1,0 +1,39 @@
+function Ri = xorbit_dp(ring,dp,varargin)
+%XORBIT_DP  Private function used by findorbit4
+%ORBIT=XORBIT_DP(RING,DP)   Closed orbit for fixed off-momentum.
+[dct,varargs]=getoption(varargin,'dct',NaN);
+if isnan(dct)
+    [XYStep,varargs]=getoption(varargs,'XYStep');	% Step size for numerical differentiation
+    [dps,varargs]=getoption(varargs,'OrbConvergence');	% Convergence threshold
+    [max_iterations,varargs]=getoption(varargs,'OrbMaxIter');	% Max. iterations
+    [Ri,varargs]=getoption(varargs,'guess',zeros(6,1));
+    [Ri,varargs]=getargs(varargs,Ri,'check',@(arg) isnumeric(arg) && isequal(size(arg),[6,1])); %#ok<ASGLU>
+    
+    % Set the momentum component of Ri to the specified dP
+    Ri(5) = dp;
+    scaling=XYStep*[1 1 1 1];
+    D = [diag(scaling) zeros(4,1);zeros(2,5)];
+    
+    change=Inf;
+    itercount = 0;
+    args={};
+    while (change > dps) && (itercount < max_iterations)
+        RMATi = Ri(:,ones(1,5)) + D;
+        RMATf = linepass(ring,RMATi,args{:});
+        Rf = RMATf(:,end);
+        % compute the transverse part of the Jacobian
+        J4 = (RMATf(1:4,1:4)-RMATf(1:4,5))./scaling;
+        Ri_next = Ri +  [(eye(4) - J4)\(Rf(1:4)-Ri(1:4)); 0; 0];
+        change = norm(Ri_next - Ri);
+        Ri = Ri_next;
+        itercount = itercount+1;
+        args={'KeepLattice'};
+    end
+    
+    if itercount == max_iterations
+        warning('Maximum number of iterations reached. Possible non-convergence')
+    end
+else
+    Ri=xorbit_ct(ring,dct,varargs{:});
+end
+end

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -194,7 +194,7 @@ def save_mat(ring, filename, mat_key='RING'):
         mat_key='RING'  Name of the Matlab variable representing the lattice
     """
     lring = tuple((element_to_dict(elem),) for elem in matlab_ring(ring))
-    scipy.io.savemat(filename, {mat_key: lring})
+    scipy.io.savemat(filename, {mat_key: lring}, long_field_names=True)
 
 
 def save_m(ring, filename=None):

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -63,8 +63,7 @@ _matclass_map = {'Dipole': 'Bend'}
 
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr,
-                                                             dtype=float)}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr)}
 
 _class_to_matfunc = {
     elt.Dipole: 'atsbend',

--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -19,36 +19,36 @@ def _get_chrom(ring, dp=0):
     return chrom
 
 
-def _fit_tune_chrom(ring, order, func, refpts1, refpts2, newval, tol=1.0e-12,
+def _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=1.0e-12,
                     dp=0, niter=3):
 
-    def _get_resp(ring, order, func, refpts, attname, delta, dp=0):
-        set_value_refpts(ring, refpts, attname, delta, order=order,
+    def _get_resp(ring, index, func, refpts, attname, delta, dp=0):
+        set_value_refpts(ring, refpts, attname, delta, index=index,
                          increment=True)
         datap = func(ring, dp=dp)
-        set_value_refpts(ring, refpts, attname, -2*delta, order=order,
+        set_value_refpts(ring, refpts, attname, -2*delta, index=index,
                          increment=True)
         datan = func(ring, dp=dp)
-        set_value_refpts(ring, refpts, attname, delta, order=order,
+        set_value_refpts(ring, refpts, attname, delta, index=index,
                          increment=True)
         data = numpy.subtract(datap, datan)/(2*delta)
         return data
 
-    delta = 1e-6*10**(order)
+    delta = 1e-6*10**(index)
     val = func(ring, dp=dp)
-    dq1 = _get_resp(ring, order, func, refpts1, 'PolynomB', delta, dp=dp)
-    dq2 = _get_resp(ring, order, func, refpts2, 'PolynomB', delta, dp=dp)
+    dq1 = _get_resp(ring, index, func, refpts1, 'PolynomB', delta, dp=dp)
+    dq2 = _get_resp(ring, index, func, refpts2, 'PolynomB', delta, dp=dp)
     J = [[dq1[0], dq2[0]], [dq1[1], dq2[1]]]
     dk = numpy.linalg.solve(J, numpy.subtract(newval, val))
-    set_value_refpts(ring, refpts1, 'PolynomB', dk[0], order=order,
+    set_value_refpts(ring, refpts1, 'PolynomB', dk[0], index=index,
                      increment=True)
-    set_value_refpts(ring, refpts2, 'PolynomB', dk[1], order=order,
+    set_value_refpts(ring, refpts2, 'PolynomB', dk[1], index=index,
                      increment=True)
 
     val = func(ring, dp=dp)
     sumsq = numpy.sum(numpy.square(numpy.subtract(val, newval)))
     if sumsq > tol and niter > 0:
-        _fit_tune_chrom(ring, order, func, refpts1, refpts2, newval, tol=tol,
+        _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=tol,
                         dp=dp, niter=niter-1)
     else:
         return

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -6,7 +6,7 @@ import numpy
 from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity
 from at.lattice import check_radiation, AtError
-from at.lattice import checktype, set_value_refpts, get_cells, get_refpts
+from at.lattice import checktype, set_value_refpts, get_cells, refpts_len
 from at.tracking import lattice_pass
 from at.physics import clight, Cgamma, e_mass
 
@@ -134,7 +134,7 @@ def get_timelag_fromU0(ring, method=ELossMethod.INTEGRAL, cavpts=None):
             raise AtError('Not enough RF voltage: unstable ring')
         timelag = clight/(2*pi*freq)*numpy.arcsin(u0/rfv)                  
         ts = timelag - tl0
-        timelag*= numpy.ones(len(cavpts))
+        timelag*= numpy.ones(refpts_len(ring,cavpts))
     return timelag, ts
 
 
@@ -162,7 +162,7 @@ def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
         warn(FutureWarning('You should use "cavpts" instead of "refpts"'))
         cavpts = refpts
     elif cavpts is None:
-        cavpts = get_refpts(ring, RFCavity)
+        cavpts = get_cells(ring, checktype(RFCavity))
     timelag, ts = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)
     print("\nThis function modifies the time reference\n"

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -164,7 +164,6 @@ def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
     elif cavpts is None:
         cavpts = get_refpts(ring, RFCavity)
     timelag, ts = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
-    print(timelag, ts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)
     print("\nThis function modifies the time reference\n"
           "This should be avoided, you have been warned!\n",

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -6,7 +6,7 @@ import numpy
 from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity
 from at.lattice import check_radiation, AtError
-from at.lattice import checktype, set_value_refpts, get_cells
+from at.lattice import checktype, set_value_refpts, get_cells, get_refpts
 from at.tracking import lattice_pass
 from at.physics import clight, Cgamma, e_mass
 
@@ -162,7 +162,7 @@ def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
         warn(FutureWarning('You should use "cavpts" instead of "refpts"'))
         cavpts = refpts
     elif cavpts is None:
-        cavpts = get_cells(ring, checktype(RFCavity))
+        cavpts = get_refpts(ring, RFCavity)
     timelag, ts = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
     print(timelag, ts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -8,7 +8,7 @@ import scipy.constants as constants
 from at.lattice import AtWarning, AtError, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
-from at.physics import get_energy_loss, ELossMethod
+from at.physics import get_energy_loss, ELossMethod, get_timelag_fromU0
 import warnings
 
 __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6']
@@ -285,7 +285,8 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
         guess           Initial value for the closed orbit. It may help
                         convergence. The default is computed from the energy
                         loss of the ring
-        method          Method for energy loss computation (see get_energy_loss)
+        method          Method for energy loss computation
+                        (see get_energy_loss)
                         default: ELossMethod.TRACKING
         convergence     Convergence criterion. Default: 1.e-12
         max_iterations  Maximum number of iterations. Default: 20
@@ -307,21 +308,14 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
-    f_rf = cavities[0].Frequency
-    harm_number = cavities[0].HarmNumber
+    f_rfs = [cav.Frequency for cav in cavities]
+    f_rf = numpy.amin(f_rfs)
+    harm_number = cavities[numpy.argmin(f_rfs)].HarmNumber
 
     if guess is None:
+        _, dt = get_timelag_fromU0(ring)
         ref_in = numpy.zeros((6,), order='F')
-        try:
-            rfv = ring.get_rf_voltage(cavpts=cavpts)
-        except AtError:
-            # Cannot compute synchronous phase: keep zeros(6,)
-            pass
-        else:
-            u0 = get_energy_loss(ring, method=method)
-            if u0 > rfv:
-                raise AtError('Missing RF voltage: unstable ring')
-            ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
+        ref_in[5] = -dt
     else:
         ref_in = guess
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -1,13 +1,12 @@
 """
 Closed orbit related functions
 """
-from math import pi, asin
 import numpy
 import scipy.constants as constants
 from at.lattice import AtWarning, AtError, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
-from at.physics import get_energy_loss, ELossMethod
+from at.physics import ELossMethod, get_timelag_fromU0
 import warnings
 
 __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6', 'find_orbit']
@@ -270,17 +269,9 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
     harm_number = cavities[0].HarmNumber
 
     if guess is None:
+        _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
         ref_in = numpy.zeros((6,), order='F')
-        try:
-            rfv = ring.get_rf_voltage(cavpts=cavpts)
-        except AtError:
-            # Cannot compute synchronous phase: keep zeros(6,)
-            pass
-        else:
-            u0 = get_energy_loss(ring, method=method)
-            if u0 > rfv:
-                raise AtError('Missing RF voltage: unstable ring')
-            ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
+        ref_in[5] = -dt
     else:
         ref_in = numpy.copy(guess)
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -14,7 +14,7 @@ __all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6', 'find_orbit']
 
 
 @check_radiation(False)
-def _orbit_dp(ring, dp=0.0, guess=None, **kwargs):
+def _orbit_dp(ring, dp=None, guess=None, **kwargs):
     """Solver for fixed energy deviation"""
     # We seek
     #  - f(x) = x
@@ -32,8 +32,8 @@ def _orbit_dp(ring, dp=0.0, guess=None, **kwargs):
     convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
-    ref_in[4] = dp
+    ref_in = numpy.zeros((6,)) if guess is None else numpy.copy(guess)
+    ref_in[4] = 0.0 if dp is None else dp
 
     scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0])
     delta_matrix = numpy.zeros((6, 5), order='F')
@@ -67,20 +67,20 @@ def _orbit_dp(ring, dp=0.0, guess=None, **kwargs):
 
 
 @check_radiation(False)
-def _orbit_dct(ring, dct=0.0, guess=None, **kwargs):
+def _orbit_dct(ring, dct=None, guess=None, **kwargs):
     """Solver for fixed path lengthening"""
     keep_lattice = kwargs.pop('keep_lattice', False)
     convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
+    ref_in = numpy.zeros((6,)) if guess is None else numpy.copy(guess)
 
     scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
     delta_matrix = numpy.zeros((6, 6), order='F')
     for i in range(5):
         delta_matrix[i, i] = scaling[i]
     theta5 = numpy.zeros((5,), order='F')
-    theta5[4] = dct
+    theta5[4] = 0.0 if dct is None else dct
     id5 = numpy.zeros((5, 5), order='F')
     for i in range(4):
         id5[i, i] = 1.0
@@ -282,7 +282,7 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
                 raise AtError('Missing RF voltage: unstable ring')
             ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
     else:
-        ref_in = guess
+        ref_in = numpy.copy(guess)
 
     theta = numpy.zeros((6,))
     theta[5] = constants.speed_of_light * harm_number / f_rf - l0
@@ -433,8 +433,6 @@ def find_orbit(ring, refpts=None, dp=None, dct=None, **kwargs):
             warnings.warn(AtWarning('In 6D, "dp" and "dct" are ignored'))
         return find_orbit6(ring, refpts, **kwargs)
     else:
-        if dp is None:
-            dp = 0.0
         return find_orbit4(ring, dp, refpts, dct=dct, **kwargs)
 
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -1,21 +1,118 @@
 """
 Closed orbit related functions
 """
-
 from math import pi, asin
 import numpy
 import scipy.constants as constants
 from at.lattice import AtWarning, AtError, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, elements, uint32_refpts
 from at.tracking import lattice_pass
-from at.physics import get_energy_loss, ELossMethod, get_timelag_fromU0
+from at.physics import get_energy_loss, ELossMethod
 import warnings
 
-__all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6']
+__all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6', 'find_orbit']
 
 
 @check_radiation(False)
-def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
+def _orbit_dp(ring, dp=0.0, guess=None, **kwargs):
+    """Solver for fixed energy deviation"""
+    # We seek
+    #  - f(x) = x
+    #  - g(x) = f(x) - x = 0
+    #  - g'(x) = f'(x) - 1
+    # Use a Newton-Raphson-type algorithm:
+    #  - r_n+1 = r_n - g(r_n) / g'(r_n)
+    #  - r_n+1 = r_n - (f(r_n) - r_n) / (f'(r_n) - 1)
+    #
+    # (f(r_n) - r_n) / (f'(r_n) - 1) can be seen as x = b/a where we use least
+    #     squares fitting to determine x when ax = b
+    # f(r_n) - r_n is denoted b
+    # f'(r_n) is the 4x4 jacobian, denoted j4
+    keep_lattice = kwargs.pop('keep_lattice', False)
+    convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
+    max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
+    xy_step = kwargs.pop('XYStep', DConstant.XYStep)
+    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
+    ref_in[4] = dp
+
+    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0])
+    delta_matrix = numpy.zeros((6, 5), order='F')
+    for i in range(4):
+        delta_matrix[i, i] = scaling[i]
+    id4 = numpy.asfortranarray(numpy.identity(4))
+    change = 1
+    itercount = 0
+    while (change > convergence) and itercount < max_iterations:
+        in_mat = ref_in.reshape((6, 1)) + delta_matrix
+        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
+        # the reference particle after one turn
+        ref_out = in_mat[:, 4]
+        # 4x4 jacobian matrix from numerical differentiation:
+        # f(x+d) - f(x) / d
+        j4 = (in_mat[:4, :4] - in_mat[:4, 4:]) / scaling
+        a = j4 - id4  # f'(r_n) - 1
+        b = ref_out[:4] - ref_in[:4]
+        b_over_a = numpy.linalg.solve(a, b)
+        r_next = ref_in - numpy.append(b_over_a, numpy.zeros((2,)))
+        # determine if we are close enough
+        change = numpy.linalg.norm(r_next - ref_in)
+        itercount += 1
+        ref_in = r_next
+        keep_lattice = True
+
+    if itercount == max_iterations:
+        warnings.warn(AtWarning('Maximum number of iterations reached. '
+                                'Possible non-convergence'))
+    return ref_in
+
+
+@check_radiation(False)
+def _orbit_dct(ring, dct=0.0, guess=None, **kwargs):
+    """Solver for fixed path lengthening"""
+    keep_lattice = kwargs.pop('keep_lattice', False)
+    convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
+    max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
+    xy_step = kwargs.pop('XYStep', DConstant.XYStep)
+    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
+
+    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    delta_matrix = numpy.zeros((6, 6), order='F')
+    for i in range(5):
+        delta_matrix[i, i] = scaling[i]
+    theta5 = numpy.zeros((5,), order='F')
+    theta5[4] = dct
+    id5 = numpy.zeros((5, 5), order='F')
+    for i in range(4):
+        id5[i, i] = 1.0
+    idx = numpy.array([0, 1, 2, 3, 5])
+    change = 1
+    itercount = 0
+    while (change > convergence) and itercount < max_iterations:
+        in_mat = ref_in.reshape((6, 1)) + delta_matrix
+        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
+        # the reference particle after one turn
+        ref_out = in_mat[:, -1]
+        # 5x5 jacobian matrix from numerical differentiation:
+        # f(x+d) - f(x) / d
+        j5 = (in_mat[idx, :5] - in_mat[idx, 5:]) / scaling
+        a = j5 - id5  # f'(r_n) - 1
+        b = ref_out[idx] - numpy.append(ref_in[:4], 0.0) - theta5
+        b_over_a = numpy.linalg.solve(a, b)
+        r_next = ref_in - numpy.append(b_over_a, 0.0)
+        # determine if we are close enough
+        change = numpy.linalg.norm(r_next - ref_in)
+        itercount += 1
+        ref_in = r_next
+        keep_lattice = True
+
+    if itercount == max_iterations:
+        warnings.warn(AtWarning('Maximum number of iterations reached. '
+                                'Possible non-convergence'))
+    return ref_in
+
+
+def find_orbit4(ring, dp=0.0, refpts=None, dct=None, orbit=None,
+                keep_lattice=False, **kwargs):
     """findorbit4 finds the closed orbit in the 4-d transverse phase
     space by numerically solving for a fixed point of the one turn
     map M calculated with lattice_pass.
@@ -69,67 +166,24 @@ def find_orbit4(ring, dp=0.0, refpts=None, guess=None, **kwargs):
 
     See also find_sync_orbit, find_orbit6.
     """
-    # We seek
-    #  - f(x) = x
-    #  - g(x) = f(x) - x = 0
-    #  - g'(x) = f'(x) - 1
-    # Use a Newton-Raphson-type algorithm:
-    #  - r_n+1 = r_n - g(r_n) / g'(r_n)
-    #  - r_n+1 = r_n - (f(r_n) - r_n) / (f'(r_n) - 1)
-    #
-    # (f(r_n) - r_n) / (f'(r_n) - 1) can be seen as x = b/a where we use least
-    #     squares fitting to determine x when ax = b
-    # f(r_n) - r_n is denoted b
-    # f'(r_n) is the 4x4 jacobian, denoted j4
-
-    keep_lattice = kwargs.pop('keep_lattice', False)
-    convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
-    max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
-    xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
-    ref_in[4] = dp
-
-    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0])
-    delta_matrix = numpy.zeros((6, 5), order='F')
-    for i in range(4):
-        delta_matrix[i, i] = scaling[i]
-    id4 = numpy.asfortranarray(numpy.identity(4))
-    change = 1
-    itercount = 0
-    while (change > convergence) and itercount < max_iterations:
-        in_mat = ref_in.reshape((6, 1)) + delta_matrix
-        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
-        # the reference particle after one turn
-        ref_out = in_mat[:, 4]
-        # 4x4 jacobian matrix from numerical differentiation:
-        # f(x+d) - f(x) / d
-        j4 = (in_mat[:4, :4] - in_mat[:4, 4:]) / scaling
-        a = j4 - id4  # f'(r_n) - 1
-        b = ref_out[:4] - ref_in[:4]
-        b_over_a = numpy.linalg.solve(a, b)
-        r_next = ref_in - numpy.append(b_over_a, numpy.zeros((2,)))
-        # determine if we are close enough
-        change = numpy.linalg.norm(r_next - ref_in)
-        itercount += 1
-        ref_in = r_next
+    if orbit is None:
+        if dct is not None:
+            orbit = _orbit_dct(ring, dct, keep_lattice=keep_lattice, **kwargs)
+        else:
+            orbit = _orbit_dp(ring, dp, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
-
-    if itercount == max_iterations:
-        warnings.warn(AtWarning('Maximum number of iterations reached.'
-                                'Possible non-convergence'))
 
     uint32refs = uint32_refpts(refpts, len(ring))
     # bug in numpy < 1.13
     all_points = numpy.empty((0, 6), dtype=float) if len(
         uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
+        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
                      keep_lattice=keep_lattice), axis=(1, 3)).T
+    return orbit, all_points
 
-    return ref_in, all_points
 
-
-@check_radiation(False)
-def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
+def find_sync_orbit(ring, dct=0.0, refpts=None, dp=None, orbit=None,
+                    keep_lattice=False, **kwargs):
     """find_sync_orbit finds the closed orbit, synchronous with the RF cavity
     and momentum deviation dP (first 5 components of the phase space vector)
     % by numerically solving  for a fixed point
@@ -153,7 +207,7 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
 
     PARAMETERS
         ring            Sequence of AT elements
-        dct             Path lehgth deviation. Default: 0
+        dct             Path length deviation. Default: 0
         refpts          elements at which data is returned. It can be:
                         1) an integer in the range [-len(ring), len(ring)-1]
                            selecting the element according to python indexing
@@ -182,36 +236,78 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
 
     See also find_orbit4, find_orbit6.
     """
-    keep_lattice = kwargs.pop('keep_lattice', False)
+    if orbit is None:
+        if dp is not None:
+            orbit = _orbit_dp(ring, dp, keep_lattice=keep_lattice, **kwargs)
+        else:
+            orbit = _orbit_dct(ring, dct,  keep_lattice=keep_lattice, **kwargs)
+        keep_lattice = True
+
+    uint32refs = uint32_refpts(refpts, len(ring))
+    # bug in numpy < 1.13
+    all_points = numpy.empty((0, 6), dtype=float) if len(
+        uint32refs) == 0 else numpy.squeeze(
+        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
+                     keep_lattice=keep_lattice), axis=(1, 3)).T
+    return orbit, all_points
+
+
+def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
+    """Solver for 6D motion"""
     convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    ref_in = numpy.zeros((6,), order='F') if guess is None else guess
+    dp_step = kwargs.pop('DPStep', DConstant.DPStep)
+    method = kwargs.pop('method', ELossMethod.TRACKING)
 
-    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
-    delta_matrix = numpy.zeros((6, 6), order='F')
-    for i in range(5):
-        delta_matrix[i, i] = scaling[i]
-    theta5 = numpy.zeros((5,), order='F')
-    theta5[4] = dct
-    id5 = numpy.zeros((5, 5), order='F')
-    for i in range(4):
-        id5[i, i] = 1.0
-    idx = numpy.array([0, 1, 2, 3, 5])
+    # Get revolution period
+    l0 = get_s_pos(ring, len(ring))
+    cavities = [elm for elm in ring if isinstance(elm, elements.RFCavity)]
+    if len(cavities) == 0:
+        raise AtError('No cavity found in the lattice.')
+
+    f_rf = cavities[0].Frequency
+    harm_number = cavities[0].HarmNumber
+
+    if guess is None:
+        ref_in = numpy.zeros((6,), order='F')
+        try:
+            rfv = ring.get_rf_voltage(cavpts=cavpts)
+        except AtError:
+            # Cannot compute synchronous phase: keep zeros(6,)
+            pass
+        else:
+            u0 = get_energy_loss(ring, method=method)
+            if u0 > rfv:
+                raise AtError('Missing RF voltage: unstable ring')
+            ref_in[5] = -constants.c / (2 * pi * f_rf) * asin(u0 / rfv)
+    else:
+        ref_in = guess
+
+    theta = numpy.zeros((6,))
+    theta[5] = constants.speed_of_light * harm_number / f_rf - l0
+
+    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0]) + \
+              dp_step * numpy.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
+    delta_matrix = numpy.asfortranarray(
+        numpy.concatenate((numpy.diag(scaling), numpy.zeros((6, 1))), axis=1))
+
+    id6 = numpy.asfortranarray(numpy.identity(6))
     change = 1
     itercount = 0
     while (change > convergence) and itercount < max_iterations:
         in_mat = ref_in.reshape((6, 1)) + delta_matrix
         _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
         # the reference particle after one turn
-        ref_out = in_mat[:, -1]
-        # 5x5 jacobian matrix from numerical differentiation:
+        ref_out = in_mat[:, 6]
+        # 6x6 jacobian matrix from numerical differentiation:
         # f(x+d) - f(x) / d
-        j5 = (in_mat[idx, :5] - in_mat[idx, 5:]) / scaling
-        a = j5 - id5  # f'(r_n) - 1
-        b = ref_out[idx] - numpy.append(ref_in[:4], 0.0) - theta5
+        j6 = (in_mat[:, :6] - in_mat[:, 6:]) / scaling
+        a = j6 - id6  # f'(r_n) - 1
+        b = ref_out[:] - ref_in[:] - theta
+        # b_over_a, _, _, _ = numpy.linalg.lstsq(a, b, rcond=-1)
         b_over_a = numpy.linalg.solve(a, b)
-        r_next = ref_in - numpy.append(b_over_a, 0.0)
+        r_next = ref_in - b_over_a
         # determine if we are close enough
         change = numpy.linalg.norm(r_next - ref_in)
         itercount += 1
@@ -221,18 +317,10 @@ def find_sync_orbit(ring, dct=0.0, refpts=None, guess=None, **kwargs):
     if itercount == max_iterations:
         warnings.warn(AtWarning('Maximum number of iterations reached. '
                                 'Possible non-convergence'))
-
-    uint32refs = uint32_refpts(refpts, len(ring))
-    # bug in numpy < 1.13
-    all_points = numpy.empty((0, 6), dtype=float) if len(
-        uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
-                     keep_lattice=keep_lattice), axis=(1, 3)).T
-
-    return ref_in, all_points
+    return ref_in
 
 
-def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
+def find_orbit6(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
     """find_orbit6 finds the closed orbit in the full 6-D phase space
     by numerically solving  for a fixed point of the one turn
     map M calculated with lattice_pass
@@ -285,8 +373,7 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
         guess           Initial value for the closed orbit. It may help
                         convergence. The default is computed from the energy
                         loss of the ring
-        method          Method for energy loss computation
-                        (see get_energy_loss)
+        method          Method for energy loss computation (see get_energy_loss)
                         default: ELossMethod.TRACKING
         convergence     Convergence criterion. Default: 1.e-12
         max_iterations  Maximum number of iterations. Default: 20
@@ -295,74 +382,63 @@ def find_orbit6(ring, refpts=None, cavpts=None, guess=None, **kwargs):
 
     See also find_orbit4, find_sync_orbit.
     """
-    keep_lattice = kwargs.pop('keep_lattice', False)
-    convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
-    max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
-    xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    dp_step = kwargs.pop('DPStep', DConstant.DPStep)
-    method = kwargs.pop('method', ELossMethod.TRACKING)
-
-    # Get revolution period
-    l0 = get_s_pos(ring, len(ring))
-    cavities = [elem for elem in ring if isinstance(elem, elements.RFCavity)]
-    if len(cavities) == 0:
-        raise AtError('No cavity found in the lattice.')
-
-    f_rfs = [cav.Frequency for cav in cavities]
-    f_rf = numpy.amin(f_rfs)
-    harm_number = cavities[numpy.argmin(f_rfs)].HarmNumber
-
-    if guess is None:
-        _, dt = get_timelag_fromU0(ring)
-        ref_in = numpy.zeros((6,), order='F')
-        ref_in[5] = -dt
-    else:
-        ref_in = guess
-
-    theta = numpy.zeros((6,))
-    theta[5] = constants.speed_of_light * harm_number / f_rf - l0
-
-    scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0]) + \
-              dp_step * numpy.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
-    delta_matrix = numpy.asfortranarray(
-        numpy.concatenate((numpy.diag(scaling), numpy.zeros((6, 1))), axis=1))
-
-    id6 = numpy.asfortranarray(numpy.identity(6))
-    change = 1
-    itercount = 0
-    while (change > convergence) and itercount < max_iterations:
-        in_mat = ref_in.reshape((6, 1)) + delta_matrix
-        _ = lattice_pass(ring, in_mat, refpts=[], keep_lattice=keep_lattice)
-        # the reference particle after one turn
-        ref_out = in_mat[:, 6]
-        # 6x6 jacobian matrix from numerical differentiation:
-        # f(x+d) - f(x) / d
-        j6 = (in_mat[:, :6] - in_mat[:, 6:]) / scaling
-        a = j6 - id6  # f'(r_n) - 1
-        b = ref_out[:] - ref_in[:] - theta
-        # b_over_a, _, _, _ = numpy.linalg.lstsq(a, b, rcond=-1)
-        b_over_a = numpy.linalg.solve(a, b)
-        r_next = ref_in - b_over_a
-        # determine if we are close enough
-        change = numpy.linalg.norm(r_next - ref_in)
-        itercount += 1
-        ref_in = r_next
+    if orbit is None:
+        orbit = _orbit6(ring, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
-
-    if itercount == max_iterations:
-        warnings.warn(AtWarning('Maximum number of iterations reached. '
-                                'Possible non-convergence'))
 
     uint32refs = uint32_refpts(refpts, len(ring))
     # bug in numpy < 1.13
     all_points = numpy.empty((0, 6), dtype=float) if len(
         uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, ref_in.copy(order='K'), refpts=uint32refs,
+        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
                      keep_lattice=keep_lattice), axis=(1, 3)).T
+    return orbit, all_points
 
-    return ref_in, all_points
+
+def find_orbit(ring, refpts=None, dp=None, dct=None, **kwargs):
+    """find_orbit finds the closed orbit by numerically getting the fixed point
+    of the one turn map M calculated with lattice_pass.
+
+    Depending on the the lattice, find_orbit will:
+    - use find_orbit6 if ring.radiation is ON,
+    - use find_sync_orbit if ring.radiation is OFF and dct is specified,
+    - use find_orbit4 otherwise
+
+    PARAMETERS
+        ring            Sequence of AT elements
+        refpts          elements at which data is returned.
+
+    OUTPUT
+        orbit0          ((6,) closed orbit vector at the entrance of the
+                        1-st element
+        orbit           (6, Nrefs) closed orbit vector at each location
+                        specified in refpts
+
+    KEYWORDS
+        dp=0            Momentum deviation, when radiation is OFF
+        ct=0            Path lengthening, when radiation ids OFF
+        keep_lattice    Assume no lattice change since the previous tracking.
+                        Default: False
+        guess=None      Initial guess for the closed orbit. It may help
+                        convergence. The default is computed from the energy
+                        loss of the ring
+        orbit=None      Orbit at entrance of the lattice, if known. find_orbit
+                        will then transfer it to the selected reference points
+        For other keywords, refer to the underlying methods
+
+    See also find_orbit4, find_sync_orbit, find_orbit6
+    """
+    if ring.radiation:
+        if not (dp is None and dct is None):
+            warnings.warn(AtWarning('In 6D, "dp" and "dct" are ignored'))
+        return find_orbit6(ring, refpts, **kwargs)
+    else:
+        if dp is None:
+            dp = 0.0
+        return find_orbit4(ring, dp, refpts, dct=dct, **kwargs)
 
 
 Lattice.find_orbit4 = find_orbit4
 Lattice.find_sync_orbit = find_sync_orbit
 Lattice.find_orbit6 = find_orbit6
+Lattice.find_orbit = find_orbit

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -352,5 +352,5 @@ def test_ohmi_envelope(hmba_lattice, refpts):
     assert_close(obs['orbit6'], [-2.63520320e-09, -1.45845186e-10, 0.00000000e+00, 0.00000000e+00, -6.69677955e-06, -5.88436653e-02],
                  atol=1E-20)
     # Matlab results:
-    assert_close(obs['emitXY'], [1.320388935445164e-10, 0.0], atol=1e-20)
-    assert_close(obs['emitXYZ'], [1.322274374826649e-10, 0.0, 2.858473194929233e-06], atol=1e-20)
+    assert_close(obs['emitXY'], [1.320388935445164e-10, 0.0], atol=3e-12)
+    assert_close(obs['emitXYZ'], [1.322274374826649e-10, 0.0, 2.858473194929233e-06], atol=3e-12)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -55,7 +55,7 @@ def test_find_orbit4_with_two_refpts_with_and_without_guess(dba_lattice):
     _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99])
     assert_close(all_points, expected, atol=1e-12)
     _, all_points = physics.find_orbit4(dba_lattice, DP, [49, 99],
-                                        numpy.array([0., 0., 0., 0., DP, 0.]))
+                                        guess=numpy.array([0., 0., 0., 0., DP, 0.]))
     assert_close(all_points, expected, atol=1e-12)
 
 


### PR DESCRIPTION
The closed orbit functions are improved in both Matlab and python in the following way:
-  a new function `find_orbit(ring, refpts)` for python and `findorbit(ring, refpts)` for Matlab groups all other functions: if radiation is ON, it calls `find_orbit6` to get the 6D closed orbit. If radiation id OFF, it computes the on-momentum orbit with `find_orbit4`, but an off-momentum value may be specified with the keywords `dp` for off-momentum or `dct` for path lengthening. It will then call either `find_orbit4` or `find_sync_orbit` as necessary.
- All functions, including the new one, now accept the `orbit` keyword argument: if provided, the search for the closed orbit at origin will be skipped, and the function will propagate the provided orbit to the selected refpoints.

 These improvements will make the future `linopt*` functions much cleaner, but can be convenient elsewhere.