### PR TITLE
Fix problems reading .mat files

### DIFF
--- a/atmat/lattice/atparticle.m
+++ b/atmat/lattice/atparticle.m
@@ -1,11 +1,12 @@
 classdef atparticle
     %ATPARTICLE Particle definition for AT
+    %
     %   A particle is defined by its name, rest energy and charge
 
     properties(SetAccess=private)
-        name
-        rest_energy
-        charge
+        name        % Name of the particle
+        rest_energy % Particle rest energy [eV]
+        charge      % Particle charge [elementary charge]
     end
 
     properties(Constant, Hidden)
@@ -29,7 +30,16 @@ classdef atparticle
     methods
         function obj = atparticle(name, varargin)
             %ATPARTICLE Construct an ATPARTICLE instance
-            %   Detailed explanation goes here
+            %
+            % ATPARTICLE(NAME)
+            %   NAME        May be 'electron', 'positron', 'proton', 'relativistic'
+            %               The rest energy and charge are automatically filled.
+            %
+            % ATPARTICLE(NAME,REST_ENERGY,CHARGE)
+            %   NAME        Name of the particle
+            %   REST_ENERGY Rest energy [eV]
+            %   CHARGE      Charge [elementary charge]
+            
             if ~strcmp(name,'electron')
                 warning('AT:particle','AT tracking still assumes beta==1. Make sure your particle is ultra-relativistic');
             end

--- a/atoctave/atparticle.m
+++ b/atoctave/atparticle.m
@@ -1,11 +1,12 @@
 classdef atparticle
     %ATPARTICLE Particle definition for AT
+    %
     %   A particle is defined by its name, rest energy and charge
 
     properties(SetAccess=private)
-        name
-        rest_energy
-        charge
+        name        % Name of the particle
+        rest_energy % Particle rest energy [eV]
+        charge      % Particle charge [elementary charge]
     end
     
     properties(Constant,Hidden)
@@ -32,8 +33,16 @@ classdef atparticle
     methods
         function obj = atparticle(name, varargin)
             %ATPARTICLE Construct an ATPARTICLE instance
-            %   Detailed explanation goes here
-
+            %
+            % ATPARTICLE(NAME)
+            %   NAME        May be 'electron', 'positron', 'proton', 'relativistic'
+            %               The rest energy and charge are automatically filled.
+            %
+            % ATPARTICLE(NAME,REST_ENERGY,CHARGE)
+            %   NAME        Name of the particle
+            %   REST_ENERGY Rest energy [eV]
+            %   CHARGE      Charge [elementary charge]
+            
             persistent known2
             if isempty(known2)
                 known2 = struct(...

--- a/pyat/at/lattice/particle_object.py
+++ b/pyat/at/lattice/particle_object.py
@@ -40,14 +40,18 @@ class Particle(object):
         for (key, val) in kwargs.items():
             setattr(self, key, val)
 
+    def to_dict(self):
+        attrs = vars(self).copy()
+        attrs['rest_energy'] = attrs.pop('_rest_energy')
+        attrs['charge'] = attrs.pop('_charge')
+        return attrs
+
     def __repr__(self):
         if self.name in self._known:
             return "Particle('{0}')".format(self.name)
         else:
-            attrs = vars(self).copy()
+            attrs = self.to_dict()
             name = attrs.pop('name')
-            attrs['rest_energy'] = attrs.pop('_rest_energy')
-            attrs['charge'] = attrs.pop('_charge')
             args = ', '.join('{0}={1!r}'.format(k, v) for k, v in attrs.items())
             return "Particle('{0}', {1})".format(name, args)
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -16,7 +16,7 @@ __all__ = ['ringparam_filter', 'load_mat', 'save_mat', 'load_m', 'save_m',
            'load_var']
 
 _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
-                     'FamName': 'name', 'Particle': 'particle',
+                     'FamName': 'name', 'Particle': '_particle',
                      'HarmNumber': 'harmonic_number'}
 _param_ignore = {'PassMethod', 'Length'}
 
@@ -39,14 +39,15 @@ def matfile_generator(params, mat_file):
     def mclean(data):
         if data.dtype.type is numpy.str_:
             # Convert strings in arrays back to strings.
-            return str(data[0])
+            return str(data[0]) if data.size > 0 else ''
         elif data.size == 1:
             v = data[0, 0]
             if issubclass(v.dtype.type, numpy.void):
-                for f in v.dtype.fields:
-                    v[f] = mclean(v[f])
-            # Return a scalar
-            return v
+                # Object => Return a dict
+                return {f: mclean(v[f]) for f in v.dtype.fields}
+            else:
+                # Return a scalar
+                return v
         else:
             # Remove any surplus dimensions in arrays.
             return numpy.squeeze(data)

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -3,7 +3,7 @@ Load lattices from Matlab files.
 """
 from __future__ import print_function
 import sys
-from os.path import abspath
+from os.path import abspath, basename, splitext
 from warnings import warn
 import scipy.io
 import numpy
@@ -219,18 +219,19 @@ def save_m(ring, filename=None):
     """
 
     def save(file):
-        print('function ring = {0}()'.format(ring.name), file=file)
         print('ring = {...', file=file)
         for elem in matlab_ring(ring):
             print(element_to_m(elem), file=file)
         print('};', file=file)
-        print('end', file=file)
 
     if filename is None:
         save(sys.stdout)
     else:
         with open(filename, 'wt') as mfile:
+            [funcname, _] = splitext(basename(filename))
+            print('function ring = {0}()'.format(funcname), file=mfile)
             save(mfile)
+            print('end', file=mfile)
 
 
 register_format('.mat', load_mat, save_mat, descr='Matlab binary mat-file')

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -11,6 +11,7 @@ from at.load.utils import element_from_string
 # imports necessary in' globals()' for 'eval'
 # noinspection PyUnresolvedReferences
 from at.lattice import Particle
+from numpy import array
 __all__ = ['load_repr', 'save_repr']
 
 

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -55,8 +55,7 @@ _alias_map = {'rbend': elt.Dipole,
 _CLASS_MAP = dict((k.lower(), v) for k, v in CLASS_MAP.items())
 _CLASS_MAP.update(_alias_map)
 
-_PASS_MAP = {'DriftPass': elt.Drift,
-             'BendLinearPass': elt.Dipole,
+_PASS_MAP = {'BendLinearPass': elt.Dipole,
              'BndMPoleSymplectic4RadPass': elt.Dipole,
              'BndMPoleSymplectic4Pass': elt.Dipole,
              'QuadLinearPass': elt.Quadrupole,

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -321,8 +321,8 @@ def element_to_m(elem):
         def convert_dict(pdir):
             def scan(d):
                 for k, v in d.items():
-                    yield repr(k)
-                    yield repr(v)
+                    yield convert(k)
+                    yield convert(v)
             return 'struct({0})'.format(', '.join(scan(pdir)))
 
         def convert_array(arr):
@@ -339,7 +339,7 @@ def element_to_m(elem):
         elif isinstance(arg, dict):
             return convert_dict(arg)
         elif isinstance(arg, Particle):
-            return convert_dict(vars(arg))
+            return convert_dict(arg.to_dict())
         else:
             return repr(arg)
 

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -18,10 +18,12 @@ from numpy import array, uint8  # For global namespace
 
 def _particle(value):
     if isinstance(value, Particle):
+        # Create from python: save_mat
         return value
     else:
-        return Particle(value['name'], rest_energy=value['rest_energy'],
-                        charge=int(value['charge']))
+        # Create from Matlab: load_mat
+        name = value.pop('name')
+        return Particle(name, **value)
 
 
 class RingParam(elt.Element):
@@ -74,7 +76,8 @@ _matclass_map = {'Dipole': 'Bend'}
 
 # Python to Matlab type translation
 _mattype_map = {int: float,
-                numpy.ndarray: lambda attr: numpy.asanyarray(attr)}
+                numpy.ndarray: lambda attr: numpy.asanyarray(attr),
+                Particle: lambda attr: attr.to_dict()}
 
 _class_to_matfunc = {
     elt.Dipole: 'atsbend',
@@ -369,17 +372,17 @@ def find_class_name(elem_dict, quiet=False):
 
 
 def split_ignoring_parentheses(string, delimiter):
-    PLACEHOLDER = "placeholder"
+    placeholder = "placeholder"
     substituted = string[:]
     matches = collections.deque(re.finditer("\\(.*?\\)", string))
     for match in matches:
-        substituted = substituted.replace(match.group(), PLACEHOLDER, 1)
+        substituted = substituted.replace(match.group(), placeholder, 1)
     parts = substituted.split(delimiter)
     replaced_parts = []
     for part in parts:
-        if PLACEHOLDER in part:
+        if placeholder in part:
             next_match = matches.popleft()
-            part = part.replace(PLACEHOLDER, next_match.group(), 1)
+            part = part.replace(placeholder, next_match.group(), 1)
         replaced_parts.append(part)
     assert not matches
 


### PR DESCRIPTION
This fixes #340.
- Workaround a bug (?) in scipy.io.loadmat where empty strings from .mat files disappear,
- Fix problems with particle objects in .mat, .m and .repr files