### PR TITLE
check/set multi-processing start method in patpass

### DIFF
--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -2,9 +2,12 @@
 
 # Make all functions visible in the at namespace:
 import sys
+import multiprocessing
 from .lattice import *
 from .tracking import *
 from .physics import *
 from .load import *
 from .matching import *
 sys.modules['at.constants'] = sys.modules['at.lattice.constants']
+
+

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -2,7 +2,6 @@
 
 # Make all functions visible in the at namespace:
 import sys
-import multiprocessing
 from .lattice import *
 from .tracking import *
 from .physics import *

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -8,5 +8,3 @@ from .physics import *
 from .load import *
 from .matching import *
 sys.modules['at.constants'] = sys.modules['at.lattice.constants']
-
-

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -43,7 +43,8 @@ def _atpass_one(ring, rin, **kwargs):
 
 
 def _atpass(ring, r_in, pool_size, globvar, **kwargs):
-    if platform.startswith('linux') and globvar:
+    print(multiprocessing.get_start_method())
+    if multiprocessing.get_start_method()=='fork':
         global globring
         globring = ring
         args = [(None, r_in[:, i]) for i in range(r_in.shape[1])]
@@ -52,7 +53,7 @@ def _atpass(ring, r_in, pool_size, globvar, **kwargs):
         globring = None
     else:
         args = [(ring, r_in[:, i]) for i in range(r_in.shape[1])]
-        with multiprocessing.get_context('fork').Pool(pool_size) as pool:
+        with multiprocessing.Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
     losses = kwargs.pop('losses', False)
     return format_results(results, r_in, losses)
@@ -97,7 +98,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))
     pm_ok = [e.PassMethod in elements._collective for e in ring]
-    if len(numpy.atleast_1d(r_in[0])) > 1 and not any(pm_ok) and 'win32' not in platform:
+    if len(numpy.atleast_1d(r_in[0])) > 1 and not any(pm_ok):
         if pool_size is None:
             pool_size = min(len(r_in[0]), multiprocessing.cpu_count())
         return _atpass(ring, r_in, pool_size, globvar, nturns=nturns,
@@ -105,7 +106,4 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
     else:
         if any(pm_ok):
             warn(AtWarning('Collective PassMethod found: use single process'))
-        if 'win32' in platform:
-            warn(AtWarning('Windows OS: patpass not available: use single '
-                           'process or compile with OpenMP'))
         return atpass(ring, numpy.asfortranarray(r_in), nturns=nturns, refpts=refpts, losses=losses)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -43,16 +43,20 @@ def _atpass_one(ring, rin, **kwargs):
 
 
 def _atpass(ring, r_in, pool_size, globvar, **kwargs):
-    if multiprocessing.get_start_method()=='fork':
+    cxt = kwargs.pop('context', None)
+    if cxt is None:
+        cxt = multiprocessing.get_context('fork')
+    print(cxt.get_start_method())
+    if cxt.get_start_method()=='fork':
         global globring
         globring = ring
         args = [(None, r_in[:, i]) for i in range(r_in.shape[1])]
-        with multiprocessing.Pool(pool_size) as pool:
+        with cxt.Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
         globring = None
     else:
         args = [(ring, r_in[:, i]) for i in range(r_in.shape[1])]
-        with multiprocessing.Pool(pool_size) as pool:
+        with cxt.Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
     losses = kwargs.pop('losses', False)
     return format_results(results, r_in, losses)
@@ -93,6 +97,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         coordinates at which the particle is lost. Set to zero for particles
         that survived
     """
+    cxt = kwargs.pop('context',None)
     if refpts is None:
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))
@@ -101,7 +106,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         if pool_size is None:
             pool_size = min(len(r_in[0]), multiprocessing.cpu_count())
         return _atpass(ring, r_in, pool_size, globvar, nturns=nturns,
-                       refpts=refpts, losses=losses)
+                       refpts=refpts, losses=losses, context=cxt)
     else:
         if any(pm_ok):
             warn(AtWarning('Collective PassMethod found: use single process'))

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -93,6 +93,13 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         coordinates at which the particle is lost. Set to zero for particles
         that survived
     """
+    start_method = kwargs.pop('start_method','spawn')
+    if start_method is not None:
+        #try:
+        multiprocessing.set_start_method(start_method)
+        #except RuntimeError:
+        #   pass
+
     if refpts is None:
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -43,7 +43,6 @@ def _atpass_one(ring, rin, **kwargs):
 
 
 def _atpass(ring, r_in, pool_size, globvar, **kwargs):
-    print(multiprocessing.get_start_method())
     if multiprocessing.get_start_method()=='fork':
         global globring
         globring = ring

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -84,6 +84,13 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         pool_size       number of processes, if None the min(npart,nproc) is used
         globvar         For linux machines speed-up is achieved by defining a global
                         ring variable, this can be disabled using globvar=False
+        start_method    This parameter allows to change the python multiprocessing
+                        start method, default=None uses the python defaults that is
+                        considered safe. 
+                        Available parameters: 'fork', 'spawn', 'forkserver'. Default
+                        for linux is fork, default for MacOS and Windows is spawn. 
+                        fork may used for MacOS to speed-up the calculation or to solve
+                        Runtime Errors, however it is considered unsafe.
 
      OUTPUT:
         (6, N, R, T) array containing output coordinates of N particles
@@ -93,11 +100,8 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         coordinates at which the particle is lost. Set to zero for particles
         that survived
     """
-    if start_method is not None:
-        try:
-            multiprocessing.set_start_method(start_method)
-        except RuntimeError:
-            pass
+    if multiprocessing.get_start_method(allow_none=True) != start_method:
+        multiprocessing.set_start_method(start_method, force=True)
 
     if refpts is None:
         refpts = len(ring)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -43,7 +43,7 @@ def _atpass_one(ring, rin, **kwargs):
 
 
 def _atpass(ring, r_in, pool_size, globvar, **kwargs):
-    if multiprocessing.get_start_method()=='fork':
+    if multiprocessing.get_start_method()=='fork' and globvar:
         global globring
         globring = ring
         args = [(None, r_in[:, i]) for i in range(r_in.shape[1])]

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -113,9 +113,9 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
             warn(AtWarning('Collective PassMethod found: use single process'))
         if r_in.flags.f_contiguous:
             return atpass(ring, r_in, nturns=nturns, refpts=refpts, losses=losses)
-    else:
-        r_fin = numpy.asfortranarray(r_in)
-        r_out = atpass(ring, r_fin, nturns=nturns, refpts=refpts, losses=losses)
-        r_in[:] = r_fin[:]
-        return r_out
+        else:
+            r_fin = numpy.asfortranarray(r_in)
+            r_out = atpass(ring, r_fin, nturns=nturns, refpts=refpts, losses=losses)
+            r_in[:] = r_fin[:]
+            return r_out
         

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -19,7 +19,7 @@ globring = None
 
 def format_results(results, r_in, losses):
     rin = [r['rin'] for r in results]
-    r_in = numpy.vstack(rin).T
+    r_in[:] = numpy.vstack(rin).T[:]
     if losses:
         rout = [r['results'][0] for r in results]
         rout = numpy.concatenate(rout, axis=1)
@@ -52,7 +52,7 @@ def _atpass(ring, r_in, pool_size, globvar, **kwargs):
         globring = None
     else:
         args = [(ring, r_in[:, i]) for i in range(r_in.shape[1])]
-        with multiprocessing.Pool(pool_size) as pool:
+        with multiprocessing.get_context('fork').Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
     losses = kwargs.pop('losses', False)
     return format_results(results, r_in, losses)
@@ -97,7 +97,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))
     pm_ok = [e.PassMethod in elements._collective for e in ring]
-    if len(numpy.atleast_1d(r_in[0])) > 1 and not any(pm_ok):
+    if len(numpy.atleast_1d(r_in[0])) > 1 and not any(pm_ok) and 'win32' not in platform:
         if pool_size is None:
             pool_size = min(len(r_in[0]), multiprocessing.cpu_count())
         return _atpass(ring, r_in, pool_size, globvar, nturns=nturns,
@@ -105,4 +105,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
     else:
         if any(pm_ok):
             warn(AtWarning('Collective PassMethod found: use single process'))
-        return atpass(ring, r_in, nturns=nturns, refpts=refpts, losses=losses)
+        if 'win32' in platform:
+            warn(AtWarning('Windows OS: patpass not available: use single '
+                           'process or compile with OpenMP'))
+        return atpass(ring, numpy.asfortranarray(r_in), nturns=nturns, refpts=refpts, losses=losses)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -43,20 +43,16 @@ def _atpass_one(ring, rin, **kwargs):
 
 
 def _atpass(ring, r_in, pool_size, globvar, **kwargs):
-    cxt = kwargs.pop('context', None)
-    if cxt is None:
-        cxt = multiprocessing.get_context('fork')
-    print(cxt.get_start_method())
-    if cxt.get_start_method()=='fork':
+    if multiprocessing.get_start_method()=='fork':
         global globring
         globring = ring
         args = [(None, r_in[:, i]) for i in range(r_in.shape[1])]
-        with cxt.Pool(pool_size) as pool:
+        with multiprocessing.Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
         globring = None
     else:
         args = [(ring, r_in[:, i]) for i in range(r_in.shape[1])]
-        with cxt.Pool(pool_size) as pool:
+        with multiprocessing.Pool(pool_size) as pool:
             results = pool.starmap(partial(_atpass_one, **kwargs), args)
     losses = kwargs.pop('losses', False)
     return format_results(results, r_in, losses)
@@ -97,7 +93,6 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         coordinates at which the particle is lost. Set to zero for particles
         that survived
     """
-    cxt = kwargs.pop('context',None)
     if refpts is None:
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))
@@ -106,7 +101,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, losses=False, pool_size=None,
         if pool_size is None:
             pool_size = min(len(r_in[0]), multiprocessing.cpu_count())
         return _atpass(ring, r_in, pool_size, globvar, nturns=nturns,
-                       refpts=refpts, losses=losses, context=cxt)
+                       refpts=refpts, losses=losses)
     else:
         if any(pm_ok):
             warn(AtWarning('Collective PassMethod found: use single process'))


### PR DESCRIPTION
This branch fixes a problem that was found by @simoneliuzzo when running python 3.9 and MACOS 12.0.1: python mulitprocessing uses "spawn" as default start method which causes the following Runtime error:

```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

This error is not clear to me as` freeze_support()` is supposed to be acitve only for Windows...

Nevertheless, for now I can propose the following:
-linux change nothing it is working
-MACOS: force "fork" start_method
-Windows: return a warning and run single process `lattice_pass`

This may not be the best approach but it is very difficult for me to validate this as I have no way of testing either MAC or Windows execution.

Help would be most appreciated!