### PR TITLE
atsetcavity accepts dp and dct arguments

### DIFF
--- a/atmat/Contents.m
+++ b/atmat/Contents.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.2-dev.359 (atcollab) 31-Jan-2022
+% Version 2.2-dev.354 (atcollab) 01-Feb-2022
 %
 %   atdiag           - Tests AT intallation
 %   atdisplay        - checks the verbosity level in the global variable GLOBVAL

--- a/atmat/at.m
+++ b/atmat/at.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.2-dev.359 (atcollab) 31-Jan-2022
+% Version 2.2-dev.354 (atcollab) 01-Feb-2022
 %
 % The Accelerator Toolbox was originally created by Andrei Terebilo.
 % Development is now continued by a multi-laboratory collaboration, <a href="matlab:web('https://github.com/atcollab')">atcollab</a>

--- a/atmat/atphysics/Radiation/atradoff.m
+++ b/atmat/atphysics/Radiation/atradoff.m
@@ -69,7 +69,7 @@ if radnum > 0
     atdisplay(1,[num2str(radnum) ' elements switched to include radiation']);
 end
 
-    function [ring,mask]=changepass(ring,newpass,selfunc,autopass,code)
+    function [ring,mask]=changepass(ring,newpass,selfunc,autopass,code) %#ok<INUSD>
         if isempty(newpass)
             mask=false(size(ring));
         else
@@ -81,8 +81,6 @@ end
             end
             if any(mask)
                 ring(mask)=cellfun(@newelem,ring(mask),passlist(ok),'UniformOutput',false);
-            else
-                warning(['AT:atradoff:NO' code], ['no ' code ' modified']),
             end
         end
         


### PR DESCRIPTION
`atsetcavity` can now set the nominal RF frequency for off-momentum operation, using '`dp`'/'`dct`' keyword arguments.

Also solves spurious warning as mentioned [here](https://github.com/atcollab/at/issues/352#issuecomment-1017322208)