### PR TITLE
Energy and particle available to C integrators

### DIFF
--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -85,6 +85,7 @@ alloptions=[atoptions varargs];
 % atpass
 cdir=fullfile(atroot,'attrack','');
 compile([alloptions, {passinclude}, LIBDL, ompoptions], fullfile(cdir,'atpass.c'));
+compile([atoptions, ompoptions],fullfile(cdir,'coptions.c'))
 
 [warnmess,warnid]=lastwarn; %#ok<ASGLU>
 if strcmp(warnid,'MATLAB:mex:GccVersion_link')

--- a/atmat/attrack/atpass.m
+++ b/atmat/attrack/atpass.m
@@ -1,7 +1,7 @@
 function varargout=atpass(varargin) %#ok<STOUT>
 %ATPASS is a numerical tracking engine for AT
 %
-% ROUT = ATPASS(LATTICE,RIN,MODE,NTURNS,REFPTS,PREFUNC,POSTFUNC,NHIST,NUMTHREADS)
+% ROUT = ATPASS(LATTICE,RIN,MODE,NTURNS,REFPTS,PREFUNC,POSTFUNC,NHIST,NUMTHREADS,RINGPROPS)
 %   LATTICE     AT lattice
 %   RIN         6xN matrix: input coordinates of N particles
 %   MODE        0 - reuse lattice
@@ -13,6 +13,7 @@ function varargout=atpass(varargin) %#ok<STOUT>
 %   POSTFUNC    function called after each element
 %   NHIST       length of history buffer. Optional, default 1
 %   NUMTHREADS  Number of threads in OpenMP. Optional, default: automatic
+%   RINGPROPS   Ring properties (energy and particle).
 %
 % [ROUT,LOST] = ATPASS(...)
 %   Additionally return information on lost particles

--- a/atmat/attrack/coptions.c
+++ b/atmat/attrack/coptions.c
@@ -1,0 +1,25 @@
+#include <mex.h>
+#ifndef OCTAVE
+#include <matrix.h>
+#endif
+
+/*!
+ * Return a structure describing the C compile options
+ 
+ @param[out] options: structure with fields
+                - "openmp": true if compiled for OpenMP
+
+*/
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+    const char *fieldnames[] = {"openmp"};
+    int omp;
+
+    plhs[0] = mxCreateStructMatrix(1, 1, 1, fieldnames);
+#ifdef _OPENMP
+    omp = 1;
+#else
+    omp = 0;
+#endif /*_OPENMP*/
+    mxSetField(plhs[0], 0, "openmp", mxCreateDoubleScalar((double)omp));
+}

--- a/atmat/attrack/linepass.m
+++ b/atmat/attrack/linepass.m
@@ -84,8 +84,11 @@ if islogical(refpts)
 end
 newlattice = double(~keeplattice);
 
+props=atCheckRingProperties(line);
+
 try
-    [Rout,lossinfo] = atpass(line,Rin,newlattice,1,refpts,prefunc,postfunc,nhist,omp_num_threads);
+    [Rout,lossinfo] = atpass(line,Rin,newlattice,1,refpts, ...
+        prefunc,postfunc,nhist,omp_num_threads,props);
     
     if nargout>1
         if nargout>2, varargout{2}=lossinfo; end

--- a/atmat/attrack/ringpass.m
+++ b/atmat/attrack/ringpass.m
@@ -81,8 +81,11 @@ else
     refpts=length(ring)+1;
 end
 
+props=atCheckRingProperties(ring);
+
 try
-    [Rout,lossinfo] = atpass(ring,Rin,newlattice,nturns,refpts,prefunc,postfunc,nhist,omp_num_threads);
+    [Rout,lossinfo] = atpass(ring,Rin,newlattice,nturns,refpts, ...
+        prefunc,postfunc,nhist,omp_num_threads,props);
     
     if nargout>1
         if nargout>3, varargout{3}=lossinfo; end

--- a/atmat/atutils/atoptions.m
+++ b/atmat/atutils/atoptions.m
@@ -15,12 +15,13 @@ classdef atoptions < handle
     
     %% AT dependent parameters
     properties (Dependent, SetAccess=private)
-        orm                         % True if compiled with OpenMP (not yet implemented)
+        openmp                      % True if compiled with OpenMP (not yet implemented)
     end
     
     methods
-        function v=get.orm(obj) %#ok<MANU>
-            v=false;
+        function v=get.openmp(obj) %#ok<MANU>
+            copts = coptions();
+            v = logical(copts.openmp);
         end
     end
     

--- a/atmat/lattice/atCheckRingProperties.m
+++ b/atmat/lattice/atCheckRingProperties.m
@@ -1,0 +1,22 @@
+function [props,idx] = atCheckRingProperties(ring)
+%ATCHECKRINGPROPERTIES Get the ring properties if existing
+%
+% PROPERTIES=ATCHECKRINGPROPERTIES(ring)
+%	Extract data from the RingParam element of the lattice, if present,
+%	otherwise return an empty structure
+%
+%  See also ATGETRINGPROPERTIES, ATSETRINGPROPERTIES
+
+idx = atlocateparam(ring);
+if ~isempty(idx)
+    parmelem=ring{idx};
+    if isfield(parmelem, 'Particle')
+        particle=atparticle.loadobj(parmelem.Particle);
+        props=rmfield(parmelem,{'Length','Class','PassMethod','Particle'});
+        props.Particle=particle;
+    else
+        props=rmfield(parmelem,{'Length','Class','PassMethod'});
+    end
+else
+    props=struct();
+end

--- a/atmat/lattice/atfindparam.m
+++ b/atmat/lattice/atfindparam.m
@@ -9,22 +9,10 @@ function [parmelem, idx] = atfindparam(ring,varargin)
 %
 %  See also ATGETRINGPROPERTIES, ATSETRINGPROPERTIES
 
-persistent location         % Location saved for fast access
-global GLOBVAL
+global GLOBVAL %#ok<*GVMIS> 
 TWO_PI_ERROR = 1.e-4;
 
-% Assume RingParam in 1st position in the ring
-if isempty(location)
-    location = 1;
-end
-
-% Check if it is where expected, otherwise look for it
-if ~(length(ring) >= location && ...
-     isfield(ring{location},'Class') && ...
-     strcmp(ring{location}.Class, 'RingParam'))
-    location=find(atgetcells(ring(:,1),'Class','RingParam'), 1);
-end
-idx = location;
+idx = atlocateparam(ring);
 
 newparms = struct(varargin{:});
 if isfield(newparms, 'Particle')

--- a/atmat/lattice/atlocateparam.m
+++ b/atmat/lattice/atlocateparam.m
@@ -1,0 +1,25 @@
+function idx = atlocateparam(ring,varargin)
+%ATLOCATEPARAM    Private function. Locate the RingParam element
+%
+% IDX=ATLOCATEPARAM(ring)
+%	Extract the RingParam element of the lattice, if present, or create
+%	a new one from the lattice elements
+%
+% ring:         Ring structure
+%
+%  See also ATGETRINGPROPERTIES, ATSETRINGPROPERTIES
+
+persistent location         % Location saved for fast access
+
+% Assume RingParam in 1st position in the ring
+if isempty(location)
+    location = 1;
+end
+
+% Check if it is where expected, otherwise look for it
+if ~(length(ring) >= location && ...
+     isfield(ring{location},'Class') && ...
+     strcmp(ring{location}.Class, 'RingParam'))
+    location=find(atgetcells(ring(:,1),'Class','RingParam'), 1);
+end
+idx = location;

--- a/atoctave/atmexall.m
+++ b/atoctave/atmexall.m
@@ -65,6 +65,7 @@ alloptions=[atoptions varargs];
 % atpass
 cdir=fullfile(atroot,'attrack','');
 compile([alloptions, {passinclude}, ompoptions], fullfile(cdir,'atpass.c'));
+compile([atoptions, ompoptions], fullfile(cdir,'coptions.c'));
 
 % Diffusion matrices
 cdir=fullfile(atroot,'atphysics','Radiation');


### PR DESCRIPTION
This is the equivalent for Matlab of #367 for python:
The energy and particle properties (rest energy and charge) are made available to all the C integrators. The list of global parameters is now:
- ring length,
- ring revolution time,
- turn number,
- energy,
- particle rest energy,
- particle charge,
- s coordinate

Since the parameters are now available in both python and Matlab, they can be used from now on in the integrators.
But for the moment, only relativistic tracking is still available (only `RFCavityPass` is involved in that). The behaviour is:
- in python, the default particle is 'relativistic', but if it is modified, the particle properties are transmitted to the integrators (which at the moment ignore it). So a warning is issued when changing the particle type.
- in Matlab, the same warning is issued, <strike>but the particle type is not yet transmitted to the C. So the integrators always see the properties of the 'relativistic' particle. The reason is the following: ring properties in Matlab are stored in the `RingParam` element. If it is absent, gathering the properties takes long, so that `atpass` (`ringpass` and `linepass`) would be too slow. A better solution is still to be found, possibly by providing the properties optionally , when the are necessary…</strike>

#### Update:
A better solution is found for Matlab: if a `RingParam` element is found (this is very fast, 0.2 ms if found, 4 ms if not), its properties are sent to `atpass.c`. Otherwise, nothings sent. For comparison, building the properties from the lattice takes 80 ms).
- a lattice without RingParam therefore assumes 'relativistic': nothing is changed,
- a lattice with a RingParam element is able to set energy and particle, ready for future use.

#### Conclusion:
Nothing new appears with this PR, but it is an important and necessary step before working on non-relativistic tracking. Additionally, having the energy available will also remove the necessity of having "Energy" as an element attribute.
**This branch (and #367) bring significant modifications of  `atpass.c`**, and start minimising the differences between the Matlab and python versions.

Side remark: while working on C code, I saw that the detection of OpenMP presence which was still missing in Matlab. It is now operational:
```Matlab
>> getoption()

ans = 

  atoptions with properties:

             XYStep: 3.0000e-08
             DPStep: 3.0000e-06
     OrbConvergence: 1.0000e-12
         OrbMaxIter: 20
    omp_num_threads: 0
        WarningDp6D: 1
             openmp: 0

>> 
```