### PR TITLE
Set the default particle to "electron"

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -85,7 +85,8 @@ if isempty(varargs)             % New syntax
             gamma0=props.Energy/E_MASS;
             beta0=sqrt(1-1/gamma0/gamma0);
             lcell=ncells*findspos(ring,length(ring)+1);
-            frev=beta0*CLIGHT/lcell;
+%           frev=beta0*CLIGHT/lcell;
+            frev=CLIGHT/lcell;
             if isfinite(dct)
                 frev=frev - frev*frev/CLIGHT*ncells*dct;
             elseif isfinite(dp)

--- a/atmat/lattice/atfindparam.m
+++ b/atmat/lattice/atfindparam.m
@@ -41,7 +41,7 @@ if ~isempty(idx)            % Found RingParam: use it
     parmelem = strupdate(parmelem, newparms);
     new_nper = parmelem.Periodicity;
     if ~isfield(parmelem, 'Particle')
-        parmelem.Particle = saveobj(atparticle('relativistic'));
+        parmelem.Particle = saveobj(atparticle('electron'));
     end
     if isfield(newparms, 'HarmNumber')
         check_h(newparms.HarmNumber, parmelem.Periodicity);

--- a/atmat/lattice/atparticle.m
+++ b/atmat/lattice/atparticle.m
@@ -30,8 +30,8 @@ classdef atparticle
         function obj = atparticle(name, varargin)
             %ATPARTICLE Construct an ATPARTICLE instance
             %   Detailed explanation goes here
-            if ~strcmp(name,'relativistic')
-                error('AT:particle','Only ''relativistic'' is allowed at the moment');
+            if ~strcmp(name,'electron')
+                warning('AT:particle','AT tracking still assumes beta==1. Make sure your particle is ultra-relativistic');
             end
             try
                 args = atparticle.known2.(name);

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1,8 +1,8 @@
 """Lattice object
 
 The methods implemented in this module are internal to the 'lattice' package.
-This is necessary to ensure that the 'lattice' package is independent
-from other AT packages.
+This is necessary to ensure that the 'lattice' package is independent of other
+AT packages.
 
 Other Lattice methods are implemented in other AT packages and are available
 as soon as the package is imported. The 'tracking' and 'physics' packages are
@@ -137,7 +137,7 @@ class Lattice(list):
         # set default values
         kwargs.setdefault('name', '')
         periodicity = kwargs.setdefault('periodicity', 1)
-        kwargs.setdefault('_particle', Particle('relativistic'))
+        kwargs.setdefault('_particle', Particle('electron'))
         # Remove temporary keywords
         frequency = kwargs.pop('_frequency', None)
         cell_h = kwargs.pop('_harmnumber', None)

--- a/pyat/at/lattice/particle_object.py
+++ b/pyat/at/lattice/particle_object.py
@@ -1,5 +1,6 @@
 from .constants import e_mass, p_mass
 import numpy
+from warnings import warn
 
 
 class Particle(object):
@@ -27,9 +28,9 @@ class Particle(object):
     )
 
     def __init__(self, name, **kwargs):
-        if name != 'relativistic':
-            raise NotImplementedError(
-                "Only 'relativistic' is allowed at the moment")
+        if name != 'electron':
+            warn(UserWarning("AT tracking still assumes beta==1\n"
+                             "Make sure your particle is ultra-relativistic"))
         if name in self._known:
             kwargs.update(self._known[name])
         self.name = name

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -4,7 +4,6 @@ from ..lattice.constants import clight, e_mass
 from ..tracking import lattice_pass
 from .orbit import find_orbit4
 import numpy
-import math
 
 __all__ = ['get_mcf', 'get_slip_factor', 'get_revolution_frequency',
            'set_rf_frequency']
@@ -64,9 +63,7 @@ def get_revolution_frequency(ring, dp=None, dct=None, **kwargs):
                         Defaults to False
         dp_step=1.0E-6  momentum deviation used for differentiation
     """
-    gamma = ring.gamma
-    beta = math.sqrt(1.0 - 1.0 / gamma / gamma)
-    frev = beta * clight / ring.circumference
+    frev = clight / ring.circumference
     if dct is not None:
         frev -= frev * frev / clight * ring.periodicity * dct
     elif dp is not None:

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -11,7 +11,7 @@ def test_lattice_creation_gets_attributes_from_arguments():
     assert lat.energy == 3.e+6
     assert lat.periodicity == 32
     assert lat.radiation is False
-    assert lat.particle.name == 'relativistic'
+    assert lat.particle.name == 'electron'
     assert lat.an_attr == 12
 
 
@@ -69,14 +69,14 @@ def test_lattice_string_ordering():
                   name='lat', energy=5, periodicity=1, attr2=3)
     latstr = str(lat)
     assert latstr.startswith("Lattice(<1 elements>, name='lat', "
-                               "energy=5, particle=Particle('relativistic'), "
+                               "energy=5, particle=Particle('electron'), "
                                "periodicity=1")
     assert latstr.endswith("attr2=3)")
 
     latrepr = repr(lat)
     assert latrepr.startswith("Lattice([Drift('D0', 1.0, attr1=array(0))], "
                                 "name='lat', "
-                                "energy=5, particle=Particle('relativistic'), "
+                                "energy=5, particle=Particle('electron'), "
                                 "periodicity=1")
     assert latrepr.endswith("attr2=3)")
 


### PR DESCRIPTION
SInce its origin, AT has been using a value of &gamma; for electrons but a &beta; strictly equal to 1.
With the introduction of the particle object, the default (and only allowed) particle was 'relativistic', so that &beta;=1 was in agreement with the tracking. But this induced problems with the computation of some analytic parameters, because of infinite &gamma;. We now switch the default particle to 'electron', so that the analytic computations are correct, and identical to the historical values. The use of the real &beta; instead of 1 is still not applied everywhere, but the difference is negligible.

&beta;=1 is still assumed for the computation of the revolution frequency and 6D closed orbit, as it was up to now. It is necessary to be compatible with the tracking.