### PR TITLE
Check keys on load

### DIFF
--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -38,7 +38,10 @@ def load_lattice(filepath, **kwargs):
     Known extensions are:
     """
     _, ext = os.path.splitext(filepath)
-    return _load_extension[ext.lower()](filepath, **kwargs)
+    try:
+        return _load_extension[ext.lower()](filepath, **kwargs)
+    except KeyError:
+        print("File load failed: unknow extension {}.".format(ext))
 
 
 def save_lattice(ring, filepath, **kwargs):
@@ -59,7 +62,7 @@ def save_lattice(ring, filepath, **kwargs):
     try:
         return _save_extension[ext.lower()](ring, filepath, **kwargs)
     except KeyError:
-        print("Could not save lattice file with extension {}.".format(ext))
+        print("File save failed: unknow extension {}.".format(ext))
 
 
 def register_format(extension, load_func=None, save_func=None, descr=''):

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -38,10 +38,7 @@ def load_lattice(filepath, **kwargs):
     Known extensions are:
     """
     _, ext = os.path.splitext(filepath)
-    try:
-        return _load_extension[ext.lower()](filepath, **kwargs)
-    except KeyError:
-        print("Could not load lattice file with extension {}.".format(ext))
+    return _load_extension[ext.lower()](filepath, **kwargs)
 
 
 def save_lattice(ring, filepath, **kwargs):

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -7,7 +7,7 @@ from os.path import abspath
 from warnings import warn
 import scipy.io
 import numpy
-from at.lattice import elements, Lattice, AtWarning, params_filter
+from at.lattice import elements, Lattice, AtWarning, params_filter, AtError
 from at.load import register_format
 from at.load.utils import element_from_dict, element_from_m, RingParam
 from at.load.utils import element_to_dict, element_to_m
@@ -39,6 +39,9 @@ def matfile_generator(params, mat_file):
     matvars = [varname for varname in m if not varname.startswith('__')]
     default_key = matvars[0] if (len(matvars) == 1) else 'RING'
     key = params.setdefault('mat_key', default_key)
+    if key not in m.keys():
+        kok = [k for k in m.keys() if '__' not in k]
+        raise AtError('Selected mat_key does not exist, please select in: {}'.format(kok))
     check = params.pop('check', True)
     quiet = params.pop('quiet', False)
     cell_array = m[key].flat

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -273,8 +273,10 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
-    f_rf = cavities[0].Frequency
-    harm_number = cavities[0].HarmNumber
+    f_rfs = [cav.Frequency for cav in cavities]
+    f_rf = numpy.amin(f_rfs)
+    l_rf = constants.speed_of_light/f_rf
+    dth = (l0/l_rf-numpy.rint(l0/l_rf))*l_rf
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
@@ -286,9 +288,9 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
         ref_in[5] = -dt
     else:
         ref_in = numpy.copy(guess)
-
+    
     theta = numpy.zeros((6,))
-    theta[5] = constants.speed_of_light * harm_number / f_rf - l0
+    theta[5] = -dth
 
     scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0]) + \
               dp_step * numpy.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -273,10 +273,8 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
     if len(cavities) == 0:
         raise AtError('No cavity found in the lattice.')
 
-    f_rfs = [cav.Frequency for cav in cavities]
-    f_rf = numpy.amin(f_rfs)
-    l_rf = constants.speed_of_light/f_rf
-    dth = (l0/l_rf-numpy.rint(l0/l_rf))*l_rf
+    f_rf = cavities[0].Frequency
+    harm_number = cavities[0].HarmNumber
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
@@ -288,9 +286,9 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
         ref_in[5] = -dt
     else:
         ref_in = numpy.copy(guess)
-    
+
     theta = numpy.zeros((6,))
-    theta[5] = -dth
+    theta[5] = constants.speed_of_light * harm_number / f_rf - l0
 
     scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0]) + \
               dp_step * numpy.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])


### PR DESCRIPTION
Instead of printing a message without explanation when loading a matfile with the wrong key, an AtError is raised that prints the list of available keys