### PR TITLE
Fixed the memory leak in atpass

### DIFF
--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -3,7 +3,7 @@ Tracking functions
 """
 
 # noinspection PyUnresolvedReferences
-from .atpass import atpass, elempass
+from .atpass import atpass, elempass, isopenmp
 from .patpass import patpass
 from .track import *
 from .particles import *


### PR DESCRIPTION
A memory leak mentioned in #290 was due to errors in the reference counting in `atpass`. This is now fixed.
While working on `at.c`, two other minor modifications:
- remaining lines for Python2 compatibility are removed,
- a new function `isopenmp` allows to test the presence of OpenMP