### PR TITLE
allow fit chrom with radon

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt6.m
+++ b/atmat/atphysics/LinearOptics/atlinopt6.m
@@ -77,7 +77,7 @@ clight = PhysConstant.speed_of_light_in_vacuum.value;   % m/s
 [get_w, varargs]=getflag(varargs, 'get_w');
 [twiss_in,varargs]=getoption(varargs,'twiss_in',[]);
 [orbitin,varargs]=getoption(varargs,'orbit',[]);
-[DPStep,~]=getoption(varargs,'DPStep');
+[DPStep,varargs]=getoption(varargs,'DPStep');
 [dp,varargs]=getoption(varargs,'dp',NaN);
 [refpts,varargs]=getargs(varargs,1);
 

--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -28,7 +28,7 @@ function newring=atfitchrom(ring,varargin)
 %check_radiation(ring,false);
 [deltaP,varargin]=getoption(varargin,'DPStep');
 [deltaS,varargin]=getoption(varargin,'HStep',1.0e-5);
-[dpp,varargin]=getargs(varargin,0.0,'check',@(arg) isscalar(arg) && isnumeric(arg));
+[dpp,varargin]=getargs(varargin,NaN,'check',@(arg) isscalar(arg) && isnumeric(arg));
 [newchrom,famname1,famname2]=deal(varargin{:});
 
 idx1=varelem(ring,famname1);

--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -25,7 +25,6 @@ function newring=atfitchrom(ring,varargin)
 %
 % See also ATFITTUNE
 
-%check_radiation(ring,false);
 [deltaP,varargin]=getoption(varargin,'DPStep');
 [deltaS,varargin]=getoption(varargin,'HStep',1.0e-5);
 [dpp,varargin]=getargs(varargin,NaN,'check',@(arg) isscalar(arg) && isnumeric(arg));

--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -44,7 +44,7 @@ kl2=atgetfieldvalues(ring(idx2),'PolynomB',{3});
     
     %Construct the Jacobian
     J = ([chrom1(:) chrom2(:)] - [chrom(:) chrom(:)])/deltaS;
-    dK = J\(newchrom(:)-chrom(:));
+    dK = J(1:2,:)\(newchrom-chrom(1:2))';
 % else
 %     dK=fminsearch(@funchrom,[0;0],...
 %         optimset(optimset('fminsearch'),'Display','iter',...

--- a/atmat/lattice/atfitchrom.m
+++ b/atmat/lattice/atfitchrom.m
@@ -25,7 +25,7 @@ function newring=atfitchrom(ring,varargin)
 %
 % See also ATFITTUNE
 
-check_radiation(ring,false);
+%check_radiation(ring,false);
 [deltaP,varargin]=getoption(varargin,'DPStep');
 [deltaS,varargin]=getoption(varargin,'HStep',1.0e-5);
 [dpp,varargin]=getargs(varargin,0.0,'check',@(arg) isscalar(arg) && isnumeric(arg));
@@ -86,8 +86,7 @@ newring=setsx(newring,idx2,kl2,dK(2));
     end
 
     function chrom=getchrom(ring,dpp,deltaP)
-        [ringda,elemdata]=atlinopt6(ring,'dp',dpp-0.5*deltaP); %#ok<ASGLU>
-        [ringdb,elemdata]=atlinopt6(ring,'dp',dpp+0.5*deltaP); %#ok<ASGLU>
-        chrom = (ringdb.tune(1:2)-ringda.tune(1:2))/deltaP;
+        [ringda,elemdata]=atlinopt6(ring,'dp',dpp,'DPStep',deltaP,'get_chrom'); %#ok<ASGLU>
+        chrom = ringda.chromaticity;
     end
 end


### PR DESCRIPTION
atfitchrom was requesting rad off in matlab: this is breaking ESRF operation tools!

This branch uses directly atlinopt6 to compute the chromaticity, rad off is not required anymore.
!!!Warning: with radiation ON the initial dp offset is ignored, frequency should be used instead!!!

For future developments, especially on matlab please make sure the implementation is fully backward compatible
because this has strong impact on operation tools relying on AT. New errors coming from check_radiation() are
difficult to handle if not foreseen