### PR TITLE
Initialisation of the harmonic number

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -778,7 +778,6 @@ def type_filter(params, elem_iterator):
             if (elem.PassMethod.endswith('RadPass') or
                     elem.PassMethod.endswith('CavityPass')):
                 radiate = True
-            print(elem.FamName)
             yield elem
         else:
             warn(AtWarning('item {0} ({1}) is not an AT element: '


### PR DESCRIPTION
@simoneliuzzo and @swhite2401 pointed out in #391 a problem with the `harmonic_number` Lattice attribute. It is properly initialised when creating a lattice, but not when a lattice is modified: if the attribute does not exist initially (no cavity in the lattice), it is not added if a cavity is added to the lattice. This concerns the following actions:
- `insert`, `append` and `extend` methods,
- `+` and `+=` operators.

This is corrected here, as well as updating properly the `radiation` property in the same events.