### PR TITLE
Default particle

### DIFF
--- a/atintegrators/attypes.h
+++ b/atintegrators/attypes.h
@@ -12,6 +12,10 @@ struct parameters
   int nturn;
   double RingLength;
   double T0;
+  double s_coord;
+  double energy;
+  double rest_energy;
+  double charge;
 };
 
 #endif /*ATTYPES_H*/

--- a/pyat/at/lattice/particle_object.py
+++ b/pyat/at/lattice/particle_object.py
@@ -27,8 +27,8 @@ class Particle(object):
         proton=dict(rest_energy=p_mass, charge=1.0)
     )
 
-    def __init__(self, name, **kwargs):
-        if name != 'electron':
+    def __init__(self, name='relativistic', **kwargs):
+        if name != 'relativistic':
             warn(UserWarning("AT tracking still assumes beta==1\n"
                              "Make sure your particle is ultra-relativistic"))
         if name in self._known:

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -2,7 +2,7 @@
 Closed orbit related functions
 """
 import numpy
-from at.lattice.constants import clight
+from at.constants import clight
 from at.lattice import AtWarning, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, uint32_refpts
 from at.tracking import lattice_pass
@@ -269,7 +269,7 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
 
     l0 = get_s_pos(ring, len(ring))[0]
     f_rf = ring.get_rf_frequency()
-    harm_number = round(f_rf*l0/clight)
+    harm_number = round(f_rf*l0/ring.beta/clight)
 
     if guess is None:
         _, dt = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
@@ -283,7 +283,7 @@ def _orbit6(ring, cavpts=None, guess=None, keep_lattice=False, **kwargs):
         ref_in = numpy.copy(guess)
 
     theta = numpy.zeros((6,))
-    theta[5] = clight * harm_number / f_rf - l0
+    theta[5] = ring.beta * clight * harm_number / f_rf - l0
 
     scaling = xy_step * numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0]) + \
               dp_step * numpy.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -1,6 +1,6 @@
 from ..lattice import Lattice, get_rf_frequency, check_radiation, get_s_pos
 from ..lattice import DConstant
-from ..lattice.constants import clight
+from ..constants import clight
 from ..tracking import lattice_pass
 from .orbit import find_orbit4
 import numpy
@@ -63,9 +63,10 @@ def get_revolution_frequency(ring, dp=None, dct=None, **kwargs):
                         Defaults to False
         dp_step=1.0E-6  momentum deviation used for differentiation
     """
-    frev = ring.revolution_frequency
+    lcell = ring.get_s_pos(len(ring))[0]
+    frev = ring.beta * clight / lcell / ring.periodicity
     if dct is not None:
-        frev -= frev * frev / clight * ring.periodicity * dct
+        frev *= lcell / (lcell + dct)
     elif dp is not None:
         rnorad = ring.radiation_off(copy=True) if ring.radiation else ring
         etac = get_slip_factor(rnorad, **kwargs)

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -3,7 +3,7 @@ Tracking functions
 """
 
 # noinspection PyUnresolvedReferences
-from .atpass import atpass, elempass, isopenmp, ismpi
+from .atpass import isopenmp, ismpi
 from .patpass import patpass
 from .track import *
 from .particles import *

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -1,15 +1,17 @@
 import numpy
-from at.tracking import atpass, elempass
-from at.lattice import uint32_refpts, DConstant
+from warnings import warn
+# noinspection PyUnresolvedReferences
+from .atpass import atpass as _atpass, elempass as _elempass
+from ..lattice import Particle, DConstant, uint32_refpts
 
 
-__all__ = ['lattice_pass', 'element_pass']
+__all__ = ['lattice_pass', 'element_pass', 'atpass', 'elempass']
 
 DIMENSION_ERROR = 'Input to lattice_pass() must be a 6xN array.'
 
 
 def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
-                 omp_num_threads=None, losses=False):
+                 omp_num_threads=None, **kwargs):
     """lattice_pass tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the
     lattice[i].PassMethod field.
@@ -28,7 +30,8 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
                     r_in is modified in-place and reports the coordinates at
                     the end of the tracking. For the the best efficiency, r_in
                     should be given as F_CONTIGUOUS numpy array.
-        nturns:     number of passes through the lattice line
+    KEYWORDS
+        nturns=1:   number of passes through the lattice line
         refpts      elements at which data is returned. It can be:
                     1) an integer in the range [-len(ring), len(ring)-1]
                        selecting the element according to python indexing
@@ -37,17 +40,26 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
                     2) an ordered list of such integers without duplicates,
                     3) a numpy array of booleans of maximum length
                        len(ring)+1, where selected elements are True.
-                    Defaults to None, meaning no refpts, equivelent to
-                    passing an empty array for calculation purposes.
+                    Default: end of lattice
         keep_lattice: use elements persisted from a previous call to at.atpass.
                     If True, assume that the lattice has not changed since
                     that previous call.
         losses:     Boolean to activate loss maps output, default is False
+    The following keyword overloads a value from lattice:
+        particle:   circulating particle. Default: lattice.particle if existing,
+                    otherwise Particle('relativistic')
+    The following keywords overload values from lattice of from particle keyword
+        energy      lattice energy
+        rest_energy rest energy of the circulating particle [eV]
+        charge      charge of the circulating particle [elementary charge]
+
+    If 'energy' is not available, relativistic tracking if forced, rest_energy
+    is ignored.
 
     OUTPUT
         (6, N, R, T) array containing output coordinates of N particles
         at R reference points for T turns.
-        If losses ==True: {islost,turn,elem,coord} dictionnary containing
+        If losses ==True: {islost,turn,elem,coord} dictionary containing
         flag for particles lost (True -> particle lost), turn, element and
         coordinates at which the particle is lost. Set to zero for particles
         that survived
@@ -55,31 +67,85 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
     assert r_in.shape[0] == 6 and r_in.ndim in (1, 2), DIMENSION_ERROR
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    nelems = len(lattice)
     if refpts is None:
-        refpts = nelems
+        refpts = len(lattice)
     if omp_num_threads is None:
         omp_num_threads = DConstant.omp_num_threads
-    refs = uint32_refpts(refpts, nelems)
+    refs = uint32_refpts(refpts, len(lattice))
+    particle = kwargs.pop('particle', getattr(lattice, 'particle', Particle()))
+    try:
+        # try to get 'energy' from the lattice
+        kwargs.setdefault('energy', getattr(lattice, 'energy'))
+    except AttributeError:
+        pass
+    if 'energy' in kwargs:
+        # energy available, use the particle properties
+        kwargs.setdefault('rest_energy', particle.rest_energy)
+        kwargs.setdefault('charge', particle.charge)
+    else:
+        # energy no available, force relativistic tracking
+        kwargs['rest_energy'] = 0.0
+        kwargs['charge'] = -1.0
     # atpass returns 6xAxBxC array where n = x*y*z;
     # * A is number of particles;
     # * B is number of refpts
     # * C is the number of turns
     if r_in.flags.f_contiguous:
-        return atpass(lattice, r_in, nturns, refpts=refs,
-                      reuse=int(keep_lattice),
-                      omp_num_threads=omp_num_threads,
-                      losses=int(losses))
+        return _atpass(lattice, r_in, nturns, refpts=refs,
+                       reuse=keep_lattice,
+                       omp_num_threads=omp_num_threads,
+                       **kwargs)
     else:
         r_fin = numpy.asfortranarray(r_in)
-        r_out = atpass(lattice, r_fin, nturns, refpts=refs,
-                       reuse=int(keep_lattice),
-                       omp_num_threads=omp_num_threads,
-                       losses=int(losses))
+        r_out = _atpass(lattice, r_fin, nturns, refpts=refs,
+                        reuse=keep_lattice,
+                        omp_num_threads=omp_num_threads,
+                        **kwargs)
         r_in[:] = r_fin[:]
         return r_out
 
 
-def element_pass(element, r_in):
+def element_pass(element, r_in, **kwargs):
+    """element_pass tracks particles through a single element.
+
+    PARAMETERS
+        element:    AT element
+        r_in:       (6, N) array: input coordinates of N particles.
+                    r_in is modified in-place and reports the coordinates at
+                    the end of the tracking. For the the best efficiency, r_in
+                    should be given as F_CONTIGUOUS numpy array.
+    KEYWORDS
+        particle:   circulating particle. Default: Particle('relativistic')
+        energy      lattice energy
+    The following keywords overload the values from the particle keyword:
+        rest_energy rest energy of the circulating particle [eV]
+        charge      charge of the circulating particle [elementary charge]
+
+    If 'energy' is not available, relativistic tracking if forced, rest_energy
+    is ignored.
+
+    OUTPUT
+        (6, N) array containing output the coordinates of the particles at the
+        exit of the element.
+    """
+    particle = kwargs.pop('particle', Particle())
+    if 'energy' in kwargs:
+        # energy available: use the particle properties
+        kwargs.setdefault('rest_energy', particle.rest_energy)
+        kwargs.setdefault('charge', particle.charge)
+    else:
+        # energy not available: force relativistic tracking
+        kwargs['rest_energy'] = 0.0
+        kwargs['charge'] = -1.0
     r_in = numpy.asfortranarray(r_in)
-    return elempass(element, r_in)
+    return _elempass(element, r_in, **kwargs)
+
+
+def atpass(*args, **kwargs):
+    warn(UserWarning("The public interface for tracking is 'lattice_pass'"))
+    return _atpass(*args, **kwargs)
+
+
+def elempass(*args, **kwargs):
+    warn(UserWarning("The public interface for tracking is 'element_pass'"))
+    return _elempass(*args, **kwargs)

--- a/pyat/test/test_atpass.py
+++ b/pyat/test/test_atpass.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy
-from at import elements, atpass, uint32_refpts
+from at.tracking.atpass import atpass
+from at import elements, uint32_refpts
 
 
 def test_incorrect_types_raises_value_error(rin):

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -11,7 +11,7 @@ def test_lattice_creation_gets_attributes_from_arguments():
     assert lat.energy == 3.e+6
     assert lat.periodicity == 32
     assert lat.radiation is False
-    assert lat.particle.name == 'electron'
+    assert lat.particle.name == 'relativistic'
     assert lat.an_attr == 12
 
 
@@ -69,15 +69,15 @@ def test_lattice_string_ordering():
                   name='lat', energy=5, periodicity=1, attr2=3)
     latstr = str(lat)
     assert latstr.startswith("Lattice(<1 elements>, name='lat', "
-                               "energy=5, particle=Particle('electron'), "
-                               "periodicity=1")
+                             "energy=5, particle=Particle('relativistic'), "
+                             "periodicity=1")
     assert latstr.endswith("attr2=3)")
 
     latrepr = repr(lat)
     assert latrepr.startswith("Lattice([Drift('D0', 1.0, attr1=array(0))], "
-                                "name='lat', "
-                                "energy=5, particle=Particle('electron'), "
-                                "periodicity=1")
+                              "name='lat', "
+                              "energy=5, particle=Particle('relativistic'), "
+                              "periodicity=1")
     assert latrepr.endswith("attr2=3)")
 
 


### PR DESCRIPTION
The default particle is set back to 'relativistic', meaning "relativistic electron", and its definition is modified as follows:
- its rest energy is zero,
- its charge is -1,
- its relativistic &beta; is 1,
- its relativistic &gamma;, **as reported by the `Lattice.gamma` property** is the one of an electron.

This is physically inconsistent (see discussion [here](https://github.com/atcollab/at/pull/362#issuecomment-1031689042)), but it describes the historical behaviour of AT.
It allows to generalise the use of the lattice properties `Lattice.gamma` and `Lattice.beta` everywhere, while being consistent with tracking.

In addition, the energy and particle properties are made available to the C integrators, in preparation for non-relativistic tracking. The "global" parameters transmitted to the C integrators are now:
- ring length,
- ring revolution time,
- turn number,
- energy,
- particle rest energy,
- particle charge,
- s coordinate

The new parameters must not be used until the equivalent is made for Matlab!
