### PR TITLE
Fix problems with transfer line mode

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt.m
+++ b/atmat/atphysics/LinearOptics/atlinopt.m
@@ -1,5 +1,11 @@
 function [lindata, varargout] = atlinopt(RING,dp,varargin)
-%ATLINOPT Performs linear analysis of the COUPLED lattices
+%ATLINOPT Performs 4D linear analysis of the COUPLED lattices
+%
+%ATLINOPT only works for CONSTANT energy. So no PassMethod should:
+%   1. change the longitudinal momentum dP (cavities, magnets with radiation)
+%   2. have any time dependence (localized impedance, fast kickers etc)
+%
+%For a more general computation, see ATLINOPT6
 %
 % LinData = ATLINOPT(RING,DP,REFPTS) is a MATLAB structure array with fields
 %

--- a/atmat/atphysics/LinearOptics/atlinopt6.m
+++ b/atmat/atphysics/LinearOptics/atlinopt6.m
@@ -86,14 +86,18 @@ if isempty(twiss_in)        % Circular machine
     is6d=check_radiation(ring);
     [orbs,orbitin]=findorbit(ring,refpts,'dp',dp,'orbit',orbitin,varargs{:});
     [vps,ms,mu,ri,ai]=build_1turn_map(ring,dp,refpts,orbitin);
+    o1P=[];
+    o1M=[];
 else                        % Transfer line
-    if isempty(orbitin), orbitin=zeros(6,1); end
+    [orbitin,sigma,d0]=build_sigma(twiss_in,orbitin);
     orbs=linepass(ring,orbitin,refpts);
-    sigma=build_sigma(twiss_in);
+    dorbit=0.5*DPStep*[d0;1;0];
     nv=size(sigma,1);
     dms=nv/2;
     is6d=(dms>=3);
     [vps,ms,mu,ri,ai]=build_1turn_map(ring,dp,refpts,orbitin,'mxx',sigma*jmat(dms));
+    o1P=orbitin+dorbit;
+    o1M=orbitin-dorbit;
 end
 
 tunes=mod(angle(vps)/2/pi,1);
@@ -129,8 +133,8 @@ if is6d                     % 6D processing
 else                        % 4D processing
     dp=orbitin(5);
     [alpha,beta]=cellfun(@output4,ri,'UniformOutput',false);
-    [orbitP,o1P]=findorbit4(ring,dp+0.5*DPStep,refpts,'guess',orbitin,varargs{:});
-    [orbitM,o1M]=findorbit4(ring,dp-0.5*DPStep,refpts,'guess',orbitin,varargs{:});
+    [orbitP,o1P]=findorbit4(ring,dp+0.5*DPStep,refpts,'orbit',o1P,'guess',orbitin,varargs{:});
+    [orbitM,o1M]=findorbit4(ring,dp-0.5*DPStep,refpts,'orbit',o1M,'guess',orbitin,varargs{:});
     disp = num2cell((orbitP-orbitM)/DPStep,1);
     if get_w
             [ringdata.chromaticity,w]=chrom_w(ring,ring,o1P,o1M,refpts);
@@ -178,15 +182,28 @@ end
         [phis,rmats,as]=r_analysis(amat0,ms);
     end
 
-    function sigma=build_sigma(twiss_in)
+    function [orbit,sigma,d0]=build_sigma(twiss_in,orbit)
         % build the initial conditions for a transfer line: sigma = R1 + R2
+        if isempty(orbit)
+            if isfield(twiss_in, 'ClosedOrbit')
+                orbit=twiss_in.ClosedOrbit;
+            else
+                orbit=zeros(6,1);
+            end
+        end
         if isfield(twiss_in,'R')
-            sigma=sum(twiss_in.R,3);
+            % For some reason, "emittances" must be different...
+            sigma=twiss_in.R(:,:,1)+10.0*twiss_in.R(:,:,2)+0.1*twiss_in.R(:,:,3);
         else
             slices=num2cell(reshape(1:4,2,2),1);
             v=num2cell(cat(1,twiss_in.alpha,twiss_in.beta),1);
             sigma=zeros(4,4);
             cellfun(@sigma22,v,slices,'UniformOutput',false);
+        end
+        if isfield(twiss_in,'Dispersion')
+            d0=twiss_in.Dispersion;
+        else
+            d0=ones(4,1);
         end
         
         function sigma22(ab,slc)

--- a/atmat/atphysics/LinearOptics/atlinopt6.m
+++ b/atmat/atphysics/LinearOptics/atlinopt6.m
@@ -185,15 +185,19 @@ end
     function [orbit,sigma,d0]=build_sigma(twiss_in,orbit)
         % build the initial conditions for a transfer line: sigma = R1 + R2
         if isempty(orbit)
+            orbit=zeros(6,1);
             if isfield(twiss_in, 'ClosedOrbit')
-                orbit=twiss_in.ClosedOrbit;
-            else
-                orbit=zeros(6,1);
+                lo=length(twiss_in.ClosedOrbit);
+                orbit(1:lo)=twiss_in.ClosedOrbit;
             end
         end
         if isfield(twiss_in,'R')
+            sz=size(twiss_in.R);
             % For some reason, "emittances" must be different...
-            sigma=twiss_in.R(:,:,1)+10.0*twiss_in.R(:,:,2)+0.1*twiss_in.R(:,:,3);
+            sigma=twiss_in.R(:,:,1)+10.0*twiss_in.R(:,:,2);
+            if sz(3) >= 3
+                sigma=sigma+0.1*twiss_in.R(:,:,3);
+            end
         else
             slices=num2cell(reshape(1:4,2,2),1);
             v=num2cell(cat(1,twiss_in.alpha,twiss_in.beta),1);
@@ -203,7 +207,7 @@ end
         if isfield(twiss_in,'Dispersion')
             d0=twiss_in.Dispersion;
         else
-            d0=ones(4,1);
+            d0=zeros(4,1);
         end
         
         function sigma22(ab,slc)

--- a/atmat/atphysics/LinearOptics/r_analysis.m
+++ b/atmat/atphysics/LinearOptics/r_analysis.m
@@ -3,7 +3,8 @@ function [phi,bks,as]=r_analysis(a0,ms)
 nv=size(a0,1);
 dms=nv/2;
 slices=num2cell(reshape(1:nv,2,dms),1);
-s=kmat(dms);
+s=jmat(dms);
+t=kmat(dms);
 
 astd=standardize(a0);
 
@@ -32,7 +33,7 @@ warning(sw);
 
     function [phi,bk,ai]=propagate(ai)
         % Propagate the A matrices
-        ais=ai*s;
+        ais=ai*t;
         invai=ai\s';
         bk=cellfun(@(slc) ais(:,slc)*invai(slc,:),slices,'UniformOutput',false);
 %       bk=cellfun(@(slc) ai(:,slc)*ai(:,slc)',slices,'UniformOutput',false);   % Only if symplectic

--- a/atmat/atutils/linoptions.m
+++ b/atmat/atutils/linoptions.m
@@ -8,7 +8,7 @@ function [linargs,opts] = linoptions(opts, dp)
 % (0, 'opt1', val1) to
 % ('opt1',val1)
 
-[linargs,opts]=getoption(opts,{'dp','dct','twiss_in'});
+[linargs,opts]=getoption(opts,{'dp','dct','twiss_in','orbit'});
 if nargin >=2 && dp ~= 0
     linargs=[{'dp',dp} linargs];
 end

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -17,7 +17,7 @@ from .harmonic_analysis import get_tunes_harmonic
 __all__ = ['linopt', 'linopt2', 'linopt4', 'linopt6', 'avlinopt',
            'get_optics', 'get_tune', 'get_chrom']
 
-_jmt = jmatswap(1)
+_S = jmat(1)
 _S2 = numpy.array([[0, 1], [-1, 0]], dtype=numpy.float64)
 
 # dtype for structured array containing linopt parameters
@@ -121,18 +121,18 @@ def _analyze4(mt, ms):
         n = t12[2:, :2]
         ff = n @ C + g * N
         gamma = sqrt(numpy.linalg.det(ff))
-        e12 = (g * M - m @ _jmt @ C.T @ _jmt.T) / gamma
+        e12 = (g * M - m @ _S @ C.T @ _S.T) / gamma
         f12 = ff / gamma
-        a12 = e12 @ A @ _jmt @ e12.T @ _jmt.T
-        b12 = f12 @ B @ _jmt @ f12.T @ _jmt.T
-        c12 = M @ C + g*m @ _jmt @ f12.T @ _jmt.T
+        a12 = e12 @ A @ _S @ e12.T @ _S.T
+        b12 = f12 @ B @ _S @ f12.T @ _S.T
+        c12 = M @ C + g * m @ _S @ f12.T @ _S.T
         return e12, f12, gamma, a12, b12, c12
 
     M = mt[:2, :2]
     N = mt[2:, 2:]
     m = mt[:2, 2:]
     n = mt[2:, :2]
-    H = m + _jmt @ n.T @ _jmt.T
+    H = m + _S @ n.T @ _S.T
     detH = numpy.linalg.det(H)
     if detH == 0.0:
         g = 1.0
@@ -146,10 +146,10 @@ def _analyze4(mt, ms):
         g2 = (1.0 + sqrt(t2 / t2h)) / 2
         g = sqrt(g2)
         C = -H * numpy.sign(t) / (g * sqrt(t2h))
-        A = g2*M - g*(m @ _jmt @ C.T @ _jmt.T + C @ n) + \
-            C @ N @ _jmt @ C.T @ _jmt.T
-        B = g2*N + g*(_jmt @ C.T @ _jmt.T @ m + n @ C) + \
-            _jmt @ C.T @ _jmt.T @ M @ C
+        A = g2 * M - g * (m @ _S @ C.T @ _S.T + C @ n) + \
+            C @ N @ _S @ C.T @ _S.T
+        B = g2 * N + g * (_S @ C.T @ _S.T @ m + n @ C) + \
+            _S @ C.T @ _S.T @ M @ C
     alp0_a, bet0_a, vp_a = _closure(A)
     alp0_b, bet0_b, vp_b = _closure(B)
     vps = numpy.array([vp_a, vp_b])
@@ -256,7 +256,8 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
             except (ValueError, KeyError):  # record arrays throw ValueError !
                 orbit = numpy.zeros((6,))
         try:
-            sigm = numpy.sum(twin['R'], axis=0)
+            # For some reason, "emittances" must be dofferent...
+            sigm = twin['R'][0,...]+10.0*twin['R'][1,...]+0.0*twin['R'][2,...]
         except (ValueError, KeyError):  # record arrays throw ValueError !
             slices = [slice(2 * i, 2 * (i + 1)) for i in range(2)]
             ab = numpy.stack((twin['alpha'], twin['beta']), axis=1)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -256,8 +256,10 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
             except (ValueError, KeyError):  # record arrays throw ValueError !
                 orbit = numpy.zeros((6,))
         try:
-            # For some reason, "emittances" must be dofferent...
-            sigm = twin['R'][0,...]+10.0*twin['R'][1,...]+0.0*twin['R'][2,...]
+            # For some reason, "emittances" must be different...
+            sigm = twin['R'][0,...]+10.0*twin['R'][1,...]
+            if twin['R'].shape[0] >= 3:
+                sigm = sigm+0.1*twin['R'][2,...]
         except (ValueError, KeyError):  # record arrays throw ValueError !
             slices = [slice(2 * i, 2 * (i + 1)) for i in range(2)]
             ab = numpy.stack((twin['alpha'], twin['beta']), axis=1)
@@ -268,7 +270,6 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
         try:
             d0 = twin['dispersion']
         except (ValueError, KeyError):  # record arrays throw ValueError !
-            print('Dispersion not found in twiss_in, setting to zero')
             d0 = numpy.zeros((4,))
         return orbit, sigm, d0
 


### PR DESCRIPTION
The transfer-line mode of `linopt*` has some problems:
- in Matlab, the initial orbit is not correctly taken into account (pointed out by @simoneliuzzo)
- in 6D, the initial dispersion is not correctly reproduces (both Matlab and python)

Both are fixed in this pull request.