### PR TITLE
changed atfitchrom.m deltaP to make fit work

### DIFF
--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -20,7 +20,7 @@ else
     dpp=0;
     [newchrom,famname1,famname2]=deal(varargin{:});
 end
-deltaP = 1e-8;
+deltaP = 1e-6;
 idx1=varelem(ring,famname1);
 idx2=varelem(ring,famname2);
 kl1=atgetfieldvalues(ring(idx1),'PolynomB',{3});


### PR DESCRIPTION
Dear @lfarv and @swhite2401 ,

Did `atfitchrom` change recently (about <1year) ? 

I had to change `deltaP` from 1e-8 to 1e-6 in `atfitchrom` to be able to fit the EBS lattice model chromaticity (deterministically and correctly). 

The problem arised only in ESRF CTRM (grappa ubuntu20.04 + matlab2020b) and the symptom was a wrong fit of chromaticity leading to sextupole strengths basically random ("fitted chromaticity" = tens of units, incorrect and not deterministic values).

The fix proposed in this PR solves the issue for the fit of chromaticity in the EBS model at ESRF-CTRM. 

I am sure that testing in your local computers you will not see this problem. It is the same for me. 

thank you for your help

regards
Simone
