### PR TITLE
Test for use of keep_lattice in find_orbit6().

### DIFF
--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -278,6 +278,8 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
+        if method is ELossMethod.INTEGRAL:
+            keep_lattice = False
         ref_in = numpy.zeros((6,), order='F')
         ref_in[5] = -dt
     else:

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -278,6 +278,8 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
+        # Getting timelag by tracking uses a different lattice,
+        # so we cannot now use the same one again.
         if method is ELossMethod.TRACKING:
             keep_lattice = False
         ref_in = numpy.zeros((6,), order='F')

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -278,7 +278,7 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
-        if method is ELossMethod.INTEGRAL:
+        if method is ELossMethod.TRACKING:
             keep_lattice = False
         ref_in = numpy.zeros((6,), order='F')
         ref_in[5] = -dt

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -133,7 +133,7 @@ diffmatrix = Extension(
 
 setup(
     name='accelerator-toolbox',
-    version='0.2.0',
+    version='0.2.1',
     description='Accelerator Toolbox',
     long_description=long_description,
     author='The AT collaboration',

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -125,6 +125,13 @@ def test_find_orbit6(hmba_lattice):
     assert_close(orbit6, orbit6_MATLAB, rtol=0, atol=1e-12)
 
 
+def test_find_orbit6_produces_same_result_with_keep_lattice_True(hmba_lattice):
+    hmba_lattice = hmba_lattice.radiation_on(quadrupole_pass=None, copy=True)
+    orbit0, _ = physics.find_orbit6(hmba_lattice)
+    orbit1, _ = physics.find_orbit6(hmba_lattice, keep_lattice=True)
+    assert_close(orbit0, orbit1, rtol=0, atol=1e-12)
+
+
 def test_find_orbit6_raises_AtError_if_there_is_no_cavity(dba_lattice):
     with pytest.raises(at.lattice.utils.AtError):
         physics.find_orbit6(dba_lattice)

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -47,6 +47,12 @@ def test_find_orbit4_result_unchanged_by_atpass(dba_lattice):
     assert_close(orbit[:4], orbit_copy[:4], atol=1e-12)
 
 
+def test_find_orbit4_produces_same_result_with_keep_lattice_True(dba_lattice):
+    orbit0, _ = physics.find_orbit4(dba_lattice)
+    orbit1, _ = physics.find_orbit4(dba_lattice, keep_lattice=True)
+    assert_close(orbit0, orbit1, rtol=0, atol=1e-12)
+
+
 def test_find_orbit4_with_two_refpts_with_and_without_guess(dba_lattice):
     expected = numpy.array(
         [[8.148212e-6, 1.0993354e-5, 0, 0, DP, 2.963929e-6],
@@ -128,8 +134,15 @@ def test_find_orbit6(hmba_lattice):
 def test_find_orbit6_produces_same_result_with_keep_lattice_True(hmba_lattice):
     hmba_lattice = hmba_lattice.radiation_on(quadrupole_pass=None, copy=True)
     orbit0, _ = physics.find_orbit6(hmba_lattice)
+    # Technicality - the default arguments to find_orbit6 mean that
+    # keep_lattice argument is always false.
     orbit1, _ = physics.find_orbit6(hmba_lattice, keep_lattice=True)
+    # With INTEGRAL keep_lattice does take effect.
+    orbit2, _ = physics.find_orbit6(
+        hmba_lattice, keep_lattice=True, method=physics.ELossMethod.INTEGRAL
+    )
     assert_close(orbit0, orbit1, rtol=0, atol=1e-12)
+    assert_close(orbit0, orbit2, rtol=0, atol=1e-12)
 
 
 def test_find_orbit6_raises_AtError_if_there_is_no_cavity(dba_lattice):


### PR DESCRIPTION
This is how I expect to use the `keep_lattice` keyword argument, and it appears to be failing in pyat-0.2.0.

The second call (with `keep_lattice=True`) is returning nan in each element of the array.

Is this related to #299 ?

cc @mjgaughran