### PR TITLE
atenergy computes the harmonic number from the RF frequency

### DIFF
--- a/atmat/atphysics/Radiation/atenergy.m
+++ b/atmat/atphysics/Radiation/atenergy.m
@@ -20,7 +20,10 @@ function [energy,nbper,voltage,harmnumber,U0]=atenergy(ring)
 %
 %  NOTES
 %    1. voltage and harmnumber assume a single RF system: fundamental
-%       frequency, no harmonic system.
+%       frequency, no harmonic system. More prcisely:
+%
+%       voltage is the sum of the voltages of all cavities,
+%       harmnuber is computed with the frequency of the 1st cavity in the ring
 %
 %  EXAMPLES
 %    1. [ENERGY,PERIODS]=atenergy(ring) also outputs the number of periods

--- a/atmat/atphysics/Radiation/atenergy.m
+++ b/atmat/atphysics/Radiation/atenergy.m
@@ -19,7 +19,8 @@ function [energy,nbper,voltage,harmnumber,U0]=atenergy(ring)
 %    5. U0         Energy loss per turn in eV
 %
 %  NOTES
-%    1. Check for 2 pi phase advance if more than 2 ouput arguments
+%    1. voltage and harmnumber assume a single RF system: fundamental
+%       frequency, no harmonic system.
 %
 %  EXAMPLES
 %    1. [ENERGY,PERIODS]=atenergy(ring) also outputs the number of periods

--- a/atmat/atphysics/Radiation/atenergy.m
+++ b/atmat/atphysics/Radiation/atenergy.m
@@ -1,105 +1,68 @@
 function [energy,nbper,voltage,harmnumber,U0]=atenergy(ring)
 %ATENERGY Gets the lattice energy
 %
-%  ENERGY=ATENERGY(RING) Gets the RING energy
-%   ATENERGY looks for the machine energy in:
-%       1) the 1st 'RingParam' element
-%       2) the 1st 'RFCavity' element
-%       3) the field "E0" of the global variable "GLOBVAL"
-%       4) The field "Energy" in any element
-%  
-%  INPUTS
-%    1. ring  Ring structure
+%  ENERGY=ATENERGY(RING)
+%  [ENERGY,PERIODS]=atenergy(RING)
+%  [ENERGY,PERIODS,VOLTAGE,HARMNUMBER]=atenergy(RING)
+%  [ENERGY,PERIODS,VOLTAGE,HARMNUMBER,U0]=atenergy(RING)
 %
-%  OUPUTS
-%    1. energy     Ring energy in eV
-%    2. nbper      Number of periods to make 2pi phase advance
-%    3. voltage    Total RF voltage  
-%    4. harmnumber Harmonic number
-%    5. U0         Energy loss per turn in eV
+% Warning: To get ENERGY, PERIODS and HARMNUMBER, use atGetRingProperties
+%          To get U0, use atgetU0
 %
-%  NOTES
-%    1. voltage and harmnumber assume a single RF system: fundamental
-%       frequency, no harmonic system. More prcisely:
+%   RING        Ring structure
 %
-%       voltage is the sum of the voltages of all cavities,
-%       harmnuber is computed with the frequency of the 1st cavity in the ring
+%   ENERGY      Ring energy
+%       ATENERGY looks for the machine energy in:
+%           1) the 1st 'RingParam' element
+%           2) the 'RFCavity' with the lowest frequency
+%           3) the field "E0" of the global variable "GLOBVAL"
+%           4) The field "Energy" in any element
+%   PERIODS     Number of periods
+%   VOLTAGE     Total RF voltage for the main cavities. The main cavities
+%               are the ones with the lowest frequency
+%   HARMNUMBER  Harmonic number. Computed from the frequency of the main cavities
+%   U0          Total energy loss per turn
 %
-%  EXAMPLES
-%    1. [ENERGY,PERIODS]=atenergy(ring) also outputs the number of periods
-%    2. [ENERGY,PERIODS,VOLTAGE,HARMNUMBER]=atenergy(ring) also outputs the harmonic number
-%    3. [ENERGY,PERIODS,VOLTAGE,HARMNUMBER,U0]=atenergy(ring) also outputs total losses in eV
-%
-%  See also atgetU0 atsetcavity atenergy
+%  See also atGetRingProperties atgetU0 atsetcavity
 
-global GLOBVAL
-TWO_PI_ERROR = 1.e-4;
- 
-params   = atgetcells(ring(:,1),'Class','RingParam');
-cavities = atgetcells(ring(:,1),'Frequency');
-        
-if any(params) % case RingParam is defined in the lattice
-    parmelem=ring{find(params,1)};
-    energy=parmelem.Energy;
-    if nargout >= 2
-        nbper=parmelem.Periodicity;
-    end
-else % else look for energy in cavity or GLOBVAL
-    E0s = atgetfieldvalues(ring,'Energy');
-    E0s = E0s(isfinite(E0s));         % Discard undefined values
-    if any(cavities) && isfield(ring{find(cavities,1)},'Energy')
-        energy=ring{find(cavities,1)}.Energy;
-    elseif isfield(GLOBVAL,'E0')
-        energy=GLOBVAL.E0;
-    elseif length(unique(E0s)) == 1
-        energy = unique(E0s);
-    elseif length(unique(E0s)) > 1
-        error('AT:NoEnergy','Energy field not equal for all elements')
+s=warning;                          % Save the warning state
+warning('Off','AT:NoRingParam');    % Disable warning
+props = atGetRingProperties(ring);  % Get ring propeties
+warning(s);                         % Restore the warning state
+energy = props.Energy;
+nbper = props.Periodicity;
+
+if nargout >= 3
+    if isfield(props, 'cavpts')
+        maincavs = ring(props.cavpts);
     else
-        error('AT:NoEnergy',...
-            ['Energy not defined (searched in '...
-            '''RingParam'',''RFCavity'',GLOBVAL.E0,',...
-            ' field ''Energy'' of each element)']);
+        maincavs = findmaincavs(ring);
     end
-    if nargout >= 2 % get number of periods
-        dipoles  = atgetcells(ring(:,1),'BendingAngle');
-        theta    = atgetfieldvalues(ring(dipoles),'BendingAngle');
-        if size(ring,2) > 1
-            nbper=size(ring,2);
-        else % Guess number of periods based on the total bending angle
-            nbp=2*pi/sum(theta);
-            nbper=round(nbp);
-            if ~isfinite(nbp)
-                warning('AT:WrongNumberOfCells','No bending in the cell, ncells set to 1');
-                nbper=1;
-            elseif abs(nbp-nbper) > TWO_PI_ERROR
-                warning('AT:WrongNumberOfCells','non integer number of cells: ncells = %g -> %g',nbp,nbper);
-            end
-        end
-    end
-end
-
-% Get total cavity voltage and harmonic number
-if nargout >= 3 
-    if any(cavities) % sum over cavity number
-        voltage=nbper*sum(atgetfieldvalues(ring(cavities),'Voltage'));
-        %harmnumber=nbper*atgetfieldvalues(ring(find(cavities,1)),'HarmNumber');
-        Frf=atgetfieldvalues(ring(find(cavities,1)),'Frequency');
-        L0 = nbper*findspos(ring,length(ring)+1); % design length [m]
-        C0 = PhysConstant.speed_of_light_in_vacuum.value; % speed of light [m/s]
-        harmnumber = round(Frf*L0/C0);
-
+    if ~isempty(maincavs)
+        voltage=nbper*sum(atgetfieldvalues(maincavs,'Voltage'));
     elseif nargout >= 5
         voltage=NaN;
-        harmnumber=NaN;
     else
         error('AT:NoCavity','No cavity element in the ring');
     end
 end
-
-% get energy loss per turn
+if nargout >= 4
+    harmnumber = props.HarmNumber;
+end
 if nargout >= 5
     U0 = atgetU0(ring);
 end
+
+    function cavs=findmaincavs(ring)
+        cavities = atgetcells(ring,'Frequency');
+        if any(cavities)
+            freqs = atgetfieldvalues(ring(cavities), 'Frequency');
+            [~,~,ic]=unique(freqs);
+            cavities(cavities) = (ic == 1);
+            cavs = ring(cavities);
+        else
+            cavs={};
+        end
+    end
 
 end

--- a/atmat/atphysics/Radiation/atenergy.m
+++ b/atmat/atphysics/Radiation/atenergy.m
@@ -79,7 +79,12 @@ end
 if nargout >= 3 
     if any(cavities) % sum over cavity number
         voltage=nbper*sum(atgetfieldvalues(ring(cavities),'Voltage'));
-        harmnumber=nbper*atgetfieldvalues(ring(find(cavities,1)),'HarmNumber');
+        %harmnumber=nbper*atgetfieldvalues(ring(find(cavities,1)),'HarmNumber');
+        Frf=atgetfieldvalues(ring(find(cavities,1)),'Frequency');
+        L0 = nbper*findspos(ring,length(ring)+1); % design length [m]
+        C0 = PhysConstant.speed_of_light_in_vacuum.value; % speed of light [m/s]
+        harmnumber = round(Frf*L0/C0);
+
     elseif nargout >= 5
         voltage=NaN;
         harmnumber=NaN;

--- a/atmat/lattice/atfindparam.m
+++ b/atmat/lattice/atfindparam.m
@@ -46,10 +46,14 @@ if ~isempty(idx)            % Found RingParam: use it
     if isfield(newparms, 'HarmNumber')
         check_h(newparms.HarmNumber, parmelem.Periodicity);
     elseif ~isfield(parmelem, 'HarmNumber')
-        maincav = findmaincav(ring(atgetcells(ring,'Frequency')));
-        if ~isempty(maincav)
+        if isfield(parmelem, 'cavpts')
+            maincavs = ring(props.cavpts);
+        else
+            maincavs = findmaincav(ring(atgetcells(ring,'Frequency')));
+        end
+        if ~isempty(maincavs)
             gamma = parmelem.Energy / parmelem.Particle.rest_energy;
-            h = parmelem.Periodicity * cellharmnumber(ring, maincav, gamma);
+            h = parmelem.Periodicity * cellharmnumber(ring, maincavs(1), gamma);
             parmelem.HarmNumber = h;
         end
     elseif new_nper ~= old_nper

--- a/atmat/lattice/atfindparam.m
+++ b/atmat/lattice/atfindparam.m
@@ -41,7 +41,7 @@ if ~isempty(idx)            % Found RingParam: use it
     parmelem = strupdate(parmelem, newparms);
     new_nper = parmelem.Periodicity;
     if ~isfield(parmelem, 'Particle')
-        parmelem.Particle = saveobj(atparticle('electron'));
+        parmelem.Particle = saveobj(atparticle('relativistic'));
     end
     if isfield(newparms, 'HarmNumber')
         check_h(newparms.HarmNumber, parmelem.Periodicity);
@@ -152,13 +152,9 @@ end
 
     function cellh=cellharmnumber(ring, maincav, gamma)
         % Extract the harmonic number from the main cavity
-        if isfield(maincav, 'HarmNumber')
-            cellh = maincav.HarmNumber;
-        else
-            vel = sqrt(1-1/gamma/gamma)*PhysConstant.speed_of_light_in_vacuum.value;
-            cellfrev = vel / findspos(ring, length(ring)+1);
-            cellh = round(maincav.Frequency/cellfrev);
-        end
+        vel = sqrt(1-1/gamma/gamma)*PhysConstant.speed_of_light_in_vacuum.value;
+        cellfrev = vel / findspos(ring, length(ring)+1);
+        cellh = round(maincav.Frequency/cellfrev);
     end
 
     function str = strupdate(str, str2)

--- a/atmat/lattice/atparticle.m
+++ b/atmat/lattice/atparticle.m
@@ -40,7 +40,7 @@ classdef atparticle
             %   REST_ENERGY Rest energy [eV]
             %   CHARGE      Charge [elementary charge]
             
-            if ~strcmp(name,'electron')
+            if ~strcmp(name,'relativistic')
                 warning('AT:particle','AT tracking still assumes beta==1. Make sure your particle is ultra-relativistic');
             end
             try


### PR DESCRIPTION
`atenergy` does not rely any more on the `HarmNumber` field of cavity elements. It computes the harmonic number from the frequency of the 1st RF cavity.