### PR TITLE
Documentation upgrade

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -5,7 +5,7 @@ name: Build and upload wheels and sdist
 on:
   push:
     tags:
-      - pyat-*
+      - pyat-[0-9]*
   workflow_dispatch:
 
 defaults:

--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -6,17 +6,17 @@ Introduction
 
 Accelerator Toolbox is a code used for simulating particle accelerators, used
 particularly for synchrotron light sources. It is hosted on `Github
-<https://github.com/atcollab>`_. Its original implementation is in Matlab.
+<https://github.com/atcollab/at>`_. Its original implementation is in Matlab.
 
 pyAT is a Python interface to Accelerator Toolbox. It uses the 'pass methods'
 defined in Accelerator Toolbox, implemented by compiling the C code used in the
 AT 'integrators' into a Python extension. These pass methods are used by
 higher-level functions to provide physics results.
 
-See the `pyAT website <https://atcollab.github.io/at/python.html>`_ for a
+See the `pyAT website <https://atcollab.github.io/at/p/Installation.html>`_ for a
 more detailed introduction.
 
-pyAT supports Python 3.6 to 3.9.
+pyAT supports Python 3.6 to 3.10.
 
 Installation
 ------------

--- a/pyat/pyat_examples.rst
+++ b/pyat/pyat_examples.rst
@@ -57,3 +57,4 @@ Calculating Physics Data:
 - Physics data functions can also be called as methods on the lattice::
 
     >>> ring.find_orbit(refpts=[0, 1, 2, 3, 4])
+

--- a/pyat/pyat_examples.rst
+++ b/pyat/pyat_examples.rst
@@ -22,8 +22,8 @@ Initialisation:
 
 - Load a pyAT ring from a .mat file::
 
-    >>> from at.load import load_mat
-    >>> ring = load_mat('test_matlab/hmba.mat')
+    >>> import at
+    >>> ring = at.load_lattice('test_matlab/hmba.mat')
 
 Basic Use:
 ----------
@@ -44,20 +44,16 @@ Basic Use:
 
 - Get the s position of the 10th element in the ring::
 
-    >>> at.lattice.get_s_pos(ring, 10)
+    >>> at.get_s_pos(ring, 10)
     array([3.4295565])
-
-- Creating a lattice object::
-
-    >>> lattice = at.lattice.Lattice(ring)
 
 Calculating Physics Data:
 -------------------------
 
 - Return the linear optics data at the first 5 elements::
 
-    >>> at.physics.linopt(ring, refpts=[0, 1, 2, 3, 4])
+    >>> at.get_optics(ring, refpts=[0, 1, 2, 3, 4])
 
 - Physics data functions can also be called as methods on the lattice::
 
-    >>> lattice.find_orbit4(refpts=[0, 1, 2, 3, 4])
+    >>> ring.find_orbit(refpts=[0, 1, 2, 3, 4])

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -4,6 +4,7 @@ author = The AT collaboration
 author_email = atcollab-general@lists.sourceforge.net
 description = Accelerator Toolbox
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 # version ignore when running setuptools_scm
 version = 0.0.0
 url = https://github.com/atcollab/at


### PR DESCRIPTION
The just-released PyAT 0.2.2 shows a few errors in the project description (mainly outdated web links or AT commands). This updates the package build and documentation:

- Update the links to Web sites,
- Update `pyat_examples.rst`,
- Trigger the build of wheels only for numeric tags. This allows creating tags like "pyat-latest" without triggering a full build. Testing the build sequence is now available by triggering the "build-python-wheels" action from the GitHub interface.
