### PR TITLE
Fit tunes and chromaticities

### DIFF
--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -20,6 +20,7 @@ check_radiation(ring,false);
 [dpp,varargin]=getargs(varargin,0.0,'check',@(arg) isscalar(arg) && isnumeric(arg));
 [newchrom,famname1,famname2]=deal(varargin{:});
 
+idx1=varelem(ring,famname1);
 idx2=varelem(ring,famname2);
 kl1=atgetfieldvalues(ring(idx1),'PolynomB',{3});
 kl2=atgetfieldvalues(ring(idx2),'PolynomB',{3});

--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -1,5 +1,5 @@
 function newring=atfitchrom(ring,varargin)
-%ATFITTUNE Fit chromaticites by scaling 2 sextupole families
+%ATFITCHROM Fit chromaticites by scaling 2 sextupole families
 % NEWRING = ATFITCHROM(RING,NEWCHROM,SEXTFAMILY1,SEXTFAMILY2)
 % NEWRING = ATFITCHROM(RING,DPP,NEWCHROM,SEXTFAMILY1,SEXTFAMILY2)
 %
@@ -14,9 +14,20 @@ function newring=atfitchrom(ring,varargin)
 %   logical array: mask of selected elements in RING
 %   Numeric array: list of selected elements in RING
 %   Cell array: All elements selected by each cell
+%
+%NEWRING = ATFITTUNE(RING,...,'DPStep',dpstep)
+%   dpstep is the momentum step applied to compute the chromaticity.
+%   The default is the DPStep global option, which defaults to 3.0e-6
+%
+%NEWRING = ATFITTUNE(RING,...,'HStep',hstep)
+%   hstep is the sextupole strength applied to build the jacobian [m^-3].
+%   Default: 1.0e-5
+%
+% See also ATFITTUNE
 
 check_radiation(ring,false);
 [deltaP,varargin]=getoption(varargin,'DPStep');
+[deltaS,varargin]=getoption(varargin,'HStep',1.0e-5);
 [dpp,varargin]=getargs(varargin,0.0,'check',@(arg) isscalar(arg) && isnumeric(arg));
 [newchrom,famname1,famname2]=deal(varargin{:});
 
@@ -25,8 +36,6 @@ idx2=varelem(ring,famname2);
 kl1=atgetfieldvalues(ring(idx1),'PolynomB',{3});
 kl2=atgetfieldvalues(ring(idx2),'PolynomB',{3});
 %if true
-    deltaS = 1e-5; % step size in Sextupole strngth
-    
     % Compute initial tunes before fitting
     chrom=getchrom(ring,dpp,deltaP);
     

--- a/atmat/lattice/atfittune.m
+++ b/atmat/lattice/atfittune.m
@@ -1,5 +1,5 @@
 function newring=atfittune(ring,varargin)
-%ATFITTUNE fits linear tunes by scaling 2 quadrupole families
+%ATFITTUNE Fit linear tunes by scaling 2 quadrupole families
 % NEWRING = ATFITTUNE(RING,NEWTUNES,QUADFAMILY1,QUADFAMILY2)
 % NEWRING = ATFITTUNE(RING,DPP,NEWTUNES,QUADFAMILY1,QUADFAMILY2)
 %
@@ -22,12 +22,12 @@ function newring=atfittune(ring,varargin)
 %
 
 [UseIntegerPart,varargin]=getflag(varargin,'UseIntegerPart');
-if isscalar(varargin{1}) && isnumeric(varargin{1})
-    dpp=varargin{1};
-    [newtunes,famname1,famname2]=deal(varargin{2:end});
+[dpp,varargin]=getargs(varargin,[],'check',@(arg) isscalar(arg) && isnumeric(arg));
+[newtunes,famname1,famname2]=deal(varargin{:});
+if isempty(dpp)
+    dpparg={};
 else
-    dpp=0;
-    [newtunes,famname1,famname2]=deal(varargin{:});
+    dpparg={'dp',dpp};
 end
 
 idx1=varelem(ring,famname1);
@@ -35,28 +35,26 @@ idx2=varelem(ring,famname2);
 
 kl1=atgetfieldvalues(ring(idx1),'PolynomB',{2});
 kl2=atgetfieldvalues(ring(idx2),'PolynomB',{2});
-delta = 1e-6;
-if ~UseIntegerPart
+delta = 1e-6;   % Step on quadrupole strengths
+
+if UseIntegerPart
+    allpos=1:length(ring)+1;
+    gettune = @getinttune;
+else
     if any(newtunes>=1)
         warning('AT:FitTune','The integer part of the tunes is ignored unless you use the ''UseIntegerPart'' flag');
         newtunes=newtunes-floor(newtunes);
     end
-    % Compute initial tunes before fitting
-    [lindata, tunes] = atlinopt(ring,dpp); %#ok<ASGLU>
-    % Take Derivative
-    [lindata, tunes1] = atlinopt(setqp(ring,idx1,kl1,delta),dpp); %#ok<ASGLU>
-    [lindata, tunes2] = atlinopt(setqp(ring,idx2,kl2,delta),dpp); %#ok<ASGLU>
-else
-    % Compute initial tunes before fitting
-    lastpos=length(ring)+1;
-    lindata = atlinopt(ring,dpp,1:lastpos);
-    tunes=lindata(lastpos).mu/2/pi;
-    % Take Derivative
-    lindata1 = atlinopt(setqp(ring,idx1,kl1,delta),dpp,1:lastpos);
-    lindata2 = atlinopt(setqp(ring,idx2,kl2,delta),dpp,1:lastpos);
-    tunes1=lindata1(lastpos).mu/2/pi;
-    tunes2=lindata2(lastpos).mu/2/pi;
+    gettune = @getfractune;
 end
+
+% Compute initial tunes before fitting
+tunes = gettune(ring,dpparg{:});
+
+% Take Derivative
+tunes1 = gettune(setqp(ring,idx1,kl1,delta),dpparg{:});
+tunes2 = gettune(setqp(ring,idx2,kl2,delta),dpparg{:});
+
 %Construct the Jacobian
 J = ([tunes1(:) tunes2(:)] - [tunes(:) tunes(:)])/delta;
 dK = J\(newtunes(:)-tunes(:));
@@ -86,5 +84,13 @@ newring = setqp(newring,idx2,kl2,dK(2));
         else
             error('AT:GetElemList:WrongArg','Cannot parse argument');
         end
+    end
+    function tun=getfractune(ring,varargin)
+        [ringdata,elemdata]=atlinopt6(ring,varargin{:}); %#ok<ASGLU>
+        tun=ringdata.tune(1:2);
+    end
+    function tun=getinttune(ring,varargin)
+        [ringdata,elemdata] = atlinopt6(ring,allpos,varargin{:}); %#ok<ASGLU>
+        tun=elemdata(end).mu(1:2)/2/pi;
     end
 end

--- a/atmat/lattice/atfittune.m
+++ b/atmat/lattice/atfittune.m
@@ -15,13 +15,19 @@ function newring=atfittune(ring,varargin)
 %   Numeric array: list of selected elements in RING
 %   Cell array: All elements selected by each cell
 %
-% NEWRING = ATFITTUNE(RING,...,'UseIntegerPart') With this flag, the 
-% function fits the tunes to the total values of NEWTUNES, including 
-% the integer part.
-% With this option the function is substantially slower!
+%NEWRING = ATFITTUNE(RING,...,'UseIntegerPart') With this flag, the 
+%   function fits the tunes to the total values of NEWTUNES, including 
+%   the integer part.
+%   With this option the function is substantially slower!
 %
+%NEWRING = ATFITTUNE(RING,...,'KStep',kstep)
+%   kstep is the quadrupole strength applied to build the jacobian [m^-2].
+%   Default: 1.0e-6
+%
+% See also ATFITCHROM
 
 [UseIntegerPart,varargin]=getflag(varargin,'UseIntegerPart');
+[delta,varargin]=getoption(varargin,'KStep',1.0e-6);
 [dpp,varargin]=getargs(varargin,[],'check',@(arg) isscalar(arg) && isnumeric(arg));
 [newtunes,famname1,famname2]=deal(varargin{:});
 if isempty(dpp)
@@ -35,7 +41,6 @@ idx2=varelem(ring,famname2);
 
 kl1=atgetfieldvalues(ring(idx1),'PolynomB',{2});
 kl2=atgetfieldvalues(ring(idx2),'PolynomB',{2});
-delta = 1e-6;   % Step on quadrupole strengths
 
 if UseIntegerPart
     allpos=1:length(ring)+1;


### PR DESCRIPTION
@simoneliuzzo reported in #302 a problem in `atfitchrom`, where the `dp` step could not not modified. Here is the solution:
- the `dp` step can be modified with the name/value pair "`'DPStep',step`". Example:
  `newring=atfitchrom(ring,...,'DPStep',1.e-6)` or
  `newring=atfitchrom(ring,...,DPStep=1.e-6)`
- the default value is the `DPStep` option value (see `getoption`/`setoption`). It is by default 3.0e-6, which is optimum in most cases.
- `atfitchrom` now uses `atlinopt6`. However it is still restricted to radiation OFF because the chromaticity computation uses fixed dp/p values.

Simultaneously, `atfittune` is also modified to use `atlinopt6`, and can now be used with radiation ON.