### PR TITLE
Fix plCorrectorStrength

### DIFF
--- a/atmat/atplot/plotfunctions/plCorrectorStrength.m
+++ b/atmat/atplot/plotfunctions/plCorrectorStrength.m
@@ -1,32 +1,41 @@
-function plotdata=plCorrectorStrength(lindata,ring,dpp,varargin) %#ok<INUSD>
-%DEFAULTPLOT    Default plotting function for ATPLOT
+function varargout=plCorrectorStrength(varargin)
+%PLCORRECTORSTRENGTH Plot PolynomB
+%Helper function for atplot: plot
+%- PolynomB(1), PolynomA(1), PolynomA(2), PolynomA(2) on the left axis
 %
-%Plots polynomB for ring and ring1
+%  EXAMPLEs
+% >> atbaseplot(ring,'synopt',false,@plCorrectorStrength);
+% >> atplot(ring,@plCorrectorStrength,'synopt',false);     (obsolete)
+%
+%  See also atplot atbaseplot
+%
 
-CoD=cat(2,lindata.ClosedOrbit);
-PolyBVal=zeros(size(CoD(1,:)));
-PolyBVal1=zeros(size(CoD(1,:)));
+if nargout == 1 % From atplot
+    [~,ring]=deal(varargin{1:2});
+    sz=length(ring)+1;
 
-PolynomBVal1=zeros(size(CoD(1,:)));
-PolynomBVal2=zeros(size(CoD(1,:)));
-PolynomBVal3=zeros(size(CoD(1,:)));
-PolynomBVal4=zeros(size(CoD(1,:)));
-ind=findcells(ring,'PolynomB');
+    PolynomBVal1=zeros(sz,1);
+    PolynomBVal2=zeros(sz,1);
+    PolynomBVal3=zeros(sz,1);
+    PolynomBVal4=zeros(sz,1);
+    ind=findcells(ring,'PolynomB');
 
-PolynomBVal1(ind)=getcellstruct(ring,'PolynomB',ind,1,1);
-PolynomBVal2(ind)=getcellstruct(ring,'PolynomA',ind,1,1);
-PolynomBVal3(ind)=getcellstruct(ring,'PolynomA',ind,1,2);
-PolynomBVal4(ind)=getcellstruct(ring,'PolynomB',ind,1,2);
+    PolynomBVal1(ind)=getcellstruct(ring,'PolynomB',ind,1,1);
+    PolynomBVal2(ind)=getcellstruct(ring,'PolynomA',ind,1,1);
+    PolynomBVal3(ind)=getcellstruct(ring,'PolynomA',ind,1,2);
+    PolynomBVal4(ind)=getcellstruct(ring,'PolynomB',ind,1,2);
 
 
-plotdata(1).values=[PolynomBVal1' PolynomBVal2' ...];%...
-                     PolynomBVal3'/1000 0*PolynomBVal4' ];
-plotdata(1).labels={'H cor','V cor',...
-                    'Skew Quad/1000','Quad'};
-plotdata(1).axislabel='PolynomB';
-% dispersion=cat(2,lindata.Dispersion)';
-% plotdata(2).values=dispersion(:,3);
-% plotdata(2).labels={'\eta_y'};
-% plotdata(2).axislabel='vertical dispersion [m]';
+    plotdata(1).values=[PolynomBVal1 PolynomBVal2 ...
+        PolynomBVal3/1000 PolynomBVal4/1000 ];
+    plotdata(1).labels={'H cor','V cor',...
+        'Skew Quad/1000','Quad/1000'};
+    plotdata(1).axislabel='PolynomB';
+    varargout={plotdata};
+else % From atbaseplot
+    [ring,dpp]=deal(varargin{1:2});
+    s=findspos(ring,1:length(ring)+1)';
+    varargout={s,plCorrectorStrength([],ring,dpp,varargin{3:end})};
+end
 
 end


### PR DESCRIPTION
Fix #388. `plCorrectorStrength` fails when called from `atbaseplot`.

This plot helper displays `PolynomB(1)`, `PolynomA(1)`, `PolynomA(2)` and `PolynomB(2)`.

**Warning**: for some reason, PolynomB(2) was scaled by 0 !!! It is now scaled by 0.001, as PolynomA(1).