### PR TITLE
deprecated order argument

### DIFF
--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -19,36 +19,36 @@ def _get_chrom(ring, dp=0):
     return chrom
 
 
-def _fit_tune_chrom(ring, order, func, refpts1, refpts2, newval, tol=1.0e-12,
+def _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=1.0e-12,
                     dp=0, niter=3):
 
-    def _get_resp(ring, order, func, refpts, attname, delta, dp=0):
-        set_value_refpts(ring, refpts, attname, delta, order=order,
+    def _get_resp(ring, index, func, refpts, attname, delta, dp=0):
+        set_value_refpts(ring, refpts, attname, delta, index=index,
                          increment=True)
         datap = func(ring, dp=dp)
-        set_value_refpts(ring, refpts, attname, -2*delta, order=order,
+        set_value_refpts(ring, refpts, attname, -2*delta, index=index,
                          increment=True)
         datan = func(ring, dp=dp)
-        set_value_refpts(ring, refpts, attname, delta, order=order,
+        set_value_refpts(ring, refpts, attname, delta, index=index,
                          increment=True)
         data = numpy.subtract(datap, datan)/(2*delta)
         return data
 
-    delta = 1e-6*10**(order)
+    delta = 1e-6*10**(index)
     val = func(ring, dp=dp)
-    dq1 = _get_resp(ring, order, func, refpts1, 'PolynomB', delta, dp=dp)
-    dq2 = _get_resp(ring, order, func, refpts2, 'PolynomB', delta, dp=dp)
+    dq1 = _get_resp(ring, index, func, refpts1, 'PolynomB', delta, dp=dp)
+    dq2 = _get_resp(ring, index, func, refpts2, 'PolynomB', delta, dp=dp)
     J = [[dq1[0], dq2[0]], [dq1[1], dq2[1]]]
     dk = numpy.linalg.solve(J, numpy.subtract(newval, val))
-    set_value_refpts(ring, refpts1, 'PolynomB', dk[0], order=order,
+    set_value_refpts(ring, refpts1, 'PolynomB', dk[0], index=index,
                      increment=True)
-    set_value_refpts(ring, refpts2, 'PolynomB', dk[1], order=order,
+    set_value_refpts(ring, refpts2, 'PolynomB', dk[1], index=index,
                      increment=True)
 
     val = func(ring, dp=dp)
     sumsq = numpy.sum(numpy.square(numpy.subtract(val, newval)))
     if sumsq > tol and niter > 0:
-        _fit_tune_chrom(ring, order, func, refpts1, refpts2, newval, tol=tol,
+        _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=tol,
                         dp=dp, niter=niter-1)
     else:
         return

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -347,7 +347,7 @@ class LinoptConstraints(ElementConstraints):
             def fun(refdata, tune, chrom):
                 if param == 'mu':
                     return getf(refdata, param)%(2*np.pi)
-                elif param == 'mu' and UseInteger:
+                elif param == 'mu' and use_integer:
                     self.refpts[:] = True # necessary not to miss 2*pi jumps
                 return getf(refdata, param)
             if param == 'dispersion':

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -34,7 +34,7 @@ class Variable(object):
     def status(self, ring, vini=np.NaN):
         vnow = self.get(ring)
         return '{:>12s}{: 16e}{: 16e}{: 16e}'.format(
-            self.name, vini, vnow, (vnow - vini) / vini)
+            self.name, vini, vnow, (vnow - vini))
 
 
 class ElementVariable(Variable):
@@ -342,7 +342,10 @@ class LinoptConstraints(ElementConstraints):
         else:
             # noinspection PyUnusedLocal
             def fun(refdata, tune, chrom):
-                return getf(refdata, param)
+                if param == 'mu':
+                    return getf(refdata, param)%(2*np.pi)
+                else:
+                    return getf(refdata, param)
             if param == 'dispersion':
                 self.get_chrom = True   # slower but necessary
             # elif param == 'mu':

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -311,12 +311,15 @@ class LinoptConstraints(ElementConstraints):
             weight=1.0    weight factor: the residual is (value-target)/weight.
             bounds=(0,0)  lower and upper bounds. The parameter is constrained
                           in the interval [target-low_bound target+up_bound]
+            UseInteger    Match integer part of mu, much slower as the optics
+                          calculation is done for all refpts
 
         The target, weight and bounds values must be broadcastable to the shape
         of value.
         """
         getf = self._recordaccess(index)
         getv = self._arrayaccess(index)
+        use_integer = kwargs.pop('UseInteger', False)
 
         if name is None:                # Generate the constraint name
             name = param.__name__ if callable(param) else param
@@ -344,12 +347,11 @@ class LinoptConstraints(ElementConstraints):
             def fun(refdata, tune, chrom):
                 if param == 'mu':
                     return getf(refdata, param)%(2*np.pi)
-                else:
-                    return getf(refdata, param)
+                elif param == 'mu' and UseInteger:
+                    self.refpts[:] = True # necessary not to miss 2*pi jumps
+                return getf(refdata, param)
             if param == 'dispersion':
                 self.get_chrom = True   # slower but necessary
-            # elif param == 'mu':
-            #     self.refpts[:] = True # necessary not to miss 2*pi jumps
 
         super(LinoptConstraints, self).add(fun, target, refpts, name=name,
                                            **kwargs)


### PR DESCRIPTION
This branches implements a few fixes on the matching modules

- globalfit: replace deprecated order argument with index
- matching: introduce optional argument UseInteger, if false (default) only the fractional part of the phase is matched. This is to avoid computing the optics at all refpts to match the integer part of the phase which represent an enormous loss in speed
- the fit results display the absolute variation to avoid nans in case the initial value is zero