### PR TITLE
Added catch to sigma_matrix. Added AtErrors and AtWarnings

### DIFF
--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -43,8 +43,14 @@ def _compute_bunch_length_from_espread(ring, espread):
     return blength
 
 
-def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
+def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None, emity=None,
                           blength=None, espread=None, verbose=False):
+
+    if ring is None and (emitx is None or emity is None or blength is None
+                         or espread is None or twiss_in is None):
+        raise AtError('Provide either a ring or twiss_in and ALL emittance '
+                      'paramaters: (ex, ey, espread, blength)')
+
     if espread is not None and blength is None:
         blength = _compute_bunch_length_from_espread(ring, espread)
     flag_all = emitx and emity and espread
@@ -122,28 +128,26 @@ def sigma_matrix(ring=None, twiss_in=None, betax=None, alphax=None,
     OUTPUT
         sigma_matrix    6x6 correlation matrix
 
-    If the lattice object is provided with no other
-    arguments, ohmi_envelope is used to compute the
-    correlated sigma matrix.
 
-    If the lattice object and emittances and longitudinal
-    parameters are provided, then the 2x2 uncorrelated
-    matrices are computed for each plane (x,y,z) using
-    the initial optics computed from ring.get_optics,
+    If the lattice object is provided ohmi_envelope is used to
+    compute the correlated sigma matrix and missing emittances
+    and longitudinal parameters
+
+    If emittances and longitudinal parameters are provided, then
+    the 2x2 uncorrelated matrices are computed for each plane (x,y,z)
+    using the initial optics computed from ring.get_optics,
     and are combined together into the 6x6 matrix.
 
-    If the twiss_in is provided alongside the emittances and
-    longitudinal parameters, then the 2x2 uncorrelated
-    matrices are computed for each plane and combined
-    into the 6x6 matrix.
+    If the twiss_in is provided it has to be produced with linopt6 and
+    contain the rmatrix. ring is used only to compute missing emittances.
 
     If neither a lattice object nor a twiss_in is provided,
     then the beta, alpha and emittance for horizontal and
     vertical is required, as well as blength and espread.
     This then computes the analytical uncoupled sigma matrix
     """
-    if ring is not None:
-        return _sigma_matrix_lattice(ring, twiss_in=twiss_in,
+    if ring is not None or twiss_in is not None:
+        return _sigma_matrix_lattice(ring=ring, twiss_in=twiss_in,
                                      emitx=emitx, emity=emity,
                                      blength=blength, espread=espread,
                                      verbose=verbose)

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -80,7 +80,6 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
             raise AtError('twiss_in should contain the R matrix. '
                           'Please use the output from linopt6.')
 
-
     if flag and twiss_in:
         assert blength is not None, 'blength must be defined for twiss_in'
     elif flag and ring:
@@ -108,14 +107,13 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
     elif flag:
         if ring:
             ld0, bd, ld = ring.get_optics()
-            rmat =  ld0.R
+            rmat = ld0.R
         elif twiss_in:
             rmat = twiss_in.R
 
         if verbose:
             print('Generating pseudo-correlated matrix '
                   'from initial optics conditions')
-
 
         sig_matrix = _sigma_matrix_from_R66(rmat,
                                             emitx, emity, blength, espread)
@@ -166,7 +164,7 @@ def sigma_matrix(ring=None, twiss_in=None, **kwargs):
     into the 6x6 matrix.
 
     If neither a lattice object nor a twiss_in is provided,
-    then the beta, alpha and emittance for horizontal and 
+    then the beta, alpha and emittance for horizontal and
     vertical is required, as well as blength and espread.
     This then computes the analytical uncoupled sigma matrix
     """

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -5,7 +5,8 @@ import numpy
 from at.physics import ohmi_envelope
 from at.lattice.constants import clight, e_mass
 from at.physics import get_mcf, get_tune
-from at.lattice import AtError
+from at.lattice import AtError, AtWarning
+import warnings
 
 __all__ = ['beam', 'sigma_matrix']
 
@@ -74,12 +75,8 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
         assert espread is not None, 'espread must be defined'
 
     if ring:
-        cavPassFlag = numpy.any(
-                        numpy.array(
-                          [i.PassMethod == 'CavityPass' for i in ring]))
-        radPassFlag = numpy.any(
-                        numpy.array(
-                          ['Rad' in i.PassMethod for i in ring]))
+        cavPassFlag = numpy.any([i.PassMethod == 'CavityPass' for i in ring])
+        radPassFlag = numpy.any(['Rad' in i.PassMethod for i in ring])
 
         if cavPassFlag and not radPassFlag and not flag:
             raise AtError('Cannot compute 6D sigma matrix without '
@@ -185,7 +182,11 @@ def sigma_matrix(ring=None, twiss_in=None, **kwargs):
     espread = d.get('espread', None)
     verbose = d.get('verbose', False)
 
-    if isinstance(ring, list) or isinstance(twiss_in, numpy.recarray):
+    if ring is not None and twiss_in is not None:
+        warnings.warn(AtWarning('Both ring and twiss_in have been provided. '
+                                'Ignoring twiss_in and taking the ring.'))
+
+    if ring is not None or twiss_in is not None:
         return _sigma_matrix_lattice(ring=ring, twiss_in=twiss_in,
                                      emitx=emitx, emity=emity,
                                      blength=blength, espread=espread,

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -45,19 +45,9 @@ def _sigma_matrix_uncoupled(betax, alphax, emitx,
 
 
 def _compute_bunch_length_from_espread(ring, espread):
-    gamma = ring.energy/e_mass
-    beta = numpy.sqrt(1.0-1.0/gamma/gamma)
-    f0 = clight/ring.circumference
-
-    mcf = get_mcf(ring.radiation_off(copy=True))
-    if ring.radiation:
-        qs3 = get_tune(ring)
-    else:
-        qs3 = get_tune(ring.radiation_on(copy=True))
-
-    f_s = qs3[2]*f0
-
-    blength = clight * beta * numpy.abs(mcf) * espread / (2 * numpy.pi * f_s)
+    rp = at.radiation_parameters(ring.radiation_off(copy=True))
+    blength = ring.beta*clight*numpy.abs(rp.etac)*espread/ \
+        (2.0*numpy.pi*rp.f_s) 
     return blength
 
 

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -3,10 +3,8 @@ Functions relating to particle generation
 """
 import numpy
 from at.physics import ohmi_envelope, radiation_parameters
-from at.lattice.constants import clight, e_mass
-from at.physics import get_mcf, get_tune
-from at.lattice import AtError, AtWarning
-import warnings
+from at.lattice.constants import clight
+from at.lattice import AtError
 
 __all__ = ['beam', 'sigma_matrix']
 
@@ -98,7 +96,9 @@ def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
     return sig_matrix
 
 
-def sigma_matrix(ring=None, twiss_in=None, **kwargs):
+def sigma_matrix(ring=None, twiss_in=None, betax=None, alphax=None,
+                 emitx=None, betay=None, alphay=None, emity=None,
+                 blength=None, espread=None, verbose=False):
     """
     Calculate the correlation matrix to be used for particle generation
 
@@ -142,15 +142,6 @@ def sigma_matrix(ring=None, twiss_in=None, **kwargs):
     vertical is required, as well as blength and espread.
     This then computes the analytical uncoupled sigma matrix
     """
-    betax = kwargs.get('betax', None)
-    alphax = kwargs.get('betax', None)
-    emitx = kwargs.get('emitx', None)
-    betay = kwargs.get('betay', None)
-    alphay = kwargs.get('betay', None)
-    emity = kwargs.get('emity', None)
-    blength = kwargs.get('blength', None)
-    espread = kwargs.get('espread', None)
-    verbose = kwargs.get('verbose', False)
     if ring is not None:
         return _sigma_matrix_lattice(ring, twiss_in=twiss_in,
                                      emitx=emitx, emity=emity,

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -18,8 +18,10 @@ def _generate_2d_trans_matrix(emit, beta, alpha):
 def _generate_2d_long_matrix(espread, blength):
     return numpy.array([[espread*espread, 0], [0, blength*blength]])
 
+
 def _generate_2d_long_Rmatrix(espread, blength):
     return numpy.array([[espread/blength, 0], [0, blength/espread]])
+
 
 def _sigma_matrix_uncoupled(betax, alphax, emitx,
                             betay, alphay, emity,
@@ -75,7 +77,6 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
         assert emity is not None, 'emity must be defined'
         assert espread is not None, 'espread must be defined'
 
-
     if twiss_in:
         if flag:
             assert blength is not None, 'blength must be defined for twiss_in'
@@ -85,7 +86,6 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
             raise AtError('twiss_in should contain the R matrix. '
                           'Please use the output from linopt6.')
         rmat = twiss_in.R
-
 
     if ring:
         if not ring.radiation and not flag:
@@ -97,8 +97,10 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
                 blength = _compute_bunch_length_from_espread(ring, espread)
         else:
 
-            cavPassFlag = numpy.any([i.PassMethod == 'CavityPass' for i in ring])
-            radPassFlag = numpy.any(['Rad' in i.PassMethod for i in ring])
+            cavPassFlag = numpy.any(
+                            [i.PassMethod == 'CavityPass' for i in ring])
+            radPassFlag = numpy.any(
+                            ['Rad' in i.PassMethod for i in ring])
 
             if cavPassFlag and not radPassFlag:
                 raise AtError('Cannot compute 6D sigma matrix without '
@@ -116,16 +118,16 @@ def _sigma_matrix_lattice(ring=None, twiss_in=None, emitx=None,
         ld0, bd, ld = ring.get_optics()
         if ld0.R.shape[0] == 3:
             rmat = ld0.R
-        else:           
+        else:
             rmat = numpy.zeros((3, 6, 6))
             rmat[0] = numpy.block([
-                                [ld0.R[0], numpy.zeros((4,2))],
-                                [numpy.zeros((2,6))]
+                                [ld0.R[0], numpy.zeros((4, 2))],
+                                [numpy.zeros((2, 6))]
                                 ])
 
             rmat[1] = numpy.block([
-                                [ld0.R[1], numpy.zeros((4,2))],
-                                [numpy.zeros((2,6))]
+                                [ld0.R[1], numpy.zeros((4, 2))],
+                                [numpy.zeros((2, 6))]
                                 ])
 
             rlong = _generate_2d_long_Rmatrix(espread, blength)

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -210,6 +210,6 @@ def beam(nparts, sigma, orbit=None):
     if orbit is not None:
         if numpy.shape(orbit) != (6,):
             raise AtError('beam: input orbit shape has to be (6,)')
-        particle_dist = (particle_dist.T + numpy.array(orb)).T
+        particle_dist = (particle_dist.T + numpy.array(orbit)).T
 
     return particle_dist

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -219,9 +219,9 @@ def beam(nparts, sigma, orbit=None):
         orbit=None      An orbit can be provided to give a center of
                         mass offset to the distribution
     OUTPUT
-        particle_dist   a matrix of shape (M, np) where M is shape of
-                        sigma matrix
+        particle_dist   a matrix of shape (6, np)
     """
+
     def _get_single_plane(dims):
         row_idx = numpy.array(dims)
         try:

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -25,7 +25,7 @@ def _generate_2d_long_Rmatrix(espread, blength):
 
 def _sigma_matrix_uncoupled(betax, alphax, emitx, betay, alphay, emity,
                             blength, espread):
-    sig_matrix = numpy.zeros((6,6))
+    sig_matrix = numpy.zeros((6, 6))
     sig_matrix[:2, :2] = _generate_2d_trans_matrix(emitx, betax, alphax)
     sig_matrix[2:4, 2:4] = _generate_2d_trans_matrix(emity, betay, alphay)
     sig_matrix[4:, 4:] = _generate_2d_long_matrix(espread, blength)
@@ -46,12 +46,12 @@ def _compute_bunch_length_from_espread(ring, espread):
 
 
 def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
-                          blength=None, espread=None, verbose=False):     
+                          blength=None, espread=None, verbose=False):
     if espread is not None and blength is None:
         blength = _compute_bunch_length_from_espread(ring, espread)
     flag_all = emitx and emity and espread
     flag_any = emitx or emity or espread
-    
+
     if not flag_all:
         if verbose:
             print('Calculating missing parameters (ex, ey or espread) '
@@ -60,7 +60,7 @@ def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
             emit0, beamdata, emit = ohmi_envelope(ring, refpts=[0])
         except AtError:
             raise AtError('Please provide ex, ey, espread or turn on '
-                          'radiations to compute the sigma matrix') 
+                          'radiations to compute the sigma matrix')
         if emitx is None:
             emitx = beamdata.mode_emittances[0]
         if emity is None:
@@ -68,9 +68,9 @@ def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
         if espread is None:
             espread = numpy.sqrt(emit0.r66[4, 4])
             blength = numpy.sqrt(emit0.r66[5, 5])
-            
+
     if not flag_any and not twiss_in:
-        return emit.r66[0]       
+        return emit.r66[0]
     elif twiss_in:
         if verbose:
             print('Generating pseudo-correlated matrix '
@@ -85,12 +85,12 @@ def _sigma_matrix_lattice(ring, twiss_in=None, emitx=None, emity=None,
                   'from start point of ring')
         l0, _, _ = ring.get_optics()
         rmat = l0.R
-        
+
     if rmat.shape[0] != 3:
         rmat6 = numpy.zeros((3, 6, 6))
-        rmat6[0,:4,:4]= rmat[0]
-        rmat6[1,:4,:4]= rmat[1]
-        rmat6[2,4:,4:]= _generate_2d_long_Rmatrix(espread, blength)
+        rmat6[0, :4, :4] = rmat[0]
+        rmat6[1, :4, :4] = rmat[1]
+        rmat6[2, 4:, 4:] = _generate_2d_long_Rmatrix(espread, blength)
     else:
         rmat6 = rmat
     sig_matrix = _sigma_matrix_from_R66(rmat6, emitx, emity, blength,
@@ -197,8 +197,8 @@ def beam(nparts, sigma, orbit=None):
 
     try:
         lmat = numpy.linalg.cholesky(sigma)
-    except numpy.linalg.LinAlgError: 
-        lmat = numpy.zeros((6,6))      
+    except numpy.linalg.LinAlgError:
+        lmat = numpy.zeros((6, 6))
         lmat[:2, :2] = _get_single_plane([0, 1])
         lmat[2:4, 2:4] = _get_single_plane([2, 3])
         lmat[4:, 4:] = _get_single_plane([4, 5])
@@ -208,7 +208,7 @@ def beam(nparts, sigma, orbit=None):
         particle_dist = numpy.array([particle_dist]).T
 
     if orbit is not None:
-        if numpy.shape(orbit) != (6,)
+        if numpy.shape(orbit) != (6,):
             raise AtError('beam: input orbit shape has to be (6,)')
         particle_dist = (particle_dist.T + numpy.array(orb)).T
 

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -108,21 +108,21 @@ def sigma_matrix(ring=None, twiss_in=None, betax=None, alphax=None,
     """
     Calculate the correlation matrix to be used for particle generation
 
-    PARAMETERS
-        ring            Lattice object or list of
-                        twiss parameters.
-        twiss_in        Data structure containing input
-                        twiss parameters.
 
     KEYWORDS
-        betax           Input horizontal beta function [m]
-        alphax          Input horizontal alpha function [m]
-        emitx           Horizontal emittance [m.rad]
-        betay           Input vertical beta function [m]
-        alphay          Input vertical alpha function [m]
-        emity           Vertical emittance [m.rad]
-        blength         One sigma bunch length [m]
-        espread         One sigma energy spread [dp/p]
+        ring=None       Lattice object or list of
+                        twiss parameters.
+        twiss_in=None        Data structure containing input
+                        twiss parameters.
+
+        betax=None      Input horizontal beta function [m]
+        alphax=None     Input horizontal alpha function [m]
+        emitx=None      Horizontal emittance [m.rad]
+        betay=None      Input vertical beta function [m]
+        alphay=None     Input vertical alpha function [m]
+        emity=None      Vertical emittance [m.rad]
+        blength=None    One sigma bunch length [m]
+        espread=None    One sigma energy spread [dp/p]
         verbose=False   Boolean flag on whether to print information
                         to the terminal
     OUTPUT

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -167,6 +167,11 @@ def sigma_matrix(ring=None, twiss_in=None, **kwargs):
     longitudinal parameters, then the 2x2 uncorrelated
     matrices are computed for each plane and combined
     into the 6x6 matrix.
+
+    If neither a lattice object nor a twiss_in is provided,
+    then the beta, alpha and emittance for horizontal and 
+    vertical is required, as well as blength and espread.
+    This then computes the analytical uncoupled sigma matrix
     """
 
     d = kwargs

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -5,8 +5,7 @@ import numpy
 from at.physics import ohmi_envelope
 from at.lattice.constants import clight, e_mass
 from at.physics import get_mcf, get_tune
-from at.lattice import AtWarning, AtError
-import warnings
+from at.lattice import AtError
 
 __all__ = ['beam', 'sigma_matrix']
 


### PR DESCRIPTION
There was a problem when CavityPass was present in a lattice without radiation damping. Now if that happens, it asserts that you specify the emittances. 

I also took the opportunity to replace some prints with AtWarnings and replace some of the appropriate errors with AtErrors. 