### PR TITLE
allow for long field names and arbitrary type in ndarray

### DIFF
--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -194,7 +194,7 @@ def save_mat(ring, filename, mat_key='RING'):
         mat_key='RING'  Name of the Matlab variable representing the lattice
     """
     lring = tuple((element_to_dict(elem),) for elem in matlab_ring(ring))
-    scipy.io.savemat(filename, {mat_key: lring})
+    scipy.io.savemat(filename, {mat_key: lring}, long_field_names=True)
 
 
 def save_m(ring, filename=None):

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -63,8 +63,7 @@ _matclass_map = {'Dipole': 'Bend'}
 
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr,
-                                                             dtype=float)}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr)}
 
 _class_to_matfunc = {
     elt.Dipole: 'atsbend',


### PR DESCRIPTION
Fixes related to problems in saving ESRF lattices to mat files:
-allow for arbitrary type in ndarray
-allow for long field names in scipy savemat