### PR TITLE
Default behavior

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atSetCavityPhase.m
+++ b/atmat/atphysics/LongitudinalDynamics/atSetCavityPhase.m
@@ -10,6 +10,9 @@ function newring=atSetCavityPhase(ring,varargin)
 %   CAVPTS is the location of RF cavities. This allows to ignore harmonic
 %   cavities.
 %
+%WARNING: This function modifies the time reference,
+%this should be avoided
+%
 %NEWRING=SETCAVITYPHASE(...,'method',METHOD)
 %   Choose the method for computing the energy loss per turn
 %
@@ -27,9 +30,6 @@ freq=unique(atgetfieldvalues(ring(cavities),'Frequency'));
 if length(freq) > 1
     error('AT:NoFrequency','RF frequency not equal for all cavities');
 end
-warning('AT:CavityTimeLag',...
-    ['\nThis function modifies the time reference\n',...
-       'This should be avoided, you have been warned\n']);
 U0=atgetU0(ring,'periods',1,varargs);
 if U0 > rfv
     error('AT:NoEnoughRFVoltage','Not enough RF voltage, unstable ring.');

--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -1,6 +1,9 @@
 function ring = atsetcavity(ring,varargin)
 %ATSECAVITY Set the cavity parameters
 %
+%WARNING: This function modifies the time reference,
+%this should be avoided
+%
 %ATSETCAVITY may be used in two modes:
 %
 %Upgrade mode
@@ -112,9 +115,6 @@ else                            % Old syntax, for compatibility
     
     %now set phaselags in cavities
     if radflag
-        warning('AT:CavityTimeLag',...
-            ['\nThis function modifies the time reference\n',...
-            'This should be avoided, you have been warned\n']);
         U0=atgetU0(ring);
         timelag= (circ/(2*pi*HarmNumber))*asin(U0/(rfv));
         ring=atradon(ring);  % set radiation on. nothing if radiation is already on

--- a/atmat/atphysics/Radiation/atradon.m
+++ b/atmat/atphysics/Radiation/atradon.m
@@ -29,10 +29,10 @@ function [ring,radelemIndex,cavitiesIndex,energy]=atradon(ring,varargin)
 %   The following keywords trigger the processing of the following elements:
 %
 %   'bendpass'      pass method for bending magnets. Default 'auto'
-%   'quadpass'      pass method for quadrupoles. Default ''
+%   'quadpass'      pass method for quadrupoles. Default 'auto'
 %   'sextupass'     pass method for sextupoles. Default ''
-%   'octupass'      pass method for bending magnets. Default ''
-%   'wigglerpass'   pass method for wigglers. Default ''
+%   'octupass'      pass method for octupoles. Default ''
+%   'wigglerpass'   pass method for wigglers. Default 'auto'
 %
 %  OUPUTS
 %  1. RING2     Output ring
@@ -43,19 +43,19 @@ function [ring,radelemIndex,cavitiesIndex,energy]=atradon(ring,varargin)
 %  EXAMPLES
 %
 %>> ringrad=atradon(ring);
-%   Turns cavities on and sets radiation in bending magnets and wigglers (default)
+%   Turns cavities on and sets radiation in bending magnets, quadrupoles and wigglers (default)
 %
 %>> ringrad=atradon(ring,'CavityPass','auto','auto');
 %   Turns cavities on and sets radiation in bending magnets, wigglers and quadrupoles
 %
-%>> ringrad=atradon(ring,'quadpass','auto');
-%   Turns cavities on and sets radiation in bending magnets, wigglers and quadrupoles
+%>> ringrad=atradon(ring,'quadpass','');
+%   Turns cavities on and sets radiation in bending magnets, wigglers
 %
 %  See also ATRADOFF, ATCAVITYON, ATCAVITYOFF
 
 [octupass,varargs]=getoption(varargin,'octupass','');
 [sextupass,varargs]=getoption(varargs,'sextupass','');
-[quadpass,varargs]=getoption(varargs,'quadpass','');
+[quadpass,varargs]=getoption(varargs,'quadpass','auto');
 [wigglerpass,varargs]=getoption(varargs,'wigglerpass','auto');
 [bendpass,varargs]=getoption(varargs,'bendpass','auto');
 [cavipass,varargs]=getoption(varargs,'cavipass','CavityPass');

--- a/atmat/lattice/element_creation/atquadrupole.m
+++ b/atmat/lattice/element_creation/atquadrupole.m
@@ -7,7 +7,7 @@ function elem=atquadrupole(fname,varargin)
 %  1. FAMNAME    - Family name
 %  2. LENGTH     - Length [m]
 %  3. K          - Strength [m-2]
-%  4. PASSMETHOD - Tracking function, defaults to 'QuadLinearPass'
+%  4. PASSMETHOD - Tracking function, defaults to 'StrMPoleSymplectic4Pass'
 %
 %  OPTIONS (order does not matter)
 %    R1			 -	6 x 6 rotation matrix at the entrance
@@ -37,11 +37,12 @@ function elem=atquadrupole(fname,varargin)
 %  See also atdrift, atsextupole, atsbend, atrbend, atskewquad,
 %          atmultipole, atthinmultipole, atmarker, atcorrector, atringparam
 
-[rsrc,L,K,method] = decodeatargs({0,[],'QuadLinearPass'},varargin);
+[rsrc,L,K,method] = decodeatargs({0,[],'StrMPoleSymplectic4Pass'},varargin);
 [L,rsrc]          = getoption(rsrc,'Length',L);
 [K,rsrc]          = getoption(rsrc,'K',K);
 [method,rsrc]     = getoption(rsrc,'PassMethod',method);
 [PolynomB,rsrc]   = getoption(rsrc,'PolynomB',[0 0]);
+[PolynomA,rsrc]   = getoption(rsrc,'PolynomA',[0 0]);
 [cl,rsrc]         = getoption(rsrc,'Class','Quadrupole');
 
 % Gradient setting if not specified explicitly
@@ -49,5 +50,5 @@ if ~isempty(K), PolynomB(2)=K; end
 
 % Build the element
 elem=atbaselem(fname,method,'Class',cl,'Length',L,'K',PolynomB(2),...
-    'PolynomB',PolynomB,'DefaultMaxOrder',1,rsrc{:});
+    'PolynomB',PolynomB,'PolynomA',PolynomA,'DefaultMaxOrder',1,rsrc{:});
 end

--- a/atmat/lattice/element_creation/atrbend.m
+++ b/atmat/lattice/element_creation/atrbend.m
@@ -10,7 +10,7 @@ function elem=atrbend(fname,varargin)
 %                     [m], default to 0
 %  3. BENDINGANGLE - Total bending angle [rad], defaults to 0 
 %  4. K			   - Focusing strength, defaults to 0
-%  5. PASSMETHOD   -Tracking function, defaults to 'BendLinearPass'
+%  5. PASSMETHOD   -Tracking function, defaults to 'BndMPoleSymplectic4Pass'
 %
 %  OPTIONS (order does not matter)
 %    R1				6 x 6 rotation matrix at the entrance
@@ -55,12 +55,13 @@ function elem=atrbend(fname,varargin)
 %          atmultipole, atthinmultipole, atmarker, atcorrector
 
 % Input parser for option
-[rsrc,L,A,K,method]  = decodeatargs({0,0,[],'BendLinearPass'},varargin);
+[rsrc,L,A,K,method]  = decodeatargs({0,0,[],'BndMPoleSymplectic4Pass'},varargin);
 [L,rsrc]             = getoption(rsrc,'Length',L);
 [A,rsrc]             = getoption(rsrc,'BendingAngle',A);
 [K,rsrc]             = getoption(rsrc,'K',K);
 [method,rsrc]        = getoption(rsrc,'PassMethod',method);
 [PolynomB,rsrc]      = getoption(rsrc,'PolynomB',[0 0]);
+[PolynomA,rsrc]      = getoption(rsrc,'PolynomA',[0 0]);
 [cl,rsrc]            = getoption(rsrc,'Class','Bend');
 [EntranceAngle,rsrc] = getoption(rsrc,'EntranceAngle',0.5*A);
 [ExitAngle,rsrc]     = getoption(rsrc,'ExitAngle',0.5*A);
@@ -71,5 +72,5 @@ if ~isempty(K), PolynomB(2) = K; end
 % Build the element
 elem = atbaselem(fname,method,'Class',cl,'Length',L,...
     'BendingAngle',A,'EntranceAngle',EntranceAngle,'ExitAngle',ExitAngle,...
-    'K',PolynomB(2),'PolynomB',PolynomB,rsrc{:});
+    'K',PolynomB(2),'PolynomB',PolynomB,'PolynomA',PolynomA,rsrc{:});
 end

--- a/atmat/lattice/element_creation/atsbend.m
+++ b/atmat/lattice/element_creation/atsbend.m
@@ -10,7 +10,7 @@ function elem=atsbend(fname,varargin)
 %                     	[m], default to 0
 %  3. BENDINGANGLE	Total bending angle [rad], defaults to 0 
 %  4. K				Focusing strength, defaults to 0
-%  5. PASSMETHOD    Tracking function, defaults to 'BendLinearPass'
+%  5. PASSMETHOD    Tracking function, defaults to 'BndMPoleSymplectic4Pass'
 %
 %  OPTIONS (order does not matter)
 %    R1				6 x 6 rotation matrix at the entrance
@@ -55,12 +55,13 @@ function elem=atsbend(fname,varargin)
 %          atmultipole, atthinmultipole, atmarker, atcorrector
 
 % Input parser for option
-[rsrc,L,A,K,method]  = decodeatargs({0,0,[],'BendLinearPass'},varargin);
+[rsrc,L,A,K,method]  = decodeatargs({0,0,[],'BndMPoleSymplectic4Pass'},varargin);
 [L,rsrc]             = getoption(rsrc,'Length',L);
 [A,rsrc]             = getoption(rsrc,'BendingAngle',A);
 [K,rsrc]             = getoption(rsrc,'K',K);
 [method,rsrc]        = getoption(rsrc,'PassMethod',method);
 [PolynomB,rsrc]      = getoption(rsrc,'PolynomB',[0 0]);
+[PolynomA,rsrc]      = getoption(rsrc,'PolynomA',[0 0]);
 [cl,rsrc]            = getoption(rsrc,'Class','Bend');
 [EntranceAngle,rsrc] = getoption(rsrc,'EntranceAngle',0);
 [ExitAngle,rsrc]     = getoption(rsrc,'ExitAngle',0);
@@ -70,5 +71,5 @@ if ~isempty(K), PolynomB(2)=K; end
 
 elem=atbaselem(fname,method,'Class',cl,'Length',L,...
     'BendingAngle',A,'EntranceAngle',EntranceAngle,'ExitAngle',ExitAngle,...
-    'K',PolynomB(2),'PolynomB',PolynomB,rsrc{:});
+    'K',PolynomB(2),'PolynomB',PolynomB,'PolynomA',PolynomA,rsrc{:});
 end

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -386,7 +386,7 @@ class Dipole(Multipole):
         kwargs.setdefault('BendingAngle', bending_angle)
         kwargs.setdefault('EntranceAngle', 0.0)
         kwargs.setdefault('ExitAngle', 0.0)
-        kwargs.setdefault('PassMethod', 'BendLinearPass')
+        kwargs.setdefault('PassMethod', 'BndMPoleSymplectic4Pass')
         super(Dipole, self).__init__(family_name, length, [], poly_b, **kwargs)
 
     def _part(self, fr, sumfr):
@@ -439,7 +439,7 @@ class Quadrupole(Multipole):
         KickAngle       Correction deviation angles (H, V)
         """
         poly_b = kwargs.pop('PolynomB', numpy.array([0, k]))
-        kwargs.setdefault('PassMethod', 'QuadLinearPass')
+        kwargs.setdefault('PassMethod', 'StrMPoleSymplectic4Pass')
         super(Quadrupole, self).__init__(family_name, length, [], poly_b,
                                          **kwargs)
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -395,7 +395,7 @@ class Lattice(list):
 
     # noinspection PyShadowingNames
     def radiation_on(self, cavity_pass='CavityPass', dipole_pass='auto',
-                     quadrupole_pass=None, wiggler_pass='auto',
+                     quadrupole_pass='auto', wiggler_pass='auto',
                      sextupole_pass=None, octupole_pass=None, copy=False):
         """
         Turn acceleration and radiation on and return the lattice
@@ -403,7 +403,7 @@ class Lattice(list):
         KEYWORDS
             cavity_pass='CavityPass'    PassMethod set on cavities
             dipole_pass='auto'          PassMethod set on dipoles
-            quadrupole_pass=None        PassMethod set on quadrupoles
+            quadrupole_pass='auto'      PassMethod set on quadrupoles
             wiggler_pass='auto'         PassMethod set on wigglers
             copy=False  If False, the modification is done in-place,
                         If True, return a shallow copy of the lattice. Only the

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -145,6 +145,9 @@ def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
    voltage and energy loss per turn, so that the synchronous phase is zero.
    An error occurs if all cavities do not have the same frequency.
 
+   !!!!WARNING!!!: This function changes the time reference, this should be 
+   avoided
+
     PARAMETERS
         ring        lattice description
 
@@ -165,9 +168,6 @@ def set_cavity_phase(ring, method=ELossMethod.INTEGRAL,
         cavpts = get_cells(ring, checktype(RFCavity))
     timelag, ts = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)
-    print("\nThis function modifies the time reference\n"
-          "This should be avoided, you have been warned!\n",
-          file=sys.stderr)
 
 
 Lattice.get_energy_loss = get_energy_loss

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -293,8 +293,8 @@ def test_quad(rin):
     lattice = [q]
     rin[0, 0] = 1e-6
     atpass(lattice, rin, 1)
-    expected = numpy.array([0.921060994002885, -0.389418342308651, 0,
-                            0, 0, 0.000000010330489]).reshape(6, 1) * 1e-6
+    expected = numpy.array([0.9210610203854122, -0.3894182419439, 0,
+                            0, 0, 0.0000000103303797478]).reshape(6, 1) * 1e-6
     numpy.testing.assert_allclose(rin, expected)
     assert q.K == 1
     q.PolynomB[1] = 0.2

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -286,7 +286,7 @@ def test_quantdiff(hmba_lattice):
 
 @pytest.mark.parametrize('refpts', ([121], [0, 40, 121]))
 def test_ohmi_envelope(hmba_lattice, refpts):
-    hmba_lattice = hmba_lattice.radiation_on(copy=True, quadrupole_pass='')
+    hmba_lattice = hmba_lattice.radiation_on(copy=True)
     emit0, beamdata, emit = hmba_lattice.ohmi_envelope(refpts)
     obs = emit[-1]
     assert_close(beamdata['tunes'], [3.81563019e-01, 8.54376397e-01, 1.09060761e-04], rtol=2e-6)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -251,7 +251,7 @@ def test_nl_detuning_chromaticity(hmba_lattice):
 
 
 def test_quantdiff(hmba_lattice):
-    hmba_lattice = hmba_lattice.radiation_on(quadrupole_pass='auto', copy=True)
+    hmba_lattice = hmba_lattice.radiation_on(copy=True)
     dmat = physics.radiation.quantdiffmat(hmba_lattice)
     lmat = physics.radiation._lmat(dmat)
     assert_close(lmat,
@@ -286,7 +286,7 @@ def test_quantdiff(hmba_lattice):
 
 @pytest.mark.parametrize('refpts', ([121], [0, 40, 121]))
 def test_ohmi_envelope(hmba_lattice, refpts):
-    hmba_lattice = hmba_lattice.radiation_on(copy=True)
+    hmba_lattice = hmba_lattice.radiation_on(copy=True, quadrupole_pass='')
     emit0, beamdata, emit = hmba_lattice.ohmi_envelope(refpts)
     obs = emit[-1]
     assert_close(beamdata['tunes'], [3.81563019e-01, 8.54376397e-01, 1.09060761e-04], rtol=2e-6)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -82,7 +82,7 @@ def test_find_m44_returns_same_answer_as_matlab(dba_lattice, refpts):
 
 @pytest.mark.parametrize('refpts', ([145], [20], [1, 2, 3]))
 def test_find_m66(hmba_lattice, refpts):
-    hmba_lattice = hmba_lattice.radiation_on(copy=True)
+    hmba_lattice = hmba_lattice.radiation_on(copy=True, quadrupole_pass=None)
     m66, mstack = physics.find_m66(hmba_lattice, refpts=refpts)
     assert_close(m66, M66_MATLAB, rtol=0, atol=1e-8)
     stack_size = 0 if refpts is None else len(refpts)
@@ -119,7 +119,7 @@ def test_find_sync_orbit_finds_zeros(dba_lattice):
 
 
 def test_find_orbit6(hmba_lattice):
-    hmba_lattice = hmba_lattice.radiation_on(copy=True)
+    hmba_lattice = hmba_lattice.radiation_on(quadrupole_pass=None, copy=True)
     refpts = numpy.ones(len(hmba_lattice), dtype=bool)
     orbit6, all_points = physics.find_orbit6(hmba_lattice, refpts)
     assert_close(orbit6, orbit6_MATLAB, rtol=0, atol=1e-12)
@@ -286,7 +286,7 @@ def test_quantdiff(hmba_lattice):
 
 @pytest.mark.parametrize('refpts', ([121], [0, 40, 121]))
 def test_ohmi_envelope(hmba_lattice, refpts):
-    hmba_lattice = hmba_lattice.radiation_on(copy=True)
+    hmba_lattice = hmba_lattice.radiation_on(quadrupole_pass=None, copy=True)
     emit0, beamdata, emit = hmba_lattice.ohmi_envelope(refpts)
     obs = emit[-1]
     assert_close(beamdata['tunes'], [3.81563019e-01, 8.54376397e-01, 1.09060761e-04], rtol=2e-6)


### PR DESCRIPTION
This branch is a placeholder for discussion, for now 2 changes are propose that as a user I would find very beneficial:

-remove warning messages in energy_loss, in my opinion a warning in the `docstring` is sufficient

-set default `radiation_on()` with `quadrupole_pass=auto`: this has been the source of many mistakes and wasted time at ESRF, I do not see any benefit in leaving this disabled by default. With modern computer, the overhead is not so relevant anymore and for standard "on-axis" usage results will be unchanged and will remain correct for DA computations, off-momentum or strong radiation lattices etc... 

This is a draft, and changes were applied only to pyAT as examples. I believe it would be good to have an open discussion on these topics that seem to be recurrent requests/issues.

Please comment and propose other modifications in case you have any.