### PR TITLE
Skip test_patpass on linux and MacOS

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,7 @@ jobs:
   build_and_run_tests:
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/pyat/test/test_patpass.py
+++ b/pyat/test/test_patpass.py
@@ -1,9 +1,11 @@
 from at import elements, patpass
 import numpy
 import pytest
+import sys
 
 
-
+@pytest.mark.skipif(not sys.platform.startswith("win"),
+                    reason="May hang on linux and MacOS")
 def test_patpass_multiple_particles_and_turns():
     nturns = 10
     nparticles = 10


### PR DESCRIPTION
This avoids the problem mentioned in #356, by skipping the test of patpass on linux and MacOS.

In addition, the timeout of test jobs is reduced to 15 minutes instead of the default 360 minutes, to avoid locking runners for 6 hours (at the moment, the maximum time for tests is ~4 minutes).