### PR TITLE
Matching with linopt2/4/6

### DIFF
--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -4,19 +4,18 @@ such as the tune and the chromaticity
 """
 import numpy
 from at.lattice import set_value_refpts
-from at.physics import linopt
+from at.physics import get_tune, get_chrom
+from at.matching import matching 
 
 __all__ = ['fit_tune', 'fit_chrom']
 
 
 def _get_tune(ring, dp=0):
-    _, tune, _, _ = linopt(ring, dp=dp)
-    return tune
+    return get_tune(ring, dp=0)[0:2]
 
 
 def _get_chrom(ring, dp=0):
-    _, _, chrom, _ = linopt(ring, dp=dp, get_chrom=True)
-    return chrom
+    return get_chrom(ring, dp=0)[0:2]
 
 
 def _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=1.0e-12,
@@ -34,24 +33,31 @@ def _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=1.0e-12,
         data = numpy.subtract(datap, datan)/(2*delta)
         return data
 
+    def _fit(ring, index, func, refpts1, refpts2, newval, J, dp=0):
+        val = func(ring, dp=dp)
+        dk = numpy.linalg.solve(J, numpy.subtract(newval, val))
+        set_value_refpts(ring, refpts1, 'PolynomB', dk[0], index=index,
+                         increment=True)
+        set_value_refpts(ring, refpts2, 'PolynomB', dk[1], index=index,
+                         increment=True)
+        val = func(ring, dp=dp)
+        sumsq = numpy.sum(numpy.square(numpy.subtract(val, newval)))
+        return sumsq
+
     delta = 1e-6*10**(index)
-    val = func(ring, dp=dp)
     dq1 = _get_resp(ring, index, func, refpts1, 'PolynomB', delta, dp=dp)
     dq2 = _get_resp(ring, index, func, refpts2, 'PolynomB', delta, dp=dp)
     J = [[dq1[0], dq2[0]], [dq1[1], dq2[1]]]
-    dk = numpy.linalg.solve(J, numpy.subtract(newval, val))
-    set_value_refpts(ring, refpts1, 'PolynomB', dk[0], index=index,
-                     increment=True)
-    set_value_refpts(ring, refpts2, 'PolynomB', dk[1], index=index,
-                     increment=True)
-
-    val = func(ring, dp=dp)
-    sumsq = numpy.sum(numpy.square(numpy.subtract(val, newval)))
-    if sumsq > tol and niter > 0:
-        _fit_tune_chrom(ring, index, func, refpts1, refpts2, newval, tol=tol,
-                        dp=dp, niter=niter-1)
-    else:
-        return
+    
+    n=0
+    sumsq = tol+1
+    print('Initial value', func(ring, dp=dp))
+    while sumsq > tol and n < niter:
+        sumsq= _fit(ring, index, func, refpts1, refpts2, newval, J, dp=dp)
+        print('iter#',n,'Res.',sumsq)
+        n +=1
+    print('Final value', func(ring, dp=dp),'\n')
+    return
 
 
 def fit_tune(ring, refpts1, refpts2, newval, tol=1.0e-12, dp=0, niter=3):
@@ -70,6 +76,7 @@ def fit_tune(ring, refpts1, refpts2, newval, tol=1.0e-12, dp=0, niter=3):
     Typical usage:
     at.matching.fit_tune(ring, refpts1, refpts2, [0.1,0.25])
     """
+    print('\nFitting Tune...')
     _fit_tune_chrom(ring, 1, _get_tune, refpts1, refpts2, newval, tol=tol,
                     dp=dp, niter=niter)
 
@@ -91,5 +98,6 @@ def fit_chrom(ring, refpts1, refpts2, newval, tol=1.0e-12, dp=0, niter=3):
     Typical usage:
     at.matching.fit_chrom(ring, refpts1, refpts2, [10,5])
     """
+    print('\nFitting Chromaticity...')
     _fit_tune_chrom(ring, 2, _get_chrom, refpts1, refpts2, newval, tol=tol,
                     dp=dp, niter=niter)

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -546,10 +546,6 @@ def match(ring, variables, constraints, verbose=2, max_nfev=1000,
     else:
         ring1 = ring  
 
-    if any([cons.rad for cons in constraints]) and not ring.radiation:
-        'Envelop constraint found: turning on radiations'
-        ring1.radiation_on()
-
     aaa = [(var.get(ring1), var.bounds) for var in variables]
     vini, bounds = zip(*aaa)
     bounds = np.array(bounds).T

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -274,17 +274,13 @@ class LinoptConstraints(ElementConstraints):
 
         KEYWORDS
         dp=0.0          momentum deviation.
-        coupled=True    if False, simplify the calculations by assuming
-                        no H/V coupling
         twiss_in=None   Initial twiss parameters for transfer line optics.
                         "lindata" stucture, where only the beta and alpha are
                         required and used.
         orbit=None      Initial trajectory for transfer line
                         ((6,) array)
-        method=None     Method used for the analysis of the transfer matrix.  
+        method=linopt6  Method used for the analysis of the transfer matrix.  
                         Can be None, at.linopt2, at.linopt4, at.linopt6
-                        None: automated selection depending on coupled and
-                        radiation flags
                         linopt2:    no longitudinal motion, no H/V coupling,
                         linopt4:    no longitudinal motion, Sagan/Rubin
                                     4D-analysis of coupled motion,
@@ -359,8 +355,6 @@ class LinoptConstraints(ElementConstraints):
                 elif param == 'mu' and use_integer:
                     self.refpts[:] = True # necessary not to miss 2*pi jumps
                 return getf(refdata, param)
-            if param == 'dispersion':
-                self.get_chrom = True   # slower but necessary
 
         super(LinoptConstraints, self).add(fun, target, refpts, name=name,
                                            **kwargs)
@@ -368,7 +362,7 @@ class LinoptConstraints(ElementConstraints):
     def compute(self, ring, *args, **kwargs):
         """Optics computation before evaluation of all constraints"""
         ld0, bd, ld = get_optics(ring, refpts=self.refpts,
-                                      get_chrom=self.get_chrom, **kwargs)
+                                 get_chrom=self.get_chrom, **kwargs)
         return (ld[ref[self.refpts]] for ref in self.refs), \
                (bd.tune[:2], bd.chromaticity)
 

--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.optimize import least_squares
 from itertools import repeat
 from at.lattice import refpts_iterator, bool_refpts, uint32_refpts
-from at.physics import get_optics, ohmi_envelope, find_orbit4
+from at.physics import get_optics, ohmi_envelope, find_orbit
 
 
 class Variable(object):

--- a/pyat/test/test_matching.py
+++ b/pyat/test/test_matching.py
@@ -41,7 +41,7 @@ def test_linopt_matching(test_ring):
         return delta_mu % 1.0
 
     # Define the constraints
-    cst1 = at.LinoptConstraints(test_ring)
+    cst1 = at.LinoptConstraints(test_ring, method=at.linopt2)
     cst1.add('tunes', [0.38, 0.85], name='tunes')
     # Start of the ring
     cst1.add('alpha', [0.0, 0.0], refpts=0, name='alpha_0')

--- a/pyat/test/test_matching.py
+++ b/pyat/test/test_matching.py
@@ -69,6 +69,7 @@ def test_linopt_matching(test_ring):
 
 def test_envelope_matching(test_ring):
     # Define the variables
+    test_ring.radiation_on()
     names = ['QF1*', 'QD2*']
     variables = [at.ElementVariable(at.get_refpts(test_ring, nm), 'PolynomB',
                                     index=1, name=nm) for nm in names]


### PR DESCRIPTION
This branch implements some modifications of matching function to integrate the developments from #257

**-globalfit.py:** 
-use the the function from linear.py
-compute the jacobian only once

**-matching.py:** 
-use `get_optics` and `find_orbit` functions
-Providing linopt and orbit constraint are now compatible with radiation_on() no ring copy is done to handle combinations of `EnvelopeConstraints` and other constraints
-In case `EnvelopeConstraints` is called for a ring without radiations, the decorator of `Ohmi_envelope` will throw an error

To be noted: this branch relies on #270 to select the proper optics method in case radiation is on