### PR TITLE
Python packaging

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - pyat-*
+  workflow_dispatch:
 
 defaults:
   run:
@@ -20,40 +21,51 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
-        name: Install Python
         with:
-          python-version: '3.7'
+          # Necessary to fetch tags and allow setuptools_scm
+          # see: https://github.com/pypa/setuptools_scm/issues/480
+          fetch-depth: 0
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
-      - name: Prepare source
-        run: |
-          pip install -e .
-
-      - name: Remove built files
-        if: (! contains(matrix.os, 'windows'))
-        run: rm -rf build
+      - name: Set build configuration
+        run: cp githubproject.toml pyproject.toml
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          # We don't yet support Python 3.10.
-          # Pypy does not have Scipy so we cannot support it.
-          CIBW_SKIP: cp310* pp*
-          CIBW_BUILD_VERBOSITY: 1
-
-      - name: Build sdist
-        run: python setup.py sdist
+        uses: pypa/cibuildwheel@v2.3.1
+        with:
+          package-dir: pyat
 
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels
-          path: ./pyat/wheelhouse/*.whl
+          path: ./wheelhouse/*.whl
           if-no-files-found: error
+
+  build_sdist:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Necessary to fetch tags and allow setuptools_scm
+          # see: https://github.com/pypa/setuptools_scm/issues/480
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install build tools
+        run: python -m pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist
 
       - name: Upload sdist
         uses: actions/upload-artifact@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,7 +35,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
-        python -m pip install -r requirements.txt
+        python -m pip install pytest
+        python -m pip install pytest-lazy-fixture
         python -m pip install pytest-cov
 
     - name: Build and install at

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,15 +32,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8
-        python -m pip install pytest
-        python -m pip install pytest-lazy-fixture
-        python -m pip install pytest-cov
+      run: python -m pip install --upgrade pip
 
-    - name: Build and install at
-      run: python -m pip install -e .
+    - name: Build and install at with tests
+      run: python -m pip install -e ".[dev]"
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -31,11 +31,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: python -m pip install --upgrade pip
-
     - name: Build and install at with tests
-      run: python -m pip install -e ".[dev]"
+      run: python -m pip install ".[dev]"
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Build and install at with tests
-      run: python -m pip install ".[dev]"
+      run: python -m pip install -e ".[dev]"
 
     - name: Lint with flake8
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pyat/dist
 pyat/at.egg-info
 pyat/prefix
 pyat/integrator-src
+pyat/at/_version.py
 *.egg-info
 .pytest_cache
 .coverage

--- a/jupyter/at.dockerfile
+++ b/jupyter/at.dockerfile
@@ -42,8 +42,9 @@ RUN git clone --depth 1 -b $AT_BRANCH $AT_REPO /home/$USERNAME/at \
 	&& octave --eval 'bootstrap(:,true);savepath'
 
 RUN cd /home/$USERNAME/at/pyat \
-	&& pip3 install -r requirements.txt \
 	&& pip3 install matplotlib \
+	&& pip3 install numpy \
+	&& pip3 install scipy \
 	&& python3 setup.py install --user
 
 WORKDIR $DOCKER_NOTEBOOK_DIR

--- a/pyat/MANIFEST.in
+++ b/pyat/MANIFEST.in
@@ -1,2 +1,2 @@
 
-recursive-include integrator-src *.c *.h
+global-include *.c *.h *.cc

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,7 +1,16 @@
 """Python port of the Accelerator Toolbox"""
 
-# Make all functions visible in the at namespace:
 import sys
+if sys.version_info.minor < 8:
+    from importlib_metadata import version, PackageNotFoundError
+else:
+    from importlib.metadata import version, PackageNotFoundError
+try:
+    __version__ = version('accelerator-toolbox')
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+# from ._version import version as __version__
+# Make all functions visible in the at namespace:
 from .lattice import *
 from .tracking import *
 from .physics import *

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -19,6 +19,12 @@ Install the Python development package for your OS. For example, using yum:
 
 * ``sudo yum install python3-devel``
 
+Source download
+---------------
+Download the latest version of AT:
+    ``$ git clone https://github.com/atcollab/at.git``
+
+
 Installation (all platforms)
 ----------------------------
 
@@ -30,9 +36,18 @@ It is easiest to do this using a virtualenv. inside pyat:
 
 Then:
 
-* ``source venv/bin/activate  # or venv\Scripts\activate on Windows``
-* ``pip install -r requirements.txt``
-* ``pip install -e .``
+* activate the virtual environment:
+
+  ``source venv/bin/activate  # or venv\Scripts\activate on Windows``
+* make sure you have a recent pip installer:
+
+  ``pip install --upgrade pip``
+* Go to the pyat root directory:
+
+  ``cd <atroot>/pyat``
+* install AT:
+
+  ``pip install -e .``
 
 Finally, you should be able to run the tests:
 
@@ -58,17 +73,17 @@ recompiled.  To force recompilation, remove the build directory:
 Any changes to .py files are automatically reinstalled in the build, but to
 ensure any changes to .c files are reinstalled rerun:
 
-* ``python setup.py develop``
+* ``pip install -e .``
 
-If you get strange behaviour even after running setup.py develop again, then
+If you get strange behaviour even after running pip install develop again, then
 running the following, inside pyat, should fix it:
 
 * ``rm -rf build``
 * ``find at -name "*.pyc" -exec rm '{}' \;``
 * ``find at -name "*.so" -exec rm '{}' \;``
-* ``python setup.py develop``
+* ``pip install -e .``
 
-N.B. setup.py develop needs to be run with the same version of Python (and
+N.B. ``pip install -e .`` needs to be run with the same version of Python (and
 numpy) that you are using to run pyAT.
 
 Releasing a version to PyPI
@@ -91,12 +106,10 @@ For testing any version that you have installed, the simple snippet in
 ``README.rst`` is sufficient.
 
 * Decide the Python versions that should be supported in the release
-   * Set these Python versions in setup.py
-   * Set at least these Python versions as python-version in .github/workflows/python-tests.yml
+   * Set these Python versions in ``python_requires`` in ``setup.cfg``
+   * Set at least these Python versions as ``python-version`` in ``.github/workflows/python-tests.yml``
 * Determine the minimum Numpy version that is required for those Python versions
-   * Set this numpy version in install_requires in setup.py
-   * Set this numpy version in requirements.txt
-* Update the pyat version in setup.py to x.y.z
+   * Set this numpy version in ``install_requires`` in ``setup.cfg``
 * Push a tag ``pyat-x.y.z`` to Github
 
 If all goes well, there will be a build of "Build and upload wheels and sdist"

--- a/pyat/githubproject.toml
+++ b/pyat/githubproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # Pypy does not have Scipy so we cannot support it.
-build = ["cp3{6,7,8,9}*", "cp310*"]
+build = ["cp3{6,7,8,9,10}*"]
 build-verbosity = "1"
 # "build" frontend fails on windows
 # build-frontend = "build"

--- a/pyat/githubproject.toml
+++ b/pyat/githubproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "numpy >= 1.16.6;python_version<'3.10'",
-    "numpy >= 1.21.5;python_version>='3.10'",
+    "numpy == 1.16.6;python_version<'3.10'",
+    "numpy == 1.21.5;python_version>='3.10'",
     "setuptools >= 45",
     "setuptools_scm>=6.2",
     "wheel",
@@ -21,5 +21,5 @@ archs = ["x86_64", "arm64"]
 [tool.setuptools_scm]
 root = ".."
 # write_to = "pyat/at/_version.py"
-git_describe_command = "git describe --dirty --tags --long --match pyat-[0-9]*"
+git_describe_command = "git describe --tags --long --match pyat-[0-9]* HEAD"
 fallback_version = "0.0.0"

--- a/pyat/requirements.txt
+++ b/pyat/requirements.txt
@@ -1,4 +1,0 @@
-pytest>=2.9
-numpy>=1.16.6
-scipy>=0.16
-pytest-lazy-fixture

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = accelerator-toolbox
+author = The AT collaboration
+author_email = atcollab-general@lists.sourceforge.net
+description = Accelerator Toolbox
+long_description = file: README.rst
+# version ignore when running setuptools_scm
+version = 0.0.0
+url = https://github.com/atcollab/at
+classifiers =
+    Development Status :: 4 - Beta
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+python_requires = >= 3.6.0
+packages = find:
+zip_safe = False
+install_requires =
+    importlib-metadata;python_version<'3.8'
+    numpy>=1.16.6
+    scipy>=0.16

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -22,5 +22,13 @@ packages = find:
 zip_safe = False
 install_requires =
     importlib-metadata;python_version<'3.8'
-    numpy>=1.16.6
+    numpy>=1.16.6;python_version<'3.10'
+    numpy>=1.21.5;python_version>='3.10'
     scipy>=0.16
+
+[options.extras_require]
+dev =
+    pytest >= 2.9
+    pytest-lazy-fixture
+    pytest-cov
+    flake8

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -1,14 +1,12 @@
 import glob
-from io import open
 import os
 from os.path import abspath, basename, dirname, exists, join, splitext
 import sys
 import shutil
-from setuptools import setup, Extension, find_packages
+from setuptools import setup, Extension
 
 # Numpy build dependency defined in pyproject.toml.
 import numpy
-
 
 
 def select_omp():
@@ -38,7 +36,7 @@ if mpi is None:
     mpi_macros = []
     mpi_includes = []
 else:
-    mpi_macros = [('MPI',None)]
+    mpi_macros = [('MPI', None)]
     os.environ["CC"] = 'mpicc'
     try:
         import mpi4py
@@ -81,32 +79,21 @@ else:
 if not sys.platform.startswith('win32'):
     cflags += ['-Wno-unused-function']
 
-
-# Get the long description from the README file
-with open(join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
-
-
 # It is easier to copy the integrator files into a directory inside pyat
 # for packaging. However, we cannot always rely on this directory being
 # inside a clone of at and having the integrator sources available, and
 # this file is executed each time any setup.py command is run.
 # It appears that only copying the files when they are available is
 # sufficient.
-at_source = abspath(join(here, 'at.c'))
 integrator_src_orig = abspath(join(here, '..', 'atintegrators'))
-integrator_src = abspath(join(here, 'integrator-src'))
-diffmatrix_source = abspath(
-    join(here, '..', 'atmat', 'atphysics', 'Radiation')
-)
+integrator_src = 'integrator-src'
+diffmatrix_orig = abspath(join(here, '..', 'atmat', 'atphysics', 'Radiation'))
 
 if exists(integrator_src_orig):
     # Copy files into pyat for distribution.
     source_files = glob.glob(join(integrator_src_orig, '*.[ch]'))
     source_files.extend(glob.glob(join(integrator_src_orig, '*.cc')))
-    source_files.extend(
-        glob.glob(join(diffmatrix_source, 'findmpoleraddiffmatrix.c'))
-    )
+    source_files.append(join(diffmatrix_orig, 'findmpoleraddiffmatrix.c'))
     if not exists(integrator_src):
         os.makedirs(integrator_src)
     for f in source_files:
@@ -114,7 +101,8 @@ if exists(integrator_src_orig):
 
 pass_methods = glob.glob(join(integrator_src, '*Pass.c'))
 pass_methods.extend(glob.glob(join(integrator_src, '*Pass.cc')))
-diffmatrix_method = join(integrator_src, 'findmpoleraddiffmatrix.c')
+diffmatrix_source = join(integrator_src, 'findmpoleraddiffmatrix.c')
+at_source = 'at.c'
 
 
 def integrator_ext(pass_method):
@@ -123,7 +111,7 @@ def integrator_ext(pass_method):
     return Extension(
         name=name,
         sources=[pass_method],
-        include_dirs=[numpy.get_include(), mpi_includes, integrator_src, diffmatrix_source],
+        include_dirs=[numpy.get_include(), mpi_includes, integrator_src],
         define_macros=macros + omp_macros + mpi_macros,
         extra_compile_args=cflags + omp_cflags,
         extra_link_args=omp_lflags
@@ -134,40 +122,19 @@ at = Extension(
     'at.tracking.atpass',
     sources=[at_source],
     define_macros=macros + omp_macros + mpi_macros,
-    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    include_dirs=[numpy.get_include(), integrator_src],
     extra_compile_args=cflags + omp_cflags,
     extra_link_args=omp_lflags
 )
 
 diffmatrix = Extension(
     name='at.physics.diffmatrix',
-    sources=[diffmatrix_method],
-    include_dirs=[numpy.get_include(), integrator_src, diffmatrix_source],
+    sources=[diffmatrix_source],
+    include_dirs=[numpy.get_include(), integrator_src],
     define_macros=macros,
     extra_compile_args=cflags
 )
 
 setup(
-    name='accelerator-toolbox',
-    version='0.2.1',
-    description='Accelerator Toolbox',
-    long_description=long_description,
-    author='The AT collaboration',
-    author_email='atcollab-general@lists.sourceforge.net',
-    url='https://github.com/atcollab/at',
-    # Numpy 1.16.6 is the oldest version that builds with Python 3.9.
-    install_requires=['numpy>=1.16.6', 'scipy>=0.16'],
-    packages=find_packages(),
     ext_modules=[at, diffmatrix] + [integrator_ext(pm) for pm in pass_methods],
-    zip_safe=False,
-    python_requires='>=3.6.0',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ]
 )

--- a/pyat/setup.py
+++ b/pyat/setup.py
@@ -28,7 +28,7 @@ here = abspath(dirname(__file__))
 macros = [('PYAT', None)]
 with_openMP = False
 
-cflags = []
+cflags = ['-std=c99']
 
 
 mpi = os.environ.get('MPI', None)


### PR DESCRIPTION
This PR is a partial move to the new python packaging standards:
- most of the packaging configuration is moved from `setup.py` to `setup.cfg`,
- `setup.py` only keeps the configuration of the compilation of C and C++ extensions and the copy of C sources, which have to be dynamic,
- more configuration of the packaging process is moved to `pyproject.toml`,
- the up-to-date build tools `python -m pip` and `python -m build` can now be used instead of `python setup.py`.

Versioning is handled fully automatically by `setuptools_scm`. The AT version is determined on each build by comparison to the last git tag of the form "pyat-x.y.z".

The version number of an 'official' release is the "x.y.x" string defined by the tag which triggered the build. The version number of intermediate builds is in the form "x.y.t.dev000+g11111" where:
- x.y.t is the value of the last git tag incremented by 1 on the last component,
- 000 is the number of commits since the tag,
- 111 is the commit identifier.

Git tags not in the form "pyat-x.y.z" are ignored by the versioning.

The version number is accessible at run time in` at.__version__`.