### PR TITLE
Avoid W and Chrom calculations in transfer line mode

### DIFF
--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -338,8 +338,10 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
 
     # Perform analysis
     vps, dtype, el0, els = analyze(mxx, ms)
-    tunes = numpy.mod(numpy.angle(vps) / 2.0 / pi, 1.0) if twiss_in is None \
-            else numpy.NaN
+    if twiss_in is None:
+        tunes = numpy.mod(numpy.angle(vps) / 2.0 / pi, 1.0) 
+    else:
+        tunes = numpy.NaN
 
     # Propagate the closed orbit
     orb0, orbs = get_orbit(ring, refpts=refpts, orbit=orbit,
@@ -354,7 +356,7 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
                          ('s_pos', numpy.float64)]
         data0 = (orb0, numpy.identity(2*dms), 0.0)
         datas = (orbs, ms, spos)
-        if get_chrom or get_w:
+        if get_chrom or get_w and twiss_in is None:
             f0 = get_rf_frequency(ring, cavpts=cavpts)
             df = -dp_step * get_mcf(ring.radiation_off(copy=True)) * f0
             rgup = set_rf_frequency(ring, f0 + 0.5*df, cavpts=cavpts, copy=True)
@@ -398,12 +400,12 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
                          ('s_pos', numpy.float64)]
         data0 = (d0, orb0, mt, get_s_pos(ring, len(ring)))
         datas = (ds, orbs, ms, spos)
-        if get_w:
+        if get_w and twiss_in is None:
             dtype = dtype + _W_DTYPE
             chrom, w0, ws = chrom_w(ring, ring, o0up, o0dn, refpts, **kwargs)
             data0 = data0 + (w0,)
             datas = datas + (ws,)
-        elif get_chrom:
+        elif get_chrom and twiss_in is None:
             tunesup = _tunes(ring, orbit=o0up)
             tunesdn = _tunes(ring, orbit=o0dn)
             chrom = (tunesup - tunesdn) / dp_step

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -328,8 +328,8 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
         if get_chrom or get_w:
             warnings.warn(AtWarning("'get_chrom' and 'get_w' are ignored in "
                                     "transfer-line mode"))
-        get_chrom = False
-        get_w = False
+            get_chrom = False
+            get_w = False
         orbit, sigma, d0 = build_sigma(twiss_in, orbit)
         dorbit = numpy.hstack((0.5*dp_step*d0, 0.5*dp_step, 0.0))
         # Get 1-turn transfer matrix

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -328,6 +328,8 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
         if get_chrom or get_w:
             warnings.warn(AtWarning("'get_chrom' and 'get_w' are ignored in "
                                     "transfer-line mode"))
+        get_chrom = False
+        get_w = False
         orbit, sigma, d0 = build_sigma(twiss_in, orbit)
         dorbit = numpy.hstack((0.5*dp_step*d0, 0.5*dp_step, 0.0))
         # Get 1-turn transfer matrix
@@ -356,7 +358,7 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
                          ('s_pos', numpy.float64)]
         data0 = (orb0, numpy.identity(2*dms), 0.0)
         datas = (orbs, ms, spos)
-        if get_chrom or get_w and twiss_in is None:
+        if get_chrom or get_w:
             f0 = get_rf_frequency(ring, cavpts=cavpts)
             df = -dp_step * get_mcf(ring.radiation_off(copy=True)) * f0
             rgup = set_rf_frequency(ring, f0 + 0.5*df, cavpts=cavpts, copy=True)
@@ -400,12 +402,12 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
                          ('s_pos', numpy.float64)]
         data0 = (d0, orb0, mt, get_s_pos(ring, len(ring)))
         datas = (ds, orbs, ms, spos)
-        if get_w and twiss_in is None:
+        if get_w:
             dtype = dtype + _W_DTYPE
             chrom, w0, ws = chrom_w(ring, ring, o0up, o0dn, refpts, **kwargs)
             data0 = data0 + (w0,)
             datas = datas + (ws,)
-        elif get_chrom and twiss_in is None:
+        elif get_chrom:
             tunesup = _tunes(ring, orbit=o0up)
             tunesdn = _tunes(ring, orbit=o0dn)
             chrom = (tunesup - tunesdn) / dp_step


### PR DESCRIPTION
For now the possibility to compute Q' and W in transfer line mode is not available (a warning is issued in case the user enables them with `twiss_in is not None`)
However a test was missing to prevent to run through the code that computes them in this case, these we added in this branch.
This solves #303.

It would be good to introduce these computation in future developments.