### PR TITLE
Add a "turn" input to atpass

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            python-version: '3.7'
+#       exclude:
+#         - os: windows-latest
+#           python-version: '3.7'
 
     steps:
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,6 +22,9 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            python-version: '3.7'
 
     steps:
 

--- a/atmat/attrack/atpass.c
+++ b/atmat/attrack/atpass.c
@@ -49,6 +49,7 @@ typedef double mxDouble;
 #define NUMTHREADS prhs[8]
 #define RINGPROPERTIES prhs[9]
 #define TURN prhs[10]
+#define KEEPCOUNTER prhs[11]
 
 #define LIMIT_AMPLITUDE		1	/*  if any of the phase space variables (except the sixth N.C.) 
 									exceeds this limit it is marked as lost */
@@ -276,10 +277,12 @@ static void getproperties(const mxArray *opts, double *energy, double *rest_ener
 @param[in]      [8] NUMTHREADS
 @param[in]      [9] RINGPROPERTIES
 @param[in]     [10] TURN
+@param[in]     [11] KEEPCOUNTER
 */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     static double lattice_length = 0.0;
+    static int last_turn = 0;
     static int valid = 0;
     
     int turn, elem_index, npart, *refpts, num_refpts;
@@ -305,6 +308,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     int new_lattice = (mxGetScalar(NEWLATTICE) == 0) ? 0 : 1;
     int num_turns = (int)mxGetScalar(NTURNS);
     int num_particles = mxGetN(INITCONDITIONS);
+    int counter = (nrhs >= 11) ? (int)mxGetScalar(TURN) : 0;
+    int keep_counter = (nrhs >= 12) ? (int)mxGetScalar(KEEPCOUNTER) : 0;
     int np6 = num_particles*6;
     int ihist, lhist;
     mxDouble *histbuf = NULL;
@@ -325,12 +330,13 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     param.energy = 0.0;
     param.rest_energy = 0.0;
     param.charge = -1.0;
-    param.nturn = 0;
+    if (keep_counter)
+        param.nturn = last_turn;
+    else
+        param.nturn = counter;
+
     if (nrhs >= 10) {
         getproperties(RINGPROPERTIES, &param.energy, &param.rest_energy, &param.charge);
-    }
-    if (nrhs >= 11) {
-        param.nturn=(int)mxGetScalar(TURN);
     }
 
     if (nlhs >= 2) {
@@ -512,7 +518,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         struct elem **elemdata= elemdata_list;
         double s_coord = 0.0;
 
-        *xturn = (mxDouble)(turn+1);
+        *xturn = (mxDouble)(param.nturn+1);
         nextrefindex = 0;
         nextref = (nextrefindex<num_refpts) ? refpts[nextrefindex++] : INT_MAX;
         for (elem_index=0; elem_index<num_elements; elem_index++) {
@@ -549,7 +555,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             integrator++;
             elemdata++;
             field_numbers++;
-            param.nturn++;
         }
         if (num_elements == nextref) {
             memcpy(drout, drin, np6*sizeof(mxDouble));
@@ -563,8 +568,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
         }   
         pass_mode = USE_LOCAL_COPY;
+        param.nturn++;
     }
     valid = 1;      /* Tracking successful: the lattice can be reused */
+    last_turn = param.nturn;  /* Store turn number in a static variable */
 
     if (num_refpts == 0) {
         memcpy(drout, drin, np6*sizeof(mxDouble));

--- a/atmat/attrack/atpass.c
+++ b/atmat/attrack/atpass.c
@@ -48,6 +48,7 @@ typedef double mxDouble;
 #define LHIST prhs[7]
 #define NUMTHREADS prhs[8]
 #define RINGPROPERTIES prhs[9]
+#define TURN prhs[10]
 
 #define LIMIT_AMPLITUDE		1	/*  if any of the phase space variables (except the sixth N.C.) 
 									exceeds this limit it is marked as lost */
@@ -273,6 +274,8 @@ static void getproperties(const mxArray *opts, double *energy, double *rest_ener
 @param[in]      [6] POSTHOOK
 @param[in]      [7] LHIST
 @param[in]      [8] NUMTHREADS
+@param[in]      [9] RINGPROPERTIES
+@param[in]     [10] TURN
 */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
@@ -322,8 +325,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     param.energy = 0.0;
     param.rest_energy = 0.0;
     param.charge = -1.0;
+    param.nturn = 0;
     if (nrhs >= 10) {
         getproperties(RINGPROPERTIES, &param.energy, &param.rest_energy, &param.charge);
+    }
+    if (nrhs >= 11) {
+        param.nturn=(int)mxGetScalar(TURN);
     }
 
     if (nlhs >= 2) {
@@ -506,7 +513,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double s_coord = 0.0;
 
         *xturn = (mxDouble)(turn+1);
-		param.nturn = turn;
         nextrefindex = 0;
         nextref = (nextrefindex<num_refpts) ? refpts[nextrefindex++] : INT_MAX;
         for (elem_index=0; elem_index<num_elements; elem_index++) {
@@ -543,6 +549,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             integrator++;
             elemdata++;
             field_numbers++;
+            param.nturn++;
         }
         if (num_elements == nextref) {
             memcpy(drout, drin, np6*sizeof(mxDouble));

--- a/atmat/attrack/linepass.m
+++ b/atmat/attrack/linepass.m
@@ -88,7 +88,7 @@ props=atCheckRingProperties(line);
 
 try
     [Rout,lossinfo] = atpass(line,Rin,newlattice,1,refpts, ...
-        prefunc,postfunc,nhist,omp_num_threads,props);
+        prefunc,postfunc,nhist,omp_num_threads,props,0);
     
     if nargout>1
         if nargout>2, varargout{2}=lossinfo; end

--- a/atmat/attrack/ringpass.m
+++ b/atmat/attrack/ringpass.m
@@ -68,6 +68,7 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 [dummy,args]=getflag(args,'reuse');	%#ok<ASGLU> % Kept for compatibility and ignored
 [silent,args]=getflag(args, 'silent');
 [nhist,args]=getoption(args,'nhist',1);
+[turn,args]=getoption(args,'turn',0);
 [omp_num_threads,args]=getoption(args,'omp_num_threads');
 funcargs=cellfun(@(arg) isa(arg,'function_handle'), args);
 nturns=getargs(args(~funcargs),1);
@@ -85,7 +86,7 @@ props=atCheckRingProperties(ring);
 
 try
     [Rout,lossinfo] = atpass(ring,Rin,newlattice,nturns,refpts, ...
-        prefunc,postfunc,nhist,omp_num_threads,props);
+        prefunc,postfunc,nhist,omp_num_threads,props,turn);
     
     if nargout>1
         if nargout>3, varargout{3}=lossinfo; end

--- a/atmat/attrack/ringpass.m
+++ b/atmat/attrack/ringpass.m
@@ -48,6 +48,18 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 % ROUT=RINGPASS(...,'reuse') is kept for compatibilty with previous
 % versions. It has no effect.
 %
+% ROUT=RINGPASS(...,'turn',turn)    Initial turn number. Default 0.
+%   The turn number is necessary to compute the absolute path length used
+%   by RFCavityPass. Ignored if KeepCounter is set.
+%
+% ROUT=RINGPASS(...,'KeepCounter')  The turn number starts with the last
+%   turn of the previous call.
+%
+% NOTE:
+% To resume an interrupted tracking (for instance to get intermediate
+% results), one must use one of the 'turn' option or 'KeepCounter' flag to
+% ensure the continuity of the turn number.
+%
 % ROUT=RINGPASS(...,'Silent') does not output the particle coordinates at
 %    each turn but only at the end of the tracking
 %
@@ -69,6 +81,7 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 [silent,args]=getflag(args, 'silent');
 [nhist,args]=getoption(args,'nhist',1);
 [turn,args]=getoption(args,'turn',0);
+[keep_counter,args]=getflag(args,'KeepCounter');
 [omp_num_threads,args]=getoption(args,'omp_num_threads');
 funcargs=cellfun(@(arg) isa(arg,'function_handle'), args);
 nturns=getargs(args(~funcargs),1);
@@ -86,7 +99,7 @@ props=atCheckRingProperties(ring);
 
 try
     [Rout,lossinfo] = atpass(ring,Rin,newlattice,nturns,refpts, ...
-        prefunc,postfunc,nhist,omp_num_threads,props,turn);
+        prefunc,postfunc,nhist,omp_num_threads,props,turn,double(keep_counter));
     
     if nargout>1
         if nargout>3, varargout{3}=lossinfo; end

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -82,19 +82,7 @@ static struct LibraryListElement {
 
 static PyObject *print_error(int elem_number, PyObject *rout)
 {
-    printf("Error in tracking element %d.\n", elem_number);
     Py_XDECREF(rout);
-    return NULL;
-}
-
-static PyObject *set_error(PyObject *errtype, const char *fmt, ...)
-{
-    char buffer[300];
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buffer, sizeof(buffer), fmt, ap);
-    PyErr_SetString(errtype, buffer);
-    va_end(ap);
     return NULL;
 }
 
@@ -263,7 +251,7 @@ static struct LibraryListElement* get_track_function(const char *fn_name) {
         
         if (!(fn_handle || pyfunction)) {
             if (dl_handle) FREELIBFCN(dl_handle);
-            set_error(PyExc_RuntimeError,
+            PyErr_Format(PyExc_RuntimeError,
             "PassMethod %s: library, module or trackFunction not found",
             fn_name);
             return NULL;
@@ -379,13 +367,13 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
         return NULL;
     }
     if (PyArray_DIM(rin,0) != 6) {
-        return set_error(PyExc_ValueError, "rin is not 6D");
+        return PyErr_Format(PyExc_ValueError, "rin is not 6D");
     }
     if (PyArray_TYPE(rin) != NPY_DOUBLE) {
-        return set_error(PyExc_ValueError, "rin is not a double array");
+        return PyErr_Format(PyExc_ValueError, "rin is not a double array");
     }
     if ((PyArray_FLAGS(rin) & NPY_ARRAY_FARRAY_RO) != NPY_ARRAY_FARRAY_RO) {
-        return set_error(PyExc_ValueError, "rin is not Fortran-aligned");
+        return PyErr_Format(PyExc_ValueError, "rin is not Fortran-aligned");
     }
 
     set_energy_particle(lattice, energy, particle, &param);
@@ -396,7 +384,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
 
     if (refs) {
         if (PyArray_TYPE(refs) != NPY_UINT32) {
-            return set_error(PyExc_ValueError, "refpts is not a uint32 array");
+            return PyErr_Format(PyExc_ValueError, "refpts is not a uint32 array");
         }
         refpts = PyArray_DATA(refs);
         num_refpts = PyArray_SIZE(refs);
@@ -622,13 +610,13 @@ static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
     if (PyArray_DIM(rin,0) != 6) {
-        return set_error(PyExc_ValueError, "rin is not 6D");
+        return PyErr_Format(PyExc_ValueError, "rin is not 6D");
     }
     if (PyArray_TYPE(rin) != NPY_DOUBLE) {
-        return set_error(PyExc_ValueError, "rin is not a double array");
+        return PyErr_Format(PyExc_ValueError, "rin is not a double array");
     }
     if ((PyArray_FLAGS(rin) & NPY_ARRAY_FARRAY_RO) != NPY_ARRAY_FARRAY_RO) {
-        return set_error(PyExc_ValueError, "rin is not Fortran-aligned");
+        return PyErr_Format(PyExc_ValueError, "rin is not Fortran-aligned");
     }
 
     set_energy_particle(NULL, energy, particle, &param);

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -32,7 +32,7 @@ typedef PyObject atElem;
 #define GETTRACKFCN(libfilename) GetProcAddress((libfilename),ATPY_PASS)
 #define SEPARATOR "\\"
 #define OBJECTEXT ".pyd"
-#if PY_MINOR_VERSION <= 7    /* module sysconfig wrong on windows for python<=3.7 */
+#if PY_MINOR_VERSION < 7    /* module sysconfig wrong on windows for python<3.7 */
 #define SYSCONFIG "distutils.sysconfig"
 #else
 #define SYSCONFIG "sysconfig"

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -61,6 +61,8 @@ static track_function *integrator_list = NULL;
 static PyObject **pyintegrator_list = NULL;
 static PyObject **kwargs_list = NULL;
 static char integrator_path[300];
+static PyObject *particle_type;
+static PyObject *element_type;
 
 /* Directly copied from atpass.c */
 static struct LibraryListElement {
@@ -161,45 +163,46 @@ static void setlost(double *drin, npy_uint32 np)
 }
 
 
-/*
- * Use Python calls to establish the location of the at integrators
- * package.
- */
-static PyObject *get_integrators(void) {
-    PyObject *at_module, *os_module, *fileobj, *dirname_function, *dirobj;
-    at_module = PyImport_ImportModule("at.integrators");
-    if (at_module == NULL) return NULL;
-    fileobj = PyObject_GetAttrString(at_module, "__file__");
-    Py_DECREF(at_module);
-    if (fileobj == NULL) return NULL;
-    os_module = PyImport_ImportModule("os.path");
-    if (os_module == NULL) return NULL;
-    dirname_function = PyObject_GetAttrString(os_module, "dirname");
-    Py_DECREF(os_module);
-    if (dirname_function == NULL) return NULL;
-    dirobj = PyObject_CallFunctionObjArgs(dirname_function, fileobj, NULL);
-    Py_DECREF(fileobj);
-    Py_DECREF(dirname_function);
-    return dirobj;
+/* Get a reference to a python object in a module
+   Equivalent to "from module_name import object" */
+static PyObject *get_pyobj(const char *module_name, const char *object)
+{
+    PyObject *pyobj = NULL;
+    PyObject *module = PyImport_ImportModule(module_name);
+    if (module) {
+        pyobj = PyObject_GetAttrString(module, object);
+        Py_DECREF(module);
+    }
+    return pyobj;
 }
 
+/* Get the location of the at integrators package. */
+static PyObject *get_integrators(void) {
+    PyObject *dirobj = NULL;
+    PyObject *fileobj = get_pyobj("at.integrators", "__file__");
+    if (fileobj) {
+        PyObject *dirname_function = get_pyobj("os.path", "dirname");
+        if (dirname_function) {
+            dirobj = PyObject_CallFunctionObjArgs(dirname_function, fileobj, NULL);
+            Py_DECREF(dirname_function);
+        }
+        Py_DECREF(fileobj);
+    }
+    return dirobj;
+}
 /*
  * Query Python for the full extension given to shared objects.
  * This is useful for Python 3, where the extension may not be trivial.
  * If none is defined, return NULL.
  */
 static PyObject *get_ext_suffix(void) {
-    PyObject *sysconfig_module, *get_config_var_fn, *ext_suffix;
-    sysconfig_module = PyImport_ImportModule("distutils.sysconfig");
-    if (sysconfig_module == NULL) return NULL;
-    get_config_var_fn = PyObject_GetAttrString(sysconfig_module, "get_config_var");
-    Py_DECREF(sysconfig_module);
+    PyObject *get_config_var_fn, *ext_suffix;
+    get_config_var_fn = get_pyobj("sysconfig", "get_config_var");
     if (get_config_var_fn == NULL) return NULL;
     ext_suffix = PyObject_CallFunction(get_config_var_fn, "s", "EXT_SUFFIX");
     Py_DECREF(get_config_var_fn);
     return ext_suffix;
 }
-
 
 /*
  * Import the python module for python integrators
@@ -279,15 +282,17 @@ static struct LibraryListElement* get_track_function(const char *fn_name) {
 void set_energy_particle(PyObject *lattice, PyObject *energy,
                          PyObject *particle, struct parameters *param)
 {
-    if (energy == NULL)
-        energy = PyObject_GetAttrString(lattice, "energy");
+    if (energy == NULL) {
+        if (lattice) energy = PyObject_GetAttrString(lattice, "energy");
+    }
     else
         Py_INCREF(energy);
     if (energy != NULL) {
         param->energy = PyFloat_AsDouble(energy);
         Py_DECREF(energy);
-        if (particle == NULL)
-            particle = PyObject_GetAttrString(lattice, "particle");
+        if (particle == NULL) {
+            if (lattice) particle = PyObject_GetAttrString(lattice, "particle");
+        }
         else
             Py_INCREF(particle);
         if (particle != NULL) {
@@ -365,10 +370,10 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     particle=NULL;
     energy=NULL;
     refs=NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O!i|O!iO!OpIp", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O!i|O!$iO!O!pIp", kwlist,
         &PyList_Type, &lattice, &PyArray_Type, &rin, &num_turns,
         &PyArray_Type, &refs, &param.nturn,
-        &PyFloat_Type ,&energy, &particle,
+        &PyFloat_Type ,&energy, particle_type, &particle,
         &keep_lattice, &omp_num_threads, &losses)) {
         return NULL;
     }
@@ -591,8 +596,10 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
 static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     static char *kwlist[] = {"element", "rin",
-                             "energy", "rest_energy", "charge", NULL};
+                             "energy", "particle", NULL};
     PyObject *element;
+    PyObject *energy;
+    PyObject *particle;
     PyArrayObject *rin;
     PyObject *PyPassMethod;
     npy_uint32 num_particles;
@@ -602,12 +609,15 @@ static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
     struct parameters param;
     struct LibraryListElement *LibraryListPtr;
 
-    param.energy=1.0e9;
+    param.nturn = 0;
+    param.energy=0.0;
     param.rest_energy=0.0;
     param.charge=-1.0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO!|ddd", kwlist,
-        &element,  &PyArray_Type, &rin,
-        &param.energy, &param.rest_energy, &param.charge)) {
+    particle=NULL;
+    energy=NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O!|$O!O!", kwlist,
+        element_type, &element,  &PyArray_Type, &rin,
+        &PyFloat_Type ,&energy, particle_type, &particle)) {
         return NULL;
     }
     if (PyArray_DIM(rin,0) != 6) {
@@ -619,12 +629,14 @@ static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
     if ((PyArray_FLAGS(rin) & NPY_ARRAY_FARRAY_RO) != NPY_ARRAY_FARRAY_RO) {
         return set_error(PyExc_ValueError, "rin is not Fortran-aligned");
     }
+
+    set_energy_particle(NULL, energy, particle, &param);
+
     num_particles = (PyArray_SIZE(rin)/6);
     drin = PyArray_DATA(rin);
 
     param.RingLength = 0.0;
     param.T0 = 0.0;
-    param.nturn = 0;
 
     PyPassMethod = PyObject_GetAttrString(element, "PassMethod");
     if (!PyPassMethod) return NULL;
@@ -712,8 +724,7 @@ static PyMethodDef AtMethods[] = {
 
 PyMODINIT_FUNC PyInit_atpass(void)
 {
-    PyObject *integ_path_obj, *ext_suffix_obj;
-    const char *ext_suffix, *integ_path;
+    PyObject *integ_path_obj;
 
     static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -731,15 +742,32 @@ PyMODINIT_FUNC PyInit_atpass(void)
     if (m == NULL) return NULL;
     import_array();
 
+    /* Build path for loading Python integrators */
     integ_path_obj = get_integrators();
-    if (integ_path_obj == NULL) return NULL;
-    ext_suffix_obj = get_ext_suffix();
-    if (ext_suffix_obj == NULL) return NULL;
-    ext_suffix = (ext_suffix_obj == Py_None) ? OBJECTEXT : PyUnicode_AsUTF8(ext_suffix_obj);
-    integ_path = PyUnicode_AsUTF8(integ_path_obj);
-    snprintf(integrator_path, sizeof(integrator_path), "%s%s%%s%s", integ_path, SEPARATOR, ext_suffix);
-    Py_DECREF(integ_path_obj);
-    Py_DECREF(ext_suffix_obj);
+    if (integ_path_obj) {
+        const char *integ_path = PyUnicode_AsUTF8(integ_path_obj);
+        PyObject *ext_suffix_obj = get_ext_suffix();
+        Py_DECREF(integ_path_obj);
+        if (ext_suffix_obj) {
+            const char *ext_suffix = (ext_suffix_obj == Py_None) ? OBJECTEXT : PyUnicode_AsUTF8(ext_suffix_obj);
+            Py_DECREF(ext_suffix_obj);
+            snprintf(integrator_path, sizeof(integrator_path), "%s%s%%s%s", integ_path, SEPARATOR, ext_suffix);
+        }
+        else {
+            return NULL;
+        }
+    }
+    else {
+        return NULL;
+    }
+
+    /* get Particle type */
+    particle_type = get_pyobj("at.lattice", "Particle");
+    if (particle_type == NULL) return NULL;
+
+    /* get Element type */
+    element_type = get_pyobj("at.lattice", "Element");
+    if (element_type == NULL) return NULL;
 
     return m;
 }

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -33,6 +33,11 @@ typedef PyObject atElem;
 #define GETTRACKFCN(libfilename) GetProcAddress((libfilename),ATPY_PASS)
 #define SEPARATOR "\\"
 #define OBJECTEXT ".pyd"
+#if PY_MINOR_VERSION <= 7    /* module sysconfig wrong on windows for python<=3.7 */
+#define SYSCONFIG "distutils.sysconfig"
+#else
+#define SYSCONFIG "sysconfig"
+#endif /*PY_MINOR_VERSION*/
 #else
 #include <dlfcn.h>
 #define LIBRARYHANDLETYPE void *
@@ -41,6 +46,7 @@ typedef PyObject atElem;
 #define GETTRACKFCN(libfilename) dlsym((libfilename),ATPY_PASS)
 #define SEPARATOR "/"
 #define OBJECTEXT ".so"
+#define SYSCONFIG "sysconfig"
 #endif
 
 #define LIMIT_AMPLITUDE		1
@@ -197,7 +203,7 @@ static PyObject *get_integrators(void) {
  */
 static PyObject *get_ext_suffix(void) {
     PyObject *get_config_var_fn, *ext_suffix;
-    get_config_var_fn = get_pyobj("sysconfig", "get_config_var");
+    get_config_var_fn = get_pyobj(SYSCONFIG, "get_config_var");
     if (get_config_var_fn == NULL) return NULL;
     ext_suffix = PyObject_CallFunction(get_config_var_fn, "s", "EXT_SUFFIX");
     Py_DECREF(get_config_var_fn);

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -5,7 +5,6 @@
  */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include <stdarg.h>
 #ifdef _OPENMP
 #include <string.h>
 #include <omp.h>
@@ -525,6 +524,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
         struct elem **elemdata = elemdata_list;
         double s_coord = 0.0;
 
+      /*PySys_WriteStdout("turn: %i\n", param.nturn);*/
         nextrefindex = 0;
         nextref= (nextrefindex<num_refpts) ? refpts[nextrefindex++] : INT_MAX;
         for (elem_index = 0; elem_index < num_elements; elem_index++) {

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -2,11 +2,15 @@
 Conversion utilities for creating pyat elements
 """
 import collections
+import sys
 import os
 import re
 import numpy
 from warnings import warn
-from distutils import sysconfig
+if sys.platform.startswith('win') and sys.version_info.minor < 7:
+    from distutils import sysconfig
+else:
+    import sysconfig
 from at import integrators
 from at.lattice import AtWarning
 from at.lattice import CLASS_MAP, elements as elt
@@ -15,6 +19,7 @@ from at.lattice import Particle
 # noinspection PyUnresolvedReferences
 from numpy import array, uint8  # For global namespace
 
+_ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
 
 def _particle(value):
     if isinstance(value, Particle):
@@ -189,13 +194,6 @@ def find_class(elem_dict, quiet=False):
                     return elt.Element
 
 
-def get_pass_method_file_name(pass_method):
-    extension_list = sysconfig.get_config_vars('EXT_SUFFIX', 'SO')
-    extension = set(filter(None, extension_list))
-    ext = extension.pop() if len(extension) == 1 else '.so'
-    return pass_method + ext
-
-
 def element_from_dict(elem_dict, index=None, check=True, quiet=False):
     """return an AT element from a dictionary of attributes
     """
@@ -228,7 +226,7 @@ def element_from_dict(elem_dict, index=None, check=True, quiet=False):
         if pass_method is not None:
             pass_to_class = _PASS_MAP.get(pass_method)
             length = float(elem_dict.get('Length', 0.0))
-            file_name = get_pass_method_file_name(pass_method)
+            file_name = pass_method + _ext_suffix
             file_path = os.path.join(integrators.__path__[0], file_name)
             if not os.path.isfile(os.path.realpath(file_path)):
                 raise err("does not have a {0} file.".format(file_name))

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -92,14 +92,10 @@ def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
                         Windows is spawn. fork may used for MacOS to speed-up
                         the calculation or to solve Runtime Errors, however it
                         is considered unsafe.
-    The following keyword overloads a value from lattice:
+    The following keywords overload the lattice value:
         particle:   circulating particle. Default: lattice.particle if
                     existing, otherwise Particle('relativistic')
-    The following keywords overload values from lattice of from particle
-        keyword
         energy      lattice energy
-        rest_energy rest energy of the circulating particle [eV]
-        charge      charge of the circulating particle [elementary charge]
 
     If 'energy' is not available, relativistic tracking if forced, rest_energy
     is ignored.
@@ -117,20 +113,6 @@ def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
     if refpts is None:
         refpts = len(ring)
     refpts = uint32_refpts(refpts, len(ring))
-    particle = kwargs.pop('particle', getattr(ring, 'particle', Particle()))
-    try:
-        # try to get 'energy' from the lattice
-        kwargs.setdefault('energy', getattr(ring, 'energy'))
-    except AttributeError:
-        pass
-    if 'energy' in kwargs:
-        # energy available, use the particle properties
-        kwargs.setdefault('rest_energy', particle.rest_energy)
-        kwargs.setdefault('charge', particle.charge)
-    else:
-        # energy no available, force relativistic tracking
-        kwargs['rest_energy'] = 0.0
-        kwargs['charge'] = -1.0
     pm_ok = [e.PassMethod in elements._collective for e in ring]
     if len(numpy.atleast_1d(r_in[0])) > 1 and not any(pm_ok):
         if pool_size is None:

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -2,7 +2,7 @@ import numpy
 from warnings import warn
 # noinspection PyUnresolvedReferences
 from .atpass import atpass as _atpass, elempass as _elempass
-from ..lattice import Particle, DConstant, uint32_refpts
+from ..lattice import DConstant, uint32_refpts
 
 
 __all__ = ['lattice_pass', 'element_pass', 'atpass', 'elempass']
@@ -16,13 +16,16 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
     calling the element-specific tracking function specified in the
     lattice[i].PassMethod field.
 
-    Note:
+    Notes:
 
      * lattice_pass(lattice, r_in, refpts=len(line)) is the same as
        lattice_pass(lattice, r_in) since the reference point len(line) is the
-       exit of the last element
+       exit of the last element.
      * lattice_pass(lattice, r_in, refpts=0) is a copy of r_in since the
-       reference point 0 is the entrance of the first element
+       reference point 0 is the entrance of the first element.
+     * To resume an interrupted tracking (for instance to get intermediate
+       results), one must use one of the 'turn' or 'keep_counter' keywords to
+       ensure the continuity of the turn number.
 
     PARAMETERS
         lattice:    iterable of AT elements
@@ -31,24 +34,29 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
                     the end of the tracking. For the the best efficiency, r_in
                     should be given as F_CONTIGUOUS numpy array.
     KEYWORDS
-        nturns=1:   number of passes through the lattice line
-        refpts      elements at which data is returned. It can be:
-                    1) an integer in the range [-len(ring), len(ring)-1]
-                       selecting the element according to python indexing
-                       rules. As a special case, len(ring) is allowed and
-                       refers to the end of the last element,
-                    2) an ordered list of such integers without duplicates,
-                    3) a numpy array of booleans of maximum length
-                       len(ring)+1, where selected elements are True.
-                    Default: end of lattice
-        keep_lattice: use elements persisted from a previous call to at.atpass.
-                    If True, assume that the lattice has not changed since
-                    that previous call.
-        losses:     Boolean to activate loss maps output, default is False
+        nturns=1        number of passes through the lattice line
+        refpts          elements at which data is returned. It can be:
+                        1) an integer in the range [-len(ring), len(ring)-1]
+                           selecting the element according to python indexing
+                           rules. As a special case, len(ring) is allowed and
+                           refers to the end of the last element,
+                        2) an ordered list of such integers without duplicates,
+                        3) a numpy array of booleans of maximum length
+                           len(ring)+1, where selected elements are True.
+                        Default: end of lattice
+        keep_lattice    use elements persisted from a previous call.
+                        If True, assume that the lattice has not changed since
+                        that previous call.
+        keep_counter    Keep the turn number from the previous call.
+                        Default: False
+        turn=0          Starting turn number. Ignored if keep_counter is True.
+                        The turn number is necessary to compute the absolute
+                        path length used in RFCavityPass.
+        losses:         Boolean to activate loss maps output, default is False
     The following keywords overload the lattice value:
-        particle:   circulating particle. Default: lattice.particle if
-                    existing, otherwise Particle('relativistic')
-        energy      lattice energy. Default 0.
+        particle:       circulating particle. Default: lattice.particle if
+                        existing, otherwise Particle('relativistic')
+        energy          lattice energy. Default 0.
 
     If 'energy' is not available, relativistic tracking if forced, rest_energy
     is ignored.

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -108,15 +108,6 @@ def element_pass(element, r_in, **kwargs):
         (6, N) array containing output the coordinates of the particles at the
         exit of the element.
     """
-    particle = kwargs.pop('particle', Particle())
-    if 'energy' in kwargs:
-        # energy available: use the particle properties
-        kwargs.setdefault('rest_energy', particle.rest_energy)
-        kwargs.setdefault('charge', particle.charge)
-    else:
-        # energy not available: force relativistic tracking
-        kwargs['rest_energy'] = 0.0
-        kwargs['charge'] = -1.0
     r_in = numpy.asfortranarray(r_in)
     return _elempass(element, r_in, **kwargs)
 

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -45,14 +45,10 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
                     If True, assume that the lattice has not changed since
                     that previous call.
         losses:     Boolean to activate loss maps output, default is False
-    The following keyword overloads a value from lattice:
+    The following keywords overload the lattice value:
         particle:   circulating particle. Default: lattice.particle if
                     existing, otherwise Particle('relativistic')
-    The following keywords overload values from lattice of from particle
-    keyword
-        energy      lattice energy
-        rest_energy rest energy of the circulating particle [eV]
-        charge      charge of the circulating particle [elementary charge]
+        energy      lattice energy. Default 0.
 
     If 'energy' is not available, relativistic tracking if forced, rest_energy
     is ignored.
@@ -73,20 +69,6 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
     if omp_num_threads is None:
         omp_num_threads = DConstant.omp_num_threads
     refs = uint32_refpts(refpts, len(lattice))
-    particle = kwargs.pop('particle', getattr(lattice, 'particle', Particle()))
-    try:
-        # try to get 'energy' from the lattice
-        kwargs.setdefault('energy', getattr(lattice, 'energy'))
-    except AttributeError:
-        pass
-    if 'energy' in kwargs:
-        # energy available, use the particle properties
-        kwargs.setdefault('rest_energy', particle.rest_energy)
-        kwargs.setdefault('charge', particle.charge)
-    else:
-        # energy no available, force relativistic tracking
-        kwargs['rest_energy'] = 0.0
-        kwargs['charge'] = -1.0
     # atpass returns 6xAxBxC array where n = x*y*z;
     # * A is number of particles;
     # * B is number of refpts
@@ -118,9 +100,6 @@ def element_pass(element, r_in, **kwargs):
     KEYWORDS
         particle:   circulating particle. Default: Particle('relativistic')
         energy      lattice energy
-    The following keywords overload the values from the particle keyword:
-        rest_energy rest energy of the circulating particle [eV]
-        charge      charge of the circulating particle [elementary charge]
 
     If 'energy' is not available, relativistic tracking if forced, rest_energy
     is ignored.


### PR DESCRIPTION
Until now, the default passmethod for cavities is `CavityPass`. #372 (pending) will change it for `RFCavityPass`.
Unlike `CavityPass`, `RFCavityPass` can handle multi-turn tracking with a RF frequency different from nominal. For this, it has to compute the total path length since the beginning of tracking ("turn 0"). This is done by internally maintaining a "turn counter". This has a drawback: since the turn counter is set to zero on each call to `atpass`, splitting a long tracking is wrong. A statement like:
```python
lattice_pass(ring, particle, nturns=100)
```
is correct, but the sequence:
```python
for turn in range(100):
    lattice_pass(ring, particle, nturns=1)
```
is wrong because the turn counter is reset to zero, thus re-synchronising the particle with the RF on each turn. The same applies to the Matlab equivalent `ringpass`. In such a case, we are back to the behaviour of `CavityPass`!

This PR adds a new keyword `turn` to `lattice_pass`, allowing to handle the "turn counter" externally, so that the sequence:
```python
for turn in range(100):
    lattice_pass(ring, particle, nturns=1, turn=turn)
```
is now correct.
