### PR TITLE
Avoid problems with GitHub Windows runners

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
-#       exclude:
-#         - os: windows-latest
-#           python-version: '3.7'
+        exclude:
+          - os: windows-latest
+            python-version: ['3.6', '3.7']
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,7 +24,9 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
-            python-version: ['3.6', '3.7']
+            python-version: '3.6'
+          - os: windows-latest
+            python-version: '3.7'
 
     steps:
 

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -32,11 +32,6 @@ typedef PyObject atElem;
 #define GETTRACKFCN(libfilename) GetProcAddress((libfilename),ATPY_PASS)
 #define SEPARATOR "\\"
 #define OBJECTEXT ".pyd"
-#if PY_MINOR_VERSION < 7    /* module sysconfig wrong on windows for python<3.7 */
-#define SYSCONFIG "distutils.sysconfig"
-#else
-#define SYSCONFIG "sysconfig"
-#endif /*PY_MINOR_VERSION*/
 #else
 #include <dlfcn.h>
 #define LIBRARYHANDLETYPE void *
@@ -45,9 +40,9 @@ typedef PyObject atElem;
 #define GETTRACKFCN(libfilename) dlsym((libfilename),ATPY_PASS)
 #define SEPARATOR "/"
 #define OBJECTEXT ".so"
-#define SYSCONFIG "sysconfig"
 #endif
 
+#define SYSCONFIG "sysconfig"
 #define LIMIT_AMPLITUDE		1
 #define C0  	2.99792458e8
 

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -7,10 +7,7 @@ import os
 import re
 import numpy
 from warnings import warn
-if sys.platform.startswith('win') and sys.version_info.minor < 7:
-    from distutils import sysconfig
-else:
-    import sysconfig
+import sysconfig
 from at import integrators
 from at.lattice import AtWarning
 from at.lattice import CLASS_MAP, elements as elt


### PR DESCRIPTION
This is a workaround for a problem with GitHub Windows runners used for tests. The problem is the following:
The file extensions for the python extensions compiled from C are accessible from the python "`sysconfig`" module. This module is imported in 2 locations:
- `at.c`, where the C extensions are dynamically loaded,
- `load/utils.py`, where the presence of the extension is checked when loading a Matlab lattice description.

Unfortunately, the `sysconfig` module returns a wrong value on GitHub for python 3.6 and 3.7 on Windows: `.pyd` instead of  `.cp36-win_amd64.pyd`. Even worse, the file extension for python 3.7 changed twice without notice in the last few weeks, resulting in failing tests. 

Up to now the solution was to introduce a Windows-specific workaround in the 2 files mentioned above, by importing the deprecated `distutils.sysconfig` module instead of `sysconfig`. But this workaround has to be modified each time the GitHub configuration changes…

The proposed solution here is:
1. Remove all Windows-specific workarounds in the PyAT code. `sysconfig` is always used,
2. disable the tests on Windows for python 3.6 (always fails up to now) and python 3.7 (succeeds or fails, it depends on GitHub good will).

Consequences:
- cleaner code
- the compatibility of PyAT with python 3.6 and 3.7 is still checked on Linux and MacOS
- the problem on Windows looks specific to GitHub, and should not harm normal Windows users, though I cannot check,
- the problem is restricted to really old python versions.

