### PR TITLE
correct fundamental cavity mask 

### DIFF
--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -42,7 +42,7 @@ def _fundmask(ring, cavpts):
     if len(freqs) < 1:
         raise AtError('No cavity found in the lattice')
     mask = (freqs == min(freqs))
-    return None if numpy.all(mask) else mask
+    return mask
 
 
 def _get_cavity(ring, attr, fsingle, cavpts=None, array=False):


### PR DESCRIPTION
This PR fixes a bug in `cavity_access.py`:
In case all cavity have the same frequency `_fundmask` returns `None`, however is `mask=None` the voltage is applied on all cavities which is wrong because it leads to `ring.rf_voltage = desired_voltage*ncavities`.
The `mask` is now returned in all cases which fixes this issue.
