### PR TITLE
Improvement of RF frequency control

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -92,9 +92,12 @@ if isempty(varargs)             % New syntax
             if isfinite(dct)
                 frev=frev * lcell/(lcell+dct);
             elseif isfinite(dp)
-                [~,ringrad]=check_radiation(ring,false,'force');
-                etac=1/gamma0^2 - mcf(ringrad);
-                frev=frev + frev*etac*dp;
+                % Find the path lengthening for dp
+                [~,rnorad]=check_radiation(ring,false,'force');
+                [~,orbitin]=findorbit4(rnorad,dp);
+                orbitout=ringpass(rnorad,orbitin);
+                dct=orbitout(6);
+                frev=frev * lcell/(lcell+dct);
             end
             frequency = frev * props_harmnumber(harmnumber,props);
         else

--- a/pyat/at/acceptance/acceptance.py
+++ b/pyat/at/acceptance/acceptance.py
@@ -1,21 +1,24 @@
 import numpy
 from .boundary import GridMode
+# noinspection PyProtectedMember
 from .boundary import boundary_search
 import multiprocessing
 from ..lattice import Lattice
+from ..physics import frequency_control
 
 
 __all__ = ['get_acceptance', 'get_1d_acceptance', 'get_horizontal_acceptance',
            'get_vertical_acceptance', 'get_momentum_acceptance']
 
 
+@frequency_control
 def get_acceptance(ring, planes, npoints, amplitudes, nturns=1024,
                    refpts=None, dp=None, offset=None, bounds=None,
                    grid_mode=GridMode.RADIAL, use_mp=False, verbose=True,
                    start_method=None, divider=2, shift_zero=1.0e-9):
     """
     Computes the acceptance at repfts observation points
-    Grid Coordiantes ordering is as follows: CARTESIAN: (x,y), RADIAL/RECURSIVE
+    Grid Coordinates ordering is as follows: CARTESIAN: (x,y), RADIAL/RECURSIVE
     (r, theta). Scalar inputs can be used for 1D grid.
     The grid can be changed using grid_mode input:
     at.GridMode.CARTESIAN: (x,y) grid
@@ -192,7 +195,7 @@ def get_1d_acceptance(ring, plane, resolution, amplitude, nturns=1024, dp=None,
                              nturns=nturns, dp=dp, refpts=refpts,
                              grid_mode=grid_mode, use_mp=use_mp,
                              verbose=verbose, start_method=start_method,
-                             divider=2, shift_zero=0.0)
+                             divider=divider, shift_zero=0.0)
     return numpy.squeeze(b), s, g
 
 

--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -4,12 +4,10 @@ calculate the loss boundary for different
 grid definitions
 """
 
-import at
 from at.lattice import AtError
 from at.tracking import lattice_pass, patpass
 from enum import Enum
 import numpy
-import warnings
 from scipy.ndimage import binary_dilation, binary_opening
 from collections import namedtuple
 import time
@@ -79,20 +77,14 @@ def set_ring_orbit(ring, dp, obspt, orbit):
     Returns a ring starting at obspt and initial
     closed orbit
     """
-    if ring.radiation:
-        newring = ring.set_rf_frequency(dp=dp, copy=True)
-        dp = None
-    else:
-        newring = ring
-
     if obspt is not None:
         assert numpy.isscalar(obspt), 'Scalar value needed for obspt'
-        newring = newring.rotate(obspt)
+        ring = ring.rotate(obspt)
 
     if orbit is None:
-        orbit, _ = newring.find_orbit(dp=dp)
+        orbit = ring.find_orbit(dp=dp)[0]
 
-    return orbit, newring
+    return orbit, ring
 
 
 def grid_configuration(planes, npoints, amplitudes, grid_mode, bounds=None,

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -96,6 +96,7 @@ def get_revolution_frequency(ring, dp=None, dct=None):
     if dct is not None:
         frev *= lcell / (lcell + dct)
     elif dp is not None:
+        # Find the path lengthening for dp
         rnorad = ring.radiation_off(copy=True) if ring.radiation else ring
         orbit = lattice_pass(rnorad, rnorad.find_orbit4(dp=dp)[0])
         dct = numpy.squeeze(orbit)[5]


### PR DESCRIPTION
The `get_acceptance` function is an example of a function which may internally modify the ring RF frequency, to satisfy its `dp` or `dct` argument. The new `frequency_control` decorator avoids this and offers a cleaner solution to handle `dp` and `dct` in future similar functions.

This decorator can be applied to any function like `func(ring, *args, **kwargs)`. Example:

```python
@frequency_control
def get_acceptance(ring, planes, npoints, amplitudes, nturns=1024,
                   refpts=None, dp=None, offset=None, bounds=None,
                   grid_mode=GridMode.RADIAL, use_mp=False, verbose=True,
                   start_method=None, divider=2, shift_zero=1.0e-9):
```

It looks at the 1st argument of the decorated function, which must be a Lattice object (`ring`)

- if `ring.radiation` is `True` **and** `dp` or `dct` is specified, it makes a copy of `ring` with a modified RF frequency, removes the `dp` and `dct` keywords and call the decorated function with the copy of ring,
- otherwise, it directly calls the decorated function with the initial arguments.

So the decorated function does not need to care about RF frequency: It uses `ring` as it is, the `dp` or `dct` arguments will be present only when they are allowed (in 4D only).

In addition, `get_revolution_frequency` is improved when `dp` is specified: rather that relying on the momentum compaction factor, it uses closed orbit computation, giving a more accurate result.

