### PR TITLE
fixed memory leak in element.update

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -117,7 +117,10 @@ class Element(object):
         """
         attrs = dict(*args, **kwargs)
         for (key, value) in attrs.items():
-            setattr(self, key, value)
+            if isinstance(value, str):
+                 getattr(self,key).replace(getattr(self,key),value)
+            else:
+                 setattr(self, key, value)
 
     def copy(self):
         """Return a shallow copy of the element"""


### PR DESCRIPTION
@lfarv , @willrogers , @simoneliuzzo , this branch fixes (I think) the memory leak discussed in #287 
I have modified the behavior of element.update in case element.attr is a string. 
In this case the string is replace entirely, this is quick and dirty. I am quite sure you can come up
with more elegant solution, your help is more than welcome.