### PR TITLE
Cavity phase offset arg

### DIFF
--- a/atintegrators/CavityPass.c
+++ b/atintegrators/CavityPass.c
@@ -1,4 +1,5 @@
 /* CavityPass.c
+
  * Accelerator Toolbox
  * Revision 3/10/04
  * A.Terebilo terebilo@ssrl.slac.stanford.edu
@@ -17,9 +18,10 @@ struct elem
     double Frequency;
     /* optional fields */
     double TimeLag;
+    double Phi0;
 };
 
-void CavityPass(double *r_in, double le, double nv, double freq, double lag, int num_particles)
+void CavityPass(double *r_in, double le, double nv, double freq, double lag, double phi0, int num_particles)
 /* le - physical length
  * nv - peak voltage (V) normalized to the design enegy (eV)
  * r is a 6-by-N matrix of initial conditions reshaped into
@@ -31,7 +33,7 @@ void CavityPass(double *r_in, double le, double nv, double freq, double lag, int
     {	for(c = 0;c<num_particles;c++)
         {	c6 = c*6;
             if(!atIsNaN(r_in[c6]))
-                r_in[c6+4] += -nv*sin(TWOPI*freq*(r_in[c6+5]-lag)/C0);
+                r_in[c6+4] += -nv*sin(TWOPI*freq*(r_in[c6+5]-lag)/C0+phi0);
         }
     }
     else
@@ -46,7 +48,7 @@ void CavityPass(double *r_in, double le, double nv, double freq, double lag, int
                 r_in[c6+2]+= NormL*r_in[c6+3];
                 r_in[c6+5]+= NormL*p_norm*(r_in[c6+1]*r_in[c6+1]+r_in[c6+3]*r_in[c6+3])/2;
                 /* Longitudinal momentum kick */
-                r_in[c6+4] += -nv*sin(TWOPI*freq*(r_in[c6+5]-lag)/C0);
+                r_in[c6+4] += -nv*sin(TWOPI*freq*(r_in[c6+5]-lag)/C0+phi0);
                 p_norm = 1/(1+r_in[c6+4]);
                 NormL  = halflength*p_norm;
                 /* Prropagate through a drift equal to half cavity length */
@@ -65,21 +67,23 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         double *r_in, int num_particles, struct parameters *Param)
 {
     if (!Elem) {
-        double Length, Voltage, Energy, Frequency, TimeLag;
+        double Length, Voltage, Energy, Frequency, TimeLag, Phi0;
         Length=atGetDouble(ElemData,"Length"); check_error();
         Voltage=atGetDouble(ElemData,"Voltage"); check_error();
         Energy=atGetDouble(ElemData,"Energy"); check_error();
         Frequency=atGetDouble(ElemData,"Frequency"); check_error();
         TimeLag=atGetOptionalDouble(ElemData,"TimeLag",0); check_error();
+        Phi0=atGetOptionalDouble(ElemData,"Phi0",0); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         Elem->Length=Length;
         Elem->Voltage=Voltage;
         Elem->Energy=Energy;
         Elem->Frequency=Frequency;
         Elem->TimeLag=TimeLag;
+        Elem->Phi0=Phi0;
     }
     CavityPass(r_in,Elem->Length,Elem->Voltage/Elem->Energy,Elem->Frequency,
-            Elem->TimeLag,num_particles);
+            Elem->TimeLag,Elem->Phi0,num_particles);
     return Elem;
 }
 
@@ -89,7 +93,7 @@ MODULE_DEF(CavityPass)        /* Dummy module initialisation */
 
 #if defined(MATLAB_MEX_FILE)
 
-void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     if (nrhs == 2) {
         double *r_in;
@@ -100,6 +104,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double Energy=atGetDouble(ElemData,"Energy");
         double Frequency=atGetDouble(ElemData,"Frequency");
         double TimeLag=atGetOptionalDouble(ElemData,"TimeLag",0);
+        double Phi0=atGetOptionalDouble(ElemData,"Phi0",0);
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
@@ -113,8 +118,9 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mxSetCell(plhs[0],2,mxCreateString("Energy"));
         mxSetCell(plhs[0],3,mxCreateString("Frequency"));
         if (nlhs>1) /* optional fields */
-        {   plhs[1] = mxCreateCellMatrix(1,1);
+        {   plhs[1] = mxCreateCellMatrix(2,1);
             mxSetCell(plhs[1],0,mxCreateString("TimeLag"));
+            mxSetCell(plhs[1],1,mxCreateString("Phi0"));
         }
     }
 	else {

--- a/atintegrators/RFCavityPass.c
+++ b/atintegrators/RFCavityPass.c
@@ -124,7 +124,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
       {
           plhs[1] = mxCreateCellMatrix(2,1);
           mxSetCell(plhs[1],0,mxCreateString("TimeLag"));
-          mxSetCell(plhs[1],0,mxCreateString("PhaseLag"));
+          mxSetCell(plhs[1],1,mxCreateString("PhaseLag"));
       }
   }
   else

--- a/atintegrators/RFCavityPass.c
+++ b/atintegrators/RFCavityPass.c
@@ -21,9 +21,11 @@ struct elem
   double Frequency;
   double HarmNumber;
   double TimeLag;
+  double Phi0;
 };
 
-void RFCavityPass(double *r_in, double le, double nv, double freq, double h, double lag, int nturn, double T0, int num_particles)
+void RFCavityPass(double *r_in, double le, double nv, double freq, double h, double lag, double phi0,
+                  int nturn, double T0, int num_particles)
 /* le - physical length
    nv - peak voltage (V) normalized to the design enegy (eV)
    r is a 6-by-N matrix of initial conditions reshaped into
@@ -36,7 +38,7 @@ void RFCavityPass(double *r_in, double le, double nv, double freq, double h, dou
         for (c = 0; c<num_particles; c++) {
             double *r6 = r_in+c*6;
             if(!atIsNaN(r6[0]))
-                r6[4] += -nv*sin(TWOPI*freq*((r6[5]-lag)/C0 - (h/freq-T0)*nturn));
+                r6[4] += -nv*sin(TWOPI*freq*((r6[5]-lag)/C0 - (h/freq-T0)*nturn) + phi0);
         }
     }
     else {
@@ -47,7 +49,7 @@ void RFCavityPass(double *r_in, double le, double nv, double freq, double h, dou
                 /* Propagate through a drift equal to half cavity length */
                 drift6(r6, halflength);
                 /* Longitudinal momentum kick */
-                r6[4] += -nv*sin(TWOPI*freq*((r6[5]-lag)/C0 - (h/freq-T0)*nturn));
+                r6[4] += -nv*sin(TWOPI*freq*((r6[5]-lag)/C0 - (h/freq-T0)*nturn) + phi0);
                 /* Propagate through a drift equal to half cavity length */
                 drift6(r6, halflength);
             }
@@ -62,12 +64,13 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     int nturn=Param->nturn;
     double T0=Param->T0;
     if (!Elem) {
-        double Length, Voltage, Energy, Frequency, TimeLag;
+        double Length, Voltage, Energy, Frequency, TimeLag, Phi0;
         Length=atGetDouble(ElemData,"Length"); check_error();
         Voltage=atGetDouble(ElemData,"Voltage"); check_error();
         Energy=atGetDouble(ElemData,"Energy"); check_error();
         Frequency=atGetDouble(ElemData,"Frequency"); check_error();
         TimeLag=atGetOptionalDouble(ElemData,"TimeLag",0); check_error();
+        Phi0=atGetOptionalDouble(ElemData,"Phi0",0); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         Elem->Length=Length;
         Elem->Voltage=Voltage;
@@ -75,8 +78,10 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->Frequency=Frequency;
         Elem->HarmNumber=round(Frequency*T0);
         Elem->TimeLag=TimeLag;
+        Elem->Phi0=Phi0;
     }
-    RFCavityPass(r_in, Elem->Length, Elem->Voltage/Elem->Energy, Elem->Frequency, Elem->HarmNumber, Elem->TimeLag, nturn, T0, num_particles);
+    RFCavityPass(r_in, Elem->Length, Elem->Voltage/Elem->Energy, Elem->Frequency, Elem->HarmNumber, Elem->TimeLag,
+                 Elem->Phi0, nturn, T0, num_particles);
     return Elem;
 }
 
@@ -98,13 +103,14 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
       double Energy=atGetDouble(ElemData,"Energy");
       double Frequency=atGetDouble(ElemData,"Frequency");
       double TimeLag=atGetOptionalDouble(ElemData,"TimeLag",0);
+      double Phi0=atGetOptionalDouble(ElemData,"Phi0",0);
       double T0=1.0/Frequency;      /* Does not matter since nturns == 0 */
       double HarmNumber=round(Frequency*T0);
       if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
       /* ALLOCATE memory for the output array of the same size as the input  */
       plhs[0] = mxDuplicateArray(prhs[1]);
       r_in = mxGetDoubles(plhs[0]);
-      RFCavityPass(r_in, Length, Voltage/Energy, Frequency, HarmNumber, TimeLag, 0, T0, num_particles);
+      RFCavityPass(r_in, Length, Voltage/Energy, Frequency, HarmNumber, TimeLag, Phi0, 0, T0, num_particles);
 
     }
   else if (nrhs == 0)
@@ -116,8 +122,9 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
       mxSetCell(plhs[0],3,mxCreateString("Frequency"));
       if(nlhs>1) /* optional fields */
       {
-          plhs[1] = mxCreateCellMatrix(1,1);
+          plhs[1] = mxCreateCellMatrix(2,1);
           mxSetCell(plhs[1],0,mxCreateString("TimeLag"));
+          mxSetCell(plhs[1],0,mxCreateString("Phi0"));
       }
   }
   else


### PR DESCRIPTION
This branch adds an optional phase offset argument to the cavity passmethods.
This will facilitate the upcoming beam loading development by giving an independent input to set the tuning angle without having to overwrite Timelag that is in principle fixed.

No impact on the standard use of these passmethods.