### PR TITLE
Raise an Error if dp or dct is specified for closed orbit computation of a 6D lattice

### DIFF
--- a/atmat/atphysics/Orbit/findorbit.m
+++ b/atmat/atphysics/Orbit/findorbit.m
@@ -34,7 +34,8 @@ function [orbs,orbitin]  = findorbit(ring,varargin)
 if isempty(orbitin)
     if check_radiation(ring)    % Radiation ON: 6D orbit
         if isfinite(dp) || isfinite(dct)
-            warning('AT:linopt','In 6D, "dp" and "dct" are ignored');
+%           warning('AT:linopt','In 6D, "dp" and "dct" are ignored');
+            error('AT:linopt','In 6D, "dp" and "dct" are nor allowed');
         end
         orbitin=xorbit_6(ring,varargs{:});
     elseif isfinite(dct)

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -388,7 +388,7 @@ def find_orbit6(ring, refpts=None, orbit=None, dp=None, dct=None,
     See also find_orbit4, find_sync_orbit.
     """
     if not (dp is None and dct is None):
-        raise AtError('In 6D, "dp" and "dct" cannot be specified')
+        raise AtError('In 6D, "dp" and "dct" are not allowed')
     if orbit is None:
         orbit = _orbit6(ring, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -3,7 +3,7 @@ Closed orbit related functions
 """
 import numpy
 from at.constants import clight
-from at.lattice import AtWarning, check_radiation, DConstant
+from at.lattice import AtError, AtWarning, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, uint32_refpts
 from at.tracking import lattice_pass
 from at.physics import ELossMethod, get_timelag_fromU0
@@ -388,7 +388,7 @@ def find_orbit6(ring, refpts=None, orbit=None, dp=None, dct=None,
     See also find_orbit4, find_sync_orbit.
     """
     if not (dp is None and dct is None):
-        warnings.warn(AtWarning('In 6D, "dp" and "dct" are ignored'))
+        raise AtError('In 6D, "dp" and "dct" cannot be specified')
     if orbit is None:
         orbit = _orbit6(ring, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True


### PR DESCRIPTION
Recent discussions concerning the Matlab version raised a question about a warning;
`In 6D, "dp" and "dct" are ignored`
issued in closed orbit computation of 6D lattices. This warning is similar in the python version, and the question was:

"if dp or dct is ignored, the result is wrong, so an error should be triggered."

I do not consider this as an error: for a 6D lattice, the orbit is unique, entirely determined by the RF frequency and independent of anything else you may specify, so the returned value is correct.

It is like asking for `find_orbit(ring, color=blue)`. The result is not wrong because the orbit is not blue, it's correct ! The color specification makes no sense, and it is ignored, with a warning (or should be…).

However we may consider that accepting any unexpected keyword should not be allowed, so this is a proposal for raising an error instead of a warning.