### PR TITLE
Allow sphinx 5 for building the documentation

### DIFF
--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -40,7 +40,7 @@ dev =
     pytest-cov
     flake8
 doc =
-    Sphinx < 5.0.0, >= 5.0.2
+    Sphinx
     myst-parser
     pydata-sphinx-theme
     sphinx-copybutton

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -40,7 +40,7 @@ dev =
     pytest-cov
     flake8
 doc =
-    Sphinx<5
+    Sphinx < 5.0.0, >= 5.0.2
     myst-parser
     pydata-sphinx-theme
     sphinx-copybutton

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -40,7 +40,7 @@ dev =
     pytest-cov
     flake8
 doc =
-    Sphinx
+    Sphinx >= 5.0.2
     myst-parser
     pydata-sphinx-theme
     sphinx-copybutton


### PR DESCRIPTION
Sphinx 5.0.0 had regressions that prevented  using it for building the web site. These have been corrected in 5.0.2. This is now the minimum version for AT.