### PR TITLE
Resolve conflict with a Matlab toolbox

### DIFF
--- a/atmat/atplot/atplot.m
+++ b/atmat/atplot/atplot.m
@@ -92,7 +92,7 @@ args=getdparg(args(1:funcarg-1));
         varargs=cellfun(@correct, varargs, 'UniformOutput',false);
         [dpargs,varargs]=getoption(varargs,{'dp','dct','df'});
         [srange,varargs]=getargs(varargs,[0 inf],'check',@(x) isnumeric(x) && numel(x)==2);
-        [largs,varargs]=linoptions(varargs);
+        [largs,varargs]=opticsoptions(varargs);
 
         lindata=[];
 
@@ -118,7 +118,7 @@ args=getdparg(args(1:funcarg-1));
         if nargout>0, varargout={curve}; end
 
         function [s,plotdata]=ringplot(ring,dpp,plotfun,varargin)
-            [linargs,vargs] = linoptions(varargin);
+            [linargs,vargs] = opticsoptions(varargin);
             [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
             s=cat(1,lindata.SPos);
             plotdata=plotfun(lindata,ring,dpp,vargs{:});

--- a/atmat/atplot/plotfunctions/plBeamSize.m
+++ b/atmat/atplot/plotfunctions/plBeamSize.m
@@ -25,7 +25,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plBeamSize(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plClosedOrbit.m
+++ b/atmat/atplot/plotfunctions/plClosedOrbit.m
@@ -25,7 +25,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plClosedOrbit(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plEmitContrib.m
+++ b/atmat/atplot/plotfunctions/plEmitContrib.m
@@ -30,7 +30,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plEmitContrib(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plotB0curlyh.m
+++ b/atmat/atplot/plotfunctions/plotB0curlyh.m
@@ -31,7 +31,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plotB0curlyh(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plotbetadisp.m
+++ b/atmat/atplot/plotfunctions/plotbetadisp.m
@@ -25,7 +25,7 @@ if nargout == 1     % From atplot
     varargout={plotdata};
 else                % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plotbetadisp(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plotbetadispcurlyh.m
+++ b/atmat/atplot/plotfunctions/plotbetadispcurlyh.m
@@ -23,7 +23,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plotbetadispcurlyh(lindata,ring,dpp,varargs{:})};

--- a/atmat/atplot/plotfunctions/plotsqrtbetadispcurlyh.m
+++ b/atmat/atplot/plotfunctions/plotsqrtbetadispcurlyh.m
@@ -23,7 +23,7 @@ if nargout == 1 % From atplot
     varargout={plotdata};
 else % From atbaseplot
     [ring,dpp]=deal(varargin{1:2});
-    [linargs,varargs]=linoptions(varargin(3:end));
+    [linargs,varargs]=opticsoptions(varargin(3:end));
     [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
     s=cat(1,lindata.SPos);
     varargout={s,plotsqrtbetadispcurlyh(lindata,ring,dpp,varargs{:})};

--- a/atmat/atutils/opticsoptions.m
+++ b/atmat/atutils/opticsoptions.m
@@ -1,5 +1,5 @@
-function [linargs,opts] = linoptions(opts)
-%LINOPTIONS  (private) extract arguments for atlinopt
+function [linargs,opts] = opticsoptions(opts)
+%OPTICSOPTIONS  (private) extract arguments for atlinopt
 %
 % Separate the options for atlinopt
 


### PR DESCRIPTION
A test revealed a conflict with the "Simulink Control Design" toolbox. The AT private function `linoptions` has the same name as an obsolete function of the Simulink toolbox.

The Matlab function is part of the utility functions for processing function arguments. It is considered and advertised as private, though it is publicly accessible. This PR changes the name of the Matlab function to `opticsoptions`.