### PR TITLE
Documentation for the at.physics package (part 1)

### DIFF
--- a/atmat/atphysics/Radiation/findmpoleraddiffmatrix.c
+++ b/atmat/atphysics/Radiation/findmpoleraddiffmatrix.c
@@ -577,20 +577,19 @@ static PyMethodDef AtMethods[] = {
     {"find_mpole_raddiff_matrix",
     (PyCFunction)compute_diffmatrix, METH_VARARGS,
     PyDoc_STR(
-        "diffmatrix=find_mpole_raddiff_matrix(element, orbit, energy)\n\n"
-        "element:   element structure with field names consistent with\n"
-        "           a multipole transverse field model.\n"
-        "orbit:     (6,) vector of the closed orbit at the entrance\n"
-        "energy:    ring energy\n\n"
-             
-        "calculate radiation diffusion matrix B defined in [2]\n"
-        "for multipole elements in MATLAB Accelerator Toolbox\n"
-        "A.Terebilo 8/14/00\n\n"
-
-        "References\n"
-        "[1] M.Sands 'The Physics of Electron Storage Rings\n"
-        "[2] Ohmi, Kirata, Oide 'From the beam-envelope matrix to synchrotron\n"
-        "radiation integrals', Phys.Rev.E  Vol.49 p.751 (1994)\n"
+    "find_mpole_raddiff_matrix(element, orbit, energy)\n\n"
+    "Computes the radiation diffusion matrix B defined in [2]_\n"
+    "for multipole elements\n\n"
+    "Args:\n"
+    "    element:    Lattice element\n"
+    "    orbit:      (6,) closed orbit at the entrance of ``element``\n"
+    "    energy:     particle energy\n\n"
+    "Returns:\n"
+    "    diffmatrix: The radiation diffusion matrix\n\n"
+    "References:\n"
+    "    **[1]** M.Sands, *The Physics of Electron Storage Rings*\n\n"
+    "    .. [2] Ohmi, Kirata, Oide, *From the beam-envelope matrix to synchrotron\n"
+    "       radiation integrals*, Phys.Rev.E  Vol.49 p.751 (1994)\n"
 	)},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,4 +3,5 @@
 !/p/api/at.tracking.patpass.rst
 !/p/api/at.acceptance.rst
 !/p/api/at.matching.rst
+!/p/api/at.physics.amat.rst
 /_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,11 @@ extensions = ['sphinx.ext.autosummary',
               'sphinx_copybutton',
               ]
 
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'matplotlib': ('https://matplotlib.org/stable/', None),
+                       'numpy': ('https://numpy.org/doc/stable/', None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+                       }
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/p/api/at.physics.amat.rst
+++ b/docs/p/api/at.physics.amat.rst
@@ -1,0 +1,16 @@
+at.physics.amat
+===============
+
+.. automodule:: at.physics.amat
+
+   .. rubric:: Functions
+
+   .. autosummary::
+
+      a_matrix
+      amat
+      jmat
+      jmatswap
+      get_tunes_damp
+      get_mode_matrices
+      symplectify

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -21,3 +21,13 @@ class _Dst(object):
 
 
 DConstant = _Dst()
+"""
+Default values for AT algorithms
+
+Attributes:
+    XYStep:             Coordinate step for differentiation
+    DPStep:             Momentum step for dispersion and chromaticity
+    OrbConvergence:     Convergence criterion for orbit
+    OrbMaxIter:         Max. number of iterations for orbit
+    omp_num_threads:    Default number of OpenMP threads
+"""

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -24,8 +24,8 @@ from .elements import Element
 
 Refpts = TypeVar("Refpts", int, Sequence[int], bool, Sequence[bool])
 ElementFilter = Callable[[Element], bool]
-BoolRefpts = Sequence[bool]
-Uint32Refpts = Sequence[numpy.uint32]
+BoolRefpts = numpy.ndarray
+Uint32Refpts = numpy.ndarray
 Key = Union[type, Element, str]
 
 

--- a/pyat/at/physics/amat.py
+++ b/pyat/at/physics/amat.py
@@ -77,7 +77,7 @@ def a_matrix(M):
         eigval: (m/2,)    Vector of Eigen values of T
 
     References:
-        Etienne Forest, Phys. Rev. E 58, 2481 – Published 1 August 1998
+        **[1]** Etienne Forest, Phys. Rev. E 58, 2481 – Published 1 August 1998
     """
     nv = M.shape[0]
     dms = int(nv / 2)
@@ -147,7 +147,7 @@ def symplectify(M):
         MS: Symplectic matrix
 
     References:
-        `W.W.MacKay, Comment on Healy's symplectification algorithm,
+        **[1]** `W.W.MacKay, Comment on Healy's symplectification algorithm,
         Proceedings of EPAC 2006
         <https://accelconf.web.cern.ch/e06/PAPERS/WEPCH152.PDF>`_
     """
@@ -175,7 +175,7 @@ def get_mode_matrices(A):
         R:
 
     References:
-        Andrzej Wolski, Phys. Rev. ST Accel. Beams 9, 024001 –
+        **[1]** Andrzej Wolski, Phys. Rev. ST Accel. Beams 9, 024001 –
         Published 3 February 2006
     """
 

--- a/pyat/at/physics/amat.py
+++ b/pyat/at/physics/amat.py
@@ -25,7 +25,7 @@ def jmat(ind):
         ind:    Matrix dimension: 1, 2 or 3
 
     Returns:
-            jm: Block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
+        S:      Block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
     """
     return _jm[ind - 1]
 
@@ -37,38 +37,58 @@ def jmatswap(ind):
     return _jmswap[ind - 1]
 
 
-def a_matrix(tt):
-    """Find the A matrix from one turn map matrix T
+# noinspection PyPep8Naming
+def a_matrix(M):
+    r"""Find the :math:`\mathbf{A}` matrix from one turn map :math:`\mathbf{M}`
 
-               [Rotx  0    0  ]
-    inv(A)*T*A=[ 0   Rotz  0  ]
-               [ 0    0   Rots]
+    :math:`\mathbf{A}` represents A change of referential which converts the
+    one-turn transfer matrix :math:`\mathbf{M}` into a set of rotations:
 
-    Order it so that it is close to the order of x,y,z
+    .. math:: \mathbf{M} = \mathbf{A} \cdot \mathbf{R} \cdot \mathbf{A}^{-1}
 
-    also ensure that positive modes are before negative so that
-    one has proper symplecticity
+    with :math:`\mathbf{R}` A block-diagonal matrix:
 
-    Author:
-    B. Nash July 18, 2013
+    .. math::
+
+        \mathbf{R}=\begin{pmatrix}rot_1 & 0 & 0 \\ 0 & rot_2 & 0 \\ 0 & 0 &
+        rot_3\end{pmatrix} \text{, and } rot_i = \begin{pmatrix}\cos{\mu_i} &
+        \sin{\mu_i} \\ -\sin{\mu_i} & cos{\mu_i}\end{pmatrix}
+
+    With radiation damping, the diagonal blocks are instead damped rotations:
+
+    .. math::
+
+        rot_i = \begin{pmatrix}\exp{(-\alpha_i}) & 0 \\ 0 & \exp{(-\alpha_i)}
+        \end{pmatrix} \cdot \begin{pmatrix}\cos{\mu_i} & \sin{\mu_i} \\
+        -\sin{\mu_i} & cos{\mu_i}\end{pmatrix}
+
+    The order of diagonal blocks it set so that it is close to the order of
+    x,y,z.
 
     Parameters:
-        tt:     (m, m)  transfer matrix for 1 turn
+        M:     (m, m)  transfer matrix for 1 turn
+
+    m, the dimension of :math:`\mathbf{M}`, may be 2 (single plane),
+    4 (betatron motion) or 6 (full motion)
+
 
     Returns:
-        aa:     (m, m)  A-matrix
-        eigval: (m,)    Vector of Eigen values of T
+        A:      (m, m)  A-matrix
+        eigval: (m/2,)    Vector of Eigen values of T
+
+    References:
+        Etienne Forest, Phys. Rev. E 58, 2481 – Published 1 August 1998
     """
-    nv = tt.shape[0]
+    nv = M.shape[0]
     dms = int(nv / 2)
     jmt = jmatswap(dms)
     select = numpy.arange(0, nv, 2)
     rbase = numpy.stack((select, select), axis=1).flatten()
 
     # noinspection PyTupleAssignmentBalance
-    lmbd, vv = eig(tt)
+    lmbd, vv = eig(M)
     # Compute the norms
-    vp = numpy.dot(vv.conj().T, jmt)
+    vp = vv.conj().T @ jmt
     n = -0.5j * numpy.sum(vp.T * vv, axis=0)
     if any(abs(n) < 1.0E-12):
         raise AtError('Unstable ring')
@@ -84,7 +104,7 @@ def a_matrix(tt):
     #  n1x n1y n1z
     #  n2x n2y n2z
     #  n3x n3y n3z
-    nn = 0.5 * abs(numpy.sqrt(-1.j * vn.conj().T.dot(jmt).dot(_vxyz[dms - 1])))
+    nn = 0.5 * abs(numpy.sqrt(-1.j * vn.conj().T @ jmt @ _vxyz[dms - 1]))
     rows = list(select)
     order = []
     for ixz in select:
@@ -98,114 +118,128 @@ def a_matrix(tt):
     return aa, lmbd
 
 
-def amat(tt):
+# noinspection PyPep8Naming
+def amat(M):
     """Find the A matrix from one turn map matrix T
 
-    Provided for backward compatibility, see " A, eigval = a_matrix(T)"
+    Provided for backward compatibility, see :py:func:`a_matrix`
 
     Parameters:
-        tt:     (m, m)  transfer matrix for 1 turn
+        M:     (m, m)  transfer matrix for 1 turn
 
     Returns:
-        aa:     (m, m)  A-matrix
+        A:     (m, m)  A-matrix
     """
-    aa, _ = a_matrix(tt)
+    aa, _ = a_matrix(M)
     return aa
 
 
 # noinspection PyPep8Naming
 def symplectify(M):
-    """Makes a matrix more symplectic
+    """Makes A matrix more symplectic
 
-    follow Healy algorithm as described by McKay
-    BNL-75461-2006-CP
+    following the Healy algorithm described by MacKay
 
     Parameters:
-        M:
+        M:  Almost symplectic matrix
 
     Returns:
         MS: Symplectic matrix
+
+    References:
+        `W.W.MacKay, Comment on Healy's symplectification algorithm,
+        Proceedings of EPAC 2006
+        <https://accelconf.web.cern.ch/e06/PAPERS/WEPCH152.PDF>`_
     """
     nv = M.shape[0]
-    J = jmat(nv // 2)
+    S = jmat(nv // 2)
+    I = numpy.identity(nv)
 
-    V = numpy.dot(J.dot(numpy.identity(nv) - M), inv(numpy.identity(nv) + M))
+    V = S @ (I - M) @ inv(I + M)
     # V should be almost symmetric.  Replace with symmetrized version.
-
     W = (V + V.T) / 2
     # Now reconstruct M from W
-    JW = numpy.dot(J, W)
-    MS = numpy.dot(numpy.identity(nv) + JW, inv(numpy.identity(nv) - JW))
+    SW = S @ W
+    MS = (I + SW) @ inv(I - SW)
     return MS
 
 
-def get_mode_matrices(a):
-    """Derive R-matrices from A-matrix
+# noinspection PyPep8Naming
+def get_mode_matrices(A):
+    """Derives the R-matrices from the A-matrix
 
     Parameters:
-        a:  A-matrix
+        A:  A-matrix
 
     Returns:
-        r:
+        R:
+
+    References:
+        Andrzej Wolski, Phys. Rev. ST Accel. Beams 9, 024001 –
+        Published 3 February 2006
     """
 
     def mul2(slc):
-        return a[:, slc] @ tt[slc, slc]
+        return A[:, slc] @ tt[slc, slc]
 
-    dms = a.shape[0] // 2
+    dms = A.shape[0] // 2
     # Rk = A * Ik * A.T                     Only for symplectic
-    # modelist = [numpy.dot(a[:, sl], a.T[sl, :]) for sl in _submat[:dms]]
+    # modelist = [numpy.dot(A[:, sl], A.T[sl, :]) for sl in _submat[:dms]]
     # Rk = A * S * Ik * inv(A) * S.T        Even for non-symplectic
     ss = jmat(dms)
     tt = jmatswap(dms)
     a_s = numpy.concatenate([mul2(slc) for slc in _submat[:dms]], axis=1)
-    inva = solve(a, ss.T)
+    inva = solve(A, ss.T)
     modelist = [a_s[:, sl] @ inva[sl, :] for sl in _submat[:dms]]
     return numpy.stack(modelist, axis=0)
 
 
-def get_tunes_damp(tt, rr=None):
-    """Compute Mode emittances, tunes and damping times
+# noinspection PyPep8Naming
+def get_tunes_damp(M, R=None):
+    r"""Computes the mode emittances, tunes and damping times
 
     Parameters:
-        tt:     (m, m) transfer matrix for 1 turn
-        rr:     (m, m) beam matrix (optional)
+        M:     (m, m) transfer matrix for 1 turn
+        R:     (m, m) beam matrix (optional), allows computing the mode
+                emittances
 
-        m can be 2 (single plane), 4 (betatron motion) or 6 (full motion)
+    m, the dimension of :math:`\mathbf{M}`, may be 2 (single plane),
+    4 (betatron motion) or 6 (full motion)
 
     Returns:
-        vv:     record array with the following fields:
+        V:     record array with the following fields:
 
           **tunes**             (m/2,) tunes of the m/2 normal modes
 
           **damping_rates**     (m/2,) damping rates of the m/2 normal modes
 
-          **mode_matrices**     (m/2, m, m) the R-matrices of the m/2 normal modes
+          **mode_matrices**     (m/2, m, m) the R-matrices of the m/2 normal
+          modes
 
           **mode_emittances**   Only if R is specified: (m/2,) emittance of each
-                            of the m/2 normal modes
+          of the m/2 normal modes
     """
-    nv = tt.shape[0]
+    nv = M.shape[0]
     dms = int(nv / 2)
-    aa, vps = a_matrix(tt)
+    A, vps = a_matrix(M)
     tunes = numpy.mod(numpy.angle(vps) / 2.0 / pi, 1.0)
     damping_rates = -numpy.log(numpy.absolute(vps))
 
-    if rr is None:
+    if R is None:
         return numpy.rec.fromarrays(
             (numpy.array(tunes), numpy.array(damping_rates),
-             numpy.array(get_mode_matrices(aa))),
+             numpy.array(get_mode_matrices(A))),
             dtype=[('tunes', numpy.float64, (dms,)),
                    ('damping_rates', numpy.float64, (dms,)),
                    ('mode_matrices', numpy.float64, (dms, nv, nv))]
         )
     else:
         jmt = jmat(dms)
-        rdiag = numpy.diag(aa.T.dot(jmt.dot(rr.dot(jmt.dot(aa)))))
+        rdiag = numpy.diag(A.T @ jmt @ R @ jmt @ A)
         mode_emit = -0.5 * (rdiag[0:nv:2] + rdiag[1:nv:2])
         return numpy.rec.fromarrays(
             (numpy.array(tunes), numpy.array(damping_rates),
-             numpy.array(get_mode_matrices(aa)), mode_emit),
+             numpy.array(get_mode_matrices(A)), mode_emit),
             dtype=[('tunes', numpy.float64, (dms,)),
                    ('damping_rates', numpy.float64, (dms,)),
                    ('mode_matrices', numpy.float64, (dms, nv, nv)),

--- a/pyat/at/physics/amat.py
+++ b/pyat/at/physics/amat.py
@@ -1,4 +1,4 @@
-""""""
+"""A-matrix construction"""
 import numpy
 from scipy.linalg import block_diag, eig, inv, solve
 from math import pi
@@ -19,43 +19,45 @@ _submat = [slice(0, 2), slice(2, 4), slice(4, 6)]
 
 
 def jmat(ind):
-    """
-    Return the antisymetric block diagonal matrix [[0, 1][-1, 0]]
+    """antisymetric block diagonal matrix [[0, 1][-1, 0]]
 
-    INPUT
-        ind     1, 2 or 3. Matrix dimension
+    Parameters:
+        ind:    Matrix dimension: 1, 2 or 3
 
-    OUTPUT
-        jm      block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
+    Returns:
+            jm: Block diagonal matrix, (2, 2) or (4, 4) or (6, 6)
     """
     return _jm[ind - 1]
 
 
 def jmatswap(ind):
-    """Modified version of jmat to deal with the swap of the
-    longitudinal coordinates"""
+    """Modified antisymetric block diagonal matrix to deal with the swap of the
+    longitudinal coordinates
+    """
     return _jmswap[ind - 1]
 
 
 def a_matrix(tt):
-    """A, eigval = a_matrix(T)
-    Find the A matrix from one turn map matrix T such that:
+    """Find the A matrix from one turn map matrix T
 
                [Rotx  0    0  ]
     inv(A)*T*A=[ 0   Rotz  0  ]
                [ 0    0   Rots]
 
     Order it so that it is close to the order of x,y,z
+
     also ensure that positive modes are before negative so that
     one has proper symplecticity
+
+    Author:
     B. Nash July 18, 2013
 
-    INPUT
-    T       (m, m)  transfer matrix for 1 turn
+    Parameters:
+        tt:     (m, m)  transfer matrix for 1 turn
 
-    OUTPUT
-    A       (m, m)  A-matrix
-    eigval  (m,)    vector of Eigen values of T
+    Returns:
+        aa:     (m, m)  A-matrix
+        eigval: (m,)    Vector of Eigen values of T
     """
     nv = tt.shape[0]
     dms = int(nv / 2)
@@ -97,15 +99,15 @@ def a_matrix(tt):
 
 
 def amat(tt):
-    """A = amat(T)
-    Find the A matrix from one turn map matrix T
+    """Find the A matrix from one turn map matrix T
+
     Provided for backward compatibility, see " A, eigval = a_matrix(T)"
 
-    INPUT
-    T       (m, m)  transfer matrix for 1 turn
+    Parameters:
+        tt:     (m, m)  transfer matrix for 1 turn
 
-    OUTPUT
-    A       (m, m)  A-matrix
+    Returns:
+        aa:     (m, m)  A-matrix
     """
     aa, _ = a_matrix(tt)
     return aa
@@ -113,10 +115,16 @@ def amat(tt):
 
 # noinspection PyPep8Naming
 def symplectify(M):
-    """
-    symplectify makes a matrix more symplectic
+    """Makes a matrix more symplectic
+
     follow Healy algorithm as described by McKay
     BNL-75461-2006-CP
+
+    Parameters:
+        M:
+
+    Returns:
+        MS: Symplectic matrix
     """
     nv = M.shape[0]
     J = jmat(nv // 2)
@@ -132,7 +140,14 @@ def symplectify(M):
 
 
 def get_mode_matrices(a):
-    """Given a (m, m) A matrix , find the R-matrices of the m/2 normal modes"""
+    """Derive R-matrices from A-matrix
+
+    Parameters:
+        a:  A-matrix
+
+    Returns:
+        r:
+    """
 
     def mul2(slc):
         return a[:, slc] @ tt[slc, slc]
@@ -150,21 +165,24 @@ def get_mode_matrices(a):
 
 
 def get_tunes_damp(tt, rr=None):
-    """
-    mode_emit, damping_rates, tunes = get_tunes_damp(T, R)
+    """Compute Mode emittances, tunes and damping times
 
-    INPUT
-        T                   (m, m) transfer matrix for 1 turn
-        R                   (m, m) beam matrix (optional)
+    Parameters:
+        tt:     (m, m) transfer matrix for 1 turn
+        rr:     (m, m) beam matrix (optional)
 
         m can be 2 (single plane), 4 (betatron motion) or 6 (full motion)
 
-    OUTPUT
-        record array with the following fields:
-        tunes               (m/2,) tunes of the m/2 normal modes
-        damping_rates       (m/2,) damping rates of the m/2 normal modes
-        mode_matrices       (m/2, m, m) the R-matrices of the m/2 normal modes
-        mode_emittances     Only if R is specified: (m/2,) emittance of each
+    Returns:
+        vv:     record array with the following fields:
+
+          **tunes**             (m/2,) tunes of the m/2 normal modes
+
+          **damping_rates**     (m/2,) damping rates of the m/2 normal modes
+
+          **mode_matrices**     (m/2, m, m) the R-matrices of the m/2 normal modes
+
+          **mode_emittances**   Only if R is specified: (m/2,) emittance of each
                             of the m/2 normal modes
     """
     nv = tt.shape[0]

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -1,12 +1,13 @@
 from enum import Enum
 from warnings import warn
 from math import pi
+from typing import Optional, Tuple
 import numpy
 from scipy.optimize import least_squares
-from at.lattice import Lattice, Dipole, Wiggler, RFCavity
+from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts
 from at.lattice import check_radiation, AtError
 from at.lattice import checktype, set_value_refpts, get_cells, refpts_len
-from at.lattice.constants import clight, Cgamma
+from at.constants import clight, Cgamma
 from at.tracking import lattice_pass
 
 __all__ = ['get_energy_loss', 'set_cavity_phase', 'ELossMethod',
@@ -14,25 +15,28 @@ __all__ = ['get_energy_loss', 'set_cavity_phase', 'ELossMethod',
 
 
 class ELossMethod(Enum):
-    """Enum class for energy loss methods"""
+    """methods for the computation of energy losses"""
+    #: The losses are obtained from
+    #: :math:`E_{loss}=C_\gamma/2\pi . E^4 . I_2`.
+    #: Takes into account bending magnets and wigglers.
     INTEGRAL = 1
+    #: The losses are obtained by tracking without cavities.
+    #: Needs radiation ON, takes into account all radiating elements
     TRACKING = 2
 
 
-def get_energy_loss(ring, method=ELossMethod.INTEGRAL):
-    """Compute the energy loss per turn [eV]
+def get_energy_loss(ring: Lattice,
+                    method: Optional[ELossMethod] = ELossMethod.INTEGRAL
+                    ) -> float:
+    """Computes the energy loss per turn
 
-    PARAMETERS
-        ring                        lattice description
+    Parameters:
+        ring:           Lattice description
+        method:         Method for energy loss computation.
+          See :py:class:`ELossMethod`.
 
-    KEYWORDS
-        method=ELossMethod.INTEGRAL method for energy loss computation
-            The enum class ELossMethod declares 2 values
-            INTEGRAL: The losses are obtained from
-                Losses = Cgamma / 2pi * EGeV^4 * i2
-                Takes into account bending magnets and wigglers.
-            TRACKING: The losses are obtained by tracking without cavities.
-                Needs radiation ON, takes into account all radiating elements.
+    Returns:
+        eloss (float):  Energy loss per turn [eV]
     """
 
     # noinspection PyShadowingNames
@@ -40,14 +44,14 @@ def get_energy_loss(ring, method=ELossMethod.INTEGRAL):
         """Losses = Cgamma / 2pi * EGeV^4 * i2
         """
 
-        def wiggler_i2(wiggler):
+        def wiggler_i2(wiggler: Wiggler):
             rhoinv = wiggler.Bmax / ring.BRho
             coefh = wiggler.By[1, :]
             coefv = wiggler.Bx[1, :]
             return wiggler.Length * (numpy.sum(coefh * coefh) + numpy.sum(
                 coefv*coefv)) * rhoinv ** 2 / 2
 
-        def dipole_i2(dipole):
+        def dipole_i2(dipole: Dipole):
             return dipole.BendingAngle ** 2 / dipole.Length
 
         i2 = 0.0
@@ -94,24 +98,24 @@ def get_energy_loss(ring, method=ELossMethod.INTEGRAL):
 
 
 # noinspection PyPep8Naming
-def get_timelag_fromU0(ring, method=ELossMethod.INTEGRAL, cavpts=None):
+def get_timelag_fromU0(ring: Lattice,
+                       method: Optional[ELossMethod] = ELossMethod.INTEGRAL,
+                       cavpts: Optional[Refpts] = None) -> Tuple[float, float]:
     """
     Get the TimeLag attribute of RF cavities based on frequency,
     voltage and energy loss per turn, so that the synchronous phase is zero.
     An error occurs if all cavities do not have the same frequency.
     Used in set_cavity_phase()
 
-    PARAMETERS
-        ring        lattice description
-
-    KEYWORDS
-        method=ELossMethod.INTEGRAL
-                    method for energy loss computation. See "get_energy_loss".
-        cavpts=None Cavity location. If None, use all cavities.
-                    This allows to ignore harmonic cavities.
-    RETURN
-        timelag     Timelag
-        ts          Time difference with the present value
+    Parameters:
+        ring:               Lattice description
+        method:             Method for energy loss computation.
+          See :py:class:`ELossMethod`.
+        cavpts:             Cavity location. If None, use all cavities.
+          This allows to ignore harmonic cavities.
+    Returns:
+        timelag (float):    Timelag
+        ts (float):         Time difference with the present value
     """
     def singlev(values):
         vals = numpy.unique(values)
@@ -158,27 +162,28 @@ def get_timelag_fromU0(ring, method=ELossMethod.INTEGRAL, cavpts=None):
     return timelag, ts
 
 
-def set_cavity_phase(ring, method=ELossMethod.TRACKING,
-                     refpts=None, cavpts=None, copy=False):
+def set_cavity_phase(ring: Lattice,
+                     method=ELossMethod.TRACKING,
+                     refpts: Optional[Refpts] = None,
+                     cavpts: Optional[Refpts] = None,
+                     copy: Optional[bool] = False) -> None:
     """
-   Adjust the TimeLag attribute of RF cavities based on frequency,
-   voltage and energy loss per turn, so that the synchronous phase is zero.
-   An error occurs if all cavities do not have the same frequency.
+    Adjust the TimeLag attribute of RF cavities based on frequency,
+    voltage and energy loss per turn, so that the synchronous phase is zero.
+    An error occurs if all cavities do not have the same frequency.
 
-   !!!!WARNING!!!: This function changes the time reference,
-   this should be avoided
+    .. Warning::
 
-    PARAMETERS
-        ring        lattice description
+       This function changes the time reference, this should be avoided
 
-    KEYWORDS
-        method=ELossMethod.INTEGRAL
-                            method for energy loss computation.
-                            See "get_energy_loss".
-        cavpts=None         Cavity location. If None, use all cavities.
-                            This allows to ignore harmonic cavities.
-        copy=False          If True, returns a shallow copy of ring with new
-                            cavity elements. Otherwise, modify ring in-place.
+    Parameters:
+        ring:       Lattice description
+        method:     Method for energy loss computation.
+          See :py:class:`ELossMethod`.
+        cavpts:     Cavity location. If None, use all cavities.
+          This allows to ignore harmonic cavities.
+        copy:       If True, returns a shallow copy of ring with new
+          cavity elements. Otherwise, modify ring in-place.
     """
     # refpts is kept for backward compatibility
     if cavpts is None and refpts is not None:

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -495,11 +495,12 @@ def linopt2(ring: Lattice, *args, **kwargs):
                         to the entrance of the element [2]_
     **closed_orbit**    (6,) closed orbit vector
     **dispersion**      (4,) dispersion vector
-    **beta**            [betax, betay] vector
-    **alpha**           [alphax, alphay] vector
-    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
-    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
-                        chromatic amplitude function
+    **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
+    **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
+    **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
+                        (modulo :math:`2\pi`)
+    **W**               :math:`\left[ W_x,W_y \right]` only if ``get_w``
+                        is :py:obj:`True`: chromatic amplitude function
     ================    ===================================================
 
     All values given at the entrance of each element specified in refpts.
@@ -590,13 +591,14 @@ def linopt4(ring: Lattice, *args, **kwargs):
                         to the entrance of the element [6]_
     **closed_orbit**    (6,) closed orbit vector
     **dispersion**      (4,) dispersion vector
-    **beta**            [betax, betay] vector
-    **alpha**           [alphax, alphay] vector
-    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
+    **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
+    **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
+    **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
+                        (modulo :math:`2\pi`)
     **gamma**           gamma parameter of the transformation to
                         eigenmodes [7]_
-    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
-                        chromatic amplitude function
+    **W**               :math:`\left[ W_x,W_y \right]` only if ``get_w``
+                        is :py:obj:`True`: chromatic amplitude function
     ================    ===================================================
 
     All values given at the entrance of each element specified in refpts.
@@ -625,7 +627,7 @@ def linopt4(ring: Lattice, *args, **kwargs):
     return _linopt(ring, _analyze4, *args, **kwargs)
 
 
-def linopt6(ring, *args, **kwargs):
+def linopt6(ring: Lattice, *args, **kwargs):
     r"""Linear analysis of a fully coupled lattice using normal modes
 
     For circular machines, :py:func:`linopt6` analyses
@@ -700,11 +702,12 @@ def linopt6(ring, *args, **kwargs):
     **dispersion**      (4,) dispersion vector
     **A**               (6,6) A-matrix
     **R**               (3, 6, 6) R-matrices
-    **beta**            [betax, betay] vector
-    **alpha**           [alphax, alphay] vector
-    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
-    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
-                        chromatic amplitude function
+    **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
+    **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
+    **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
+                        (modulo :math:`2\pi`)
+    **W**               :math:`\left[ W_x,W_y \right]` only if ``get_w``
+                        is :py:obj:`True`: chromatic amplitude function
     ================    ===================================================
 
     All values given at the entrance of each element specified in refpts.
@@ -838,7 +841,7 @@ def get_optics(ring: Lattice, refpts: Optional[Refpts] = None,
 @check_radiation(False)
 def linopt(ring: Lattice, dp: Optional[float] = 0.0,
            refpts: Optional[Refpts] = None,
-           get_chrom: Optional[Refpts] = False, **kwargs):
+           get_chrom: Optional[bool] = False, **kwargs):
     """Linear analysis of a H/V coupled lattice (deprecated)
 
     PARAMETERS
@@ -924,7 +927,7 @@ def linopt(ring: Lattice, dp: Optional[float] = 0.0,
 @check_radiation(False)
 def avlinopt(ring: Lattice, dp: Optional[float] = 0.0,
              refpts: Optional[Refpts] = None, **kwargs):
-    """Linear analysis of a lattice with average values
+    r"""Linear analysis of a lattice with average values
 
     :py:func:`avlinopt` returns average beta, mu, dispersion over the lattice
     elements.
@@ -974,13 +977,16 @@ def avlinopt(ring: Lattice, dp: Optional[float] = 0.0,
     Returns:
         elemdata:   Linear optics at the points refered to by ``refpts``,
           if refpts is :py:obj:`None` an empty lindata structure is returned.
-        avebeta:    Average beta functions [betax,betay] at ``refpts``
-        avemu:      Average phase advances [mux,muy] at ``refpts``
-        avedisp:    Average dispersion [Dx,Dx',Dy,Dy'] at ``refpts``
+        avebeta:    Average beta functions [:math:`\hat{\beta_x},\hat{\beta_y}`]
+          at ``refpts``
+        avemu:      Average phase advances [:math:`\hat{\mu_x},\hat{\mu_y}`]
+          at ``refpts``
+        avedisp:    Average dispersion [:math:`\hat{\eta_x}, \hat{\eta'_x},
+          \hat{\eta_y}, \hat{\eta'_y}`] at ``refpts``
         avespos:    Average s position at ``refpts``
-        tune:       [tune_A, tune_B], linear tunes for the two normal modes
-          of linear motion [1]
-        chrom:      [ksi_A , ksi_B], chromaticities
+        tune:       [:math:`\nu_1,\nu_2`], linear tunes for the two normal
+          modes of linear motion [1]
+        chrom:      [:math:`\xi_1,\xi_2`], chromaticities
 
     See also:
         :py:func:`linopt4`, :py:func:`get_optics`
@@ -1054,7 +1060,7 @@ def avlinopt(ring: Lattice, dp: Optional[float] = 0.0,
 def get_tune(ring: Lattice, method: Optional[str] = 'linopt',
              dp: Optional[float] = None, dct: Optional[float] = None,
              orbit: Optional[Orbit] = None, **kwargs):
-    """Computes the tunes using several available methods
+    r"""Computes the tunes using several available methods
 
     Parameters:
         ring:       Lattice description.
@@ -1087,7 +1093,7 @@ def get_tune(ring: Lattice, method: Optional[str] = 'linopt',
           Default: :py:obj:`False`
 
     Returns:
-        tunes (ndarray):                array([Qx,Qy])
+        tunes (ndarray):                array([:math:`\nu_x,\nu_y`])
     """
     # noinspection PyShadowingNames
     def gen_centroid(ring, ampl, nturns, remove_dc, ld):
@@ -1116,9 +1122,9 @@ def get_tune(ring: Lattice, method: Optional[str] = 'linopt',
 
 
 def get_chrom(ring: Lattice, method: Optional[str] = 'linopt',
-              dp: Optional[float] = None, dct: Optional[float] = None,
-              cavpts=None, **kwargs):
-    """Computes the chromaticities using several available methods
+              dp: Optional[float] = 0, dct: Optional[float] = None,
+              cavpts: Optional[Refpts] = None, **kwargs):
+    r"""Computes the chromaticities using several available methods
 
     Parameters:
         ring:       Lattice description.
@@ -1156,7 +1162,7 @@ def get_chrom(ring: Lattice, method: Optional[str] = 'linopt',
           Default: :py:obj:`False`
 
     Returns:
-        chromaticities (ndarray):       array([Q'x,Q'y])
+        chromaticities (ndarray):       array([:math:`\xi_x,\xi_y`])
     """
 
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -3,13 +3,14 @@ Coupled or non-coupled 4x4 linear motion
 """
 import numpy
 from math import sqrt, pi, sin, cos, atan2
+from typing import Optional, Callable
 import warnings
 from scipy.linalg import solve
-from ..lattice.constants import clight
-from ..lattice import DConstant, get_s_pos
+from ..constants import clight
+from ..lattice import DConstant, get_s_pos, Refpts
 from ..lattice import AtWarning, Lattice, check_radiation
 from ..tracking import lattice_pass
-from .orbit import find_orbit4, find_orbit6
+from .orbit import Orbit, find_orbit4, find_orbit6
 from .matrix import find_m44, find_m66
 from .amat import a_matrix, jmat, jmatswap
 from .harmonic_analysis import get_tunes_harmonic
@@ -244,7 +245,7 @@ def _analyze6(mt, ms):
 
 
 # noinspection PyShadowingNames,PyPep8Naming
-def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
+def _linopt(ring: Lattice, analyze, refpts=None, dp=None, dct=None, orbit=None,
             twiss_in=None, get_chrom=False, get_w=False, keep_lattice=False,
             mname='M', add0=(), adds=(), cavpts=None, **kwargs):
     """"""
@@ -435,259 +436,324 @@ def _linopt(ring, analyze, refpts=None, dp=None, dct=None, orbit=None,
 
 
 @check_radiation(False)
-def linopt2(ring, *args, **kwargs):
-    """Perform linear analysis of an uncoupled lattice
+def linopt2(ring: Lattice, *args, **kwargs):
+    r"""Linear analysis of an uncoupled lattice
 
-    elemdata0, beamdata, elemdata = linopt2(ring, refpts, **kwargs)
+    Parameters:
+        ring:   Lattice description.
 
-    PARAMETERS
-        lattice         lattice description.
-        refpts=None     elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-    KEYWORDS
-        dp=0.0          momentum deviation.
-        dct=None        path lengthening. If specified, dp is ignored and the
-                        off-momentum is deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        get_chrom=False compute chromaticities. Needs computing the tune at
-                        2 different momentum deviations around the central one.
-        get_w=False     computes chromatic amplitude functions (W) [4].
-                        Needs to compute the optics at 2 different momentum
-                        deviations around the central one.
-        keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
-        XYStep=1.0e-8   transverse step for numerical computation
-        DPStep=1.0E-6   momentum deviation used for computation of
-                        chromaticities and dispersion
-        twiss_in=None   Initial conditions for transfer line optics. Record
-                        array as output by linopt, or dictionary. Keys:
-                        'alpha' and 'beta'  (mandatory)
-                        'closed_orbit',     (default 0)
-                        'dispersion'        (default 0)
-                        All other attributes are ignored.
-    OUTPUT
-        lindata0        linear optics data at the entrance of the ring
-        beamdata        lattice properties
-        lindata         linear optics at the points refered to by refpts, if
-                        refpts is None an empty lindata structure is returned.
+    Keyword Args:
+        refpts (Optional[Refpts]): Elements at which data is returned.
+          It can be:
 
-        lindata is a record array with fields:
-        s_pos           longitudinal position [m]
-        M               (4, 4) transfer matrix M from the beginning of ring
-                        to the entrance of the element [2]
-        closed_orbit    (6,) closed orbit vector
-        dispersion      (4,) dispersion vector
-        beta            [betax, betay] vector
-        alpha           [alphax, alphay] vector
-        mu              [mux, muy], betatron phase (modulo 2*pi)
-        W               (2,) chromatic amplitude function (only if get_w==True)
-        All values given at the entrance of each element specified in refpts.
-        Field values can be obtained with either
-        lindata['idx']    or
-        lindata.idx
+          1. an integer in the range [-len(ring), len(ring)-1]
+             selecting the element according to python indexing rules.
+             As a special case, len(ring) is allowed and refers to the end
+             of the last element,
+          2. an ordered list of such integers without duplicates,
+          3. a numpy array of booleans of maximum length len(ring)+1,
+             where selected elements are :py:obj:`True`.
+        dp (Optional[float]):   Momentum deviation.
+        dct (Optional[float]):  Path lengthening. If specified, ``dp`` is
+          ignored and the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
+        get_chrom (Optional[bool]): Compute chromaticities. Needs computing
+          the tune at 2 different momentum deviations around the central one.
+        get_w (Optional[bool]):     Computes chromatic amplitude functions
+          (W) [4]_. Needs to compute the optics at 2 different momentum
+          deviations around the central one.
+        keep_lattice (Optional[bool]):   Assume no lattice change since the
+          previous tracking. Defaults to :py:obj:`False`
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+        twiss_in:       Initial conditions for transfer line optics. Record
+          array as output by :py:func:`linopt2`, or dictionary. Keys:
 
-        beamdata is a record with fields:
-        tune            Fractional tunes
-        chromaticity    Chromaticities, only computed if get_chrom=True
+          alpha, beta
+            mandatory (2,) arrays
+          closed_orbit
+            Optional (6,) array, default 0
+          dispersion
+            Optional (6,) array, default 0
 
-    REFERENCES
-        [1] D.Edwards,L.Teng IEEE Trans.Nucl.Sci. NS-20, No.3, p.885-888, 1973
-        [2] E.Courant, H.Snyder
-        [3] D.Sagan, D.Rubin Phys.Rev.Spec.Top.-Accelerators and beams,
-            vol.2 (1999)
-        [4] Brian W. Montague Report LEP Note 165, CERN, 1979
+          All other attributes are ignored.
+
+    Returns:
+        elemdata0:      Linear optics data at the entrance of the ring
+        ringdata:       Lattice properties
+        elemdata:       Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+
+    **elemdata** is a record array with fields:
+
+    ================    ===================================================
+    **s_pos**           longitudinal position [m]
+    **M**               (4, 4) transfer matrix M from the beginning of ring
+                        to the entrance of the element [2]_
+    **closed_orbit**    (6,) closed orbit vector
+    **dispersion**      (4,) dispersion vector
+    **beta**            [betax, betay] vector
+    **alpha**           [alphax, alphay] vector
+    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
+    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
+                        chromatic amplitude function
+    ================    ===================================================
+
+    All values given at the entrance of each element specified in refpts.
+    Field values can be obtained with either
+    ``lindata['idx']`` or ``lindata.idx``
+
+    **ringdata** is a record array with fields:
+
+    =================   ======
+    **tune**            Fractional tunes
+    **chromaticity**    Chromaticities, only computed if get_chrom is
+                        :py:obj:`True`
+    =================   ======
+
+    References:
+        **[1]** D.Edwards,L.Teng IEEE Trans.Nucl.Sci. NS-20, No.3, p.885-888
+        , 1973
+
+        .. [2] E.Courant, H.Snyder
+
+        **[3]** D.Sagan, D.Rubin Phys.Rev.Spec.Top.-Accelerators and beams,
+        vol.2 (1999)
+
+        .. [4] Brian W. Montague Report LEP Note 165, CERN, 1979
     """
     return _linopt(ring, _analyze2, *args, **kwargs)
 
 
 @check_radiation(False)
-def linopt4(ring, *args, **kwargs):
-    """Perform linear analysis of a H/V coupled lattice following Sagan/Rubin
-    4D-analysis of coupled motion
+def linopt4(ring: Lattice, *args, **kwargs):
+    r"""Linear analysis of a H/V coupled lattice
 
-    elemdata0, beamdata, elemdata = linopt4(lattice, refpts, **kwargs)
+    4D-analysis of coupled motion following Sagan/Rubin
 
-    PARAMETERS
-        lattice         lattice description.
-        refpts=None     elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-    KEYWORDS
-        dp=0.0          momentum deviation.
-        dct=None        path lengthening. If specified, dp is ignored and the
-                        off-momentum is deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        get_chrom=False compute chromaticities. Needs computing the tune at
-                        2 different momentum deviations around the central one.
-        get_w=False     computes chromatic amplitude functions (W) [4].
-                        Needs to compute the optics at 2 different momentum
-                        deviations around the central one.
-        keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
-        XYStep=1.0e-8   transverse step for numerical computation
-        DPStep=1.0E-6   momentum deviation used for computation of
-                        chromaticities and dispersion
-        twiss_in=None   Initial twiss to compute transfer line optics of the
-                        type lindata, the initial orbit in twiss_in is ignored,
-                        only the beta and alpha are required other quatities
-                        set to 0 if absent
-        twiss_in=None   Initial conditions for transfer line optics. Record
-                        array as output by linopt, or dictionary. Keys:
-                        'alpha' and 'beta'  (mandatory)
-                        'closed_orbit',     (default 0)
-                        'dispersion'        (default 0)
-                        All other attributes are ignored.
-    OUTPUT
-        lindata0        linear optics data at the entrance of the ring
-        beamdata        lattice properties
-        lindata         linear optics at the points refered to by refpts, if
-                        refpts is None an empty lindata structure is returned.
+    Parameters:
+        ring:   Lattice description.
 
-        lindata is a record array with fields:
-        s_pos           longitudinal position [m]
-        M               (4, 4) transfer matrix M from the beginning of ring
-                        to the entrance of the element [2]
-        closed_orbit    (6,) closed orbit vector
-        dispersion      (4,) dispersion vector
-        beta            [betax, betay] vector
-        alpha           [alphax, alphay] vector
-        mu              [mux, muy], betatron phase (modulo 2*pi)
-        gamma           gamma parameter of the transformation to eigenmodes [3]
-        W               (2,) chromatic amplitude function (only if get_w==True)
-        All values given at the entrance of each element specified in refpts.
-        Field values can be obtained with either
-        lindata['idx']    or
-        lindata.idx
+    Keyword Args:
+        refpts (Optional[Refpts]): Elements at which data is returned.
+          It can be:
 
-        beamdata is a record with fields:
-        tune            Fractional tunes
-        chromaticity    Chromaticities, only computed if get_chrom==True
+          1. an integer in the range [-len(ring), len(ring)-1]
+             selecting the element according to python indexing rules.
+             As a special case, len(ring) is allowed and refers to the end
+             of the last element,
+          2. an ordered list of such integers without duplicates,
+          3. a numpy array of booleans of maximum length len(ring)+1,
+             where selected elements are :py:obj:`True`.
+        dp (Optional[float]):   Momentum deviation.
+        dct (Optional[float]):  Path lengthening. If specified, ``dp`` is
+          ignored and the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
+        get_chrom (Optional[bool]): Compute chromaticities. Needs computing
+          the tune at 2 different momentum deviations around the central one.
+        get_w (Optional[bool]):     Computes chromatic amplitude functions
+          (W) [8]_. Needs to compute the optics at 2 different momentum
+          deviations around the central one.
+        keep_lattice (Optional[bool]):   Assume no lattice change since the
+          previous tracking. Defaults to :py:obj:`False`
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+        twiss_in:       Initial conditions for transfer line optics. Record
+          array as output by :py:func:`linopt2`, or dictionary. Keys:
 
-    REFERENCES
-        [1] D.Edwards,L.Teng IEEE Trans.Nucl.Sci. NS-20, No.3, p.885-888, 1973
-        [2] E.Courant, H.Snyder
-        [3] D.Sagan, D.Rubin Phys.Rev.Spec.Top.-Accelerators and beams,
-            vol.2 (1999)
-        [4] Brian W. Montague Report LEP Note 165, CERN, 1979
+          alpha, beta
+            mandatory (2,) arrays
+          closed_orbit
+            Optional (6,) array, default 0
+          dispersion
+            Optional (6,) array, default 0
+
+          All other attributes are ignored.
+
+    Returns:
+        elemdata0:      Linear optics data at the entrance of the ring
+        ringdata:       Lattice properties
+        elemdata:       Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+
+    **elemdata** is a record array with fields:
+
+    ================    ===================================================
+    **s_pos**           longitudinal position [m]
+    **M**               (4, 4) transfer matrix M from the beginning of ring
+                        to the entrance of the element [6]_
+    **closed_orbit**    (6,) closed orbit vector
+    **dispersion**      (4,) dispersion vector
+    **beta**            [betax, betay] vector
+    **alpha**           [alphax, alphay] vector
+    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
+    **gamma**           gamma parameter of the transformation to
+                        eigenmodes [7]_
+    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
+                        chromatic amplitude function
+    ================    ===================================================
+
+    All values given at the entrance of each element specified in refpts.
+    Field values can be obtained with either
+    ``lindata['idx']`` or ``lindata.idx``
+
+    **ringdata** is a record array with fields:
+
+    =================   ======
+    **tune**            Fractional tunes
+    **chromaticity**    Chromaticities, only computed if get_chrom is
+                        :py:obj:`True`
+    =================   ======
+
+    References:
+        **[5]** D.Edwards,L.Teng IEEE Trans.Nucl.Sci. NS-20, No.3, p.885-888
+        , 1973
+
+        .. [6] E.Courant, H.Snyder
+
+        .. [7] D.Sagan, D.Rubin Phys.Rev.Spec.Top.-Accelerators and beams,
+           vol.2 (1999)
+
+        .. [8] Brian W. Montague Report LEP Note 165, CERN, 1979
     """
     return _linopt(ring, _analyze4, *args, **kwargs)
 
 
 def linopt6(ring, *args, **kwargs):
-    """Perform linear analysis of a fully coupled lattice using normal modes
+    r"""Linear analysis of a fully coupled lattice using normal modes
 
-    elemdata0, beamdata, elemdata = linopt6(lattice, refpts, **kwargs)
+    For circular machines, :py:func:`linopt6` analyses
 
-    For circular machines, linopt6 analyses
-    the 4x4 1-turn transfer matrix if radiation is OFF, or
-    the 6x6 1-turn transfer matrix if radiation is ON.
+    * the 4x4 1-turn transfer matrix if radiation is OFF, or
+    * the 6x6 1-turn transfer matrix if radiation is ON.
 
     For a transfer line, The "twiss_in" intput must contain either:
-     - a field 'R', as provided by ATLINOPT6, or
-      - the fields 'beta' and 'alpha', as provided by linopt and linopt6
 
-    PARAMETERS
-        lattice         lattice description.
-        refpts=None     elements at which data is returned.
+    *  a field **R**, as provided by ATLINOPT6, or
+    * the fields **beta** and **alpha**, as provided by linopt and linopt6
 
-    KEYWORDS
-        dp=None         Ignored if radiation is ON. Momentum deviation.
-        dct=None        Ignored if radiation is ON. Path lengthening.
-                        If specified, dp is ignored and the off-momentum is
-                        deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        get_chrom=False compute chromaticities. Needs computing the tune at
-                        2 different momentum deviations around the central one.
-        get_w=False     compute chromatic amplitude functions (W) [3]. Needs to
-                        compute the optics at 2 different momentum deviations
-                        around the central one.
-        keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
-        XYStep=1.0e-8   transverse step for numerical computation
-        DPStep=1.0E-6   momentum deviation used for computation of
-                        the closed orbit
-        twiss_in=None   Initial conditions for transfer line optics. Record
-                        array as output by linopt, or dictionary. Keys:
-                        'R' or 'alpha' and 'beta'   (mandatory)
-                        'closed_orbit',             (default 0)
-                        'dispersion'                (default 0)
-                        If present, the attribute 'R' will be used, otherwise
-                        the attributes 'alpha' and 'beta' will be used. All
-                        other attributes are ignored.
-        cavpts=None     Cavity location for off-momentum tuning
+    Parameters:
+        ring:   Lattice description.
 
-    OUTPUT
-        elemdata0       linear optics data at the entrance of the ring
-        beamdata        lattice properties
-        elemdata        linear optics at the points refered to by refpts, if
-                        refpts is None an empty elemdata structure is returned.
+    Keyword Args:
+        refpts (Optional[Refpts]): Elements at which data is returned.
+          It can be:
 
-        elemdata is a record array with fields:
-        s_pos           longitudinal position [m]
-        M               Transfer matrix from the entrance of the line (6, 6)
-        closed_orbit    (6,) closed orbit vector
-        dispersion      (4,) dispersion vector
-        A               A-matrix (6, 6)
-        R               R-matrices (3, 6, 6)
-        beta            [betax, betay] vector
-        alpha           [alphax, alphay] vector
-        mu              [mux, muy], betatron phases
-        W               (2,) chromatic amplitude function (only if get_w==True)
+          1. an integer in the range [-len(ring), len(ring)-1]
+             selecting the element according to python indexing rules.
+             As a special case, len(ring) is allowed and refers to the end
+             of the last element,
+          2. an ordered list of such integers without duplicates,
+          3. a numpy array of booleans of maximum length len(ring)+1,
+             where selected elements are :py:obj:`True`.
+        dp (Optional[float]):   Momentum deviation.
+        dct (Optional[float]):  Path lengthening. If specified, ``dp`` is
+          ignored and the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
+        get_chrom (Optional[bool]): Compute chromaticities. Needs computing
+          the tune at 2 different momentum deviations around the central one.
+        get_w (Optional[bool]):     Computes chromatic amplitude functions
+          (W) [11]_. Needs to compute the optics at 2 different momentum
+          deviations around the central one.
+        keep_lattice (Optional[bool]):   Assume no lattice change since the
+          previous tracking. Defaults to :py:obj:`False`
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+        twiss_in:       Initial conditions for transfer line optics. Record
+          array as output by :py:func:`linopt2`, :py:func:`linopt6`, or
+          dictionary. Keys:
 
-        All values given at the entrance of each element specified in refpts.
-        Field values can be obtained with either
-        elemdata['beta']    or
-        elemdata.beta
+          R or alpha, beta
+            mandatory
+          closed_orbit
+            Optional (6,) array, default 0
+          dispersion
+            Optional (6,) array, default 0
 
-        beamdata is a record with fields:
-        tune            Fractional tunes
-        chromaticity    Chromaticities, only computed if get_chrom==True
-        damping_time    Damping times [s] (only if radiation is ON)
+          If present, the attribute **R**' will be used, otherwise the
+          attributes **alpha** and **beta** will be used. All other attributes
+          are ignored.
+        cavpts (Optional[Refpts]):  Cavity location for off-momentum tuning
 
-    REFERENCES
-        [1] Etienne Forest, Phys. Rev. E 58, 2481 – Published 1 August 1998
-        [2] Andrzej Wolski, Phys. Rev. ST Accel. Beams 9, 024001 –
-            Published 3 February 2006
-        [3] Brian W. Montague Report LEP Note 165, CERN, 1979
+    Returns:
+        elemdata0:      Linear optics data at the entrance of the ring
+        ringdata:       Lattice properties
+        elemdata:       Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+
+    **elemdata** is a record array with fields:
+
+    ================    ===================================================
+    **s_pos**           longitudinal position [m]
+    **M**               (6, 6) transfer matrix M from the beginning of ring
+                        to the entrance of the element
+    **closed_orbit**    (6,) closed orbit vector
+    **dispersion**      (4,) dispersion vector
+    **A**               (6,6) A-matrix
+    **R**               (3, 6, 6) R-matrices
+    **beta**            [betax, betay] vector
+    **alpha**           [alphax, alphay] vector
+    **mu**              [mux, muy], betatron phase (modulo :math:`2\pi`)
+    **W**               [Wx, Wy] only if ``get_w`` is :py:obj:`True`:
+                        chromatic amplitude function
+    ================    ===================================================
+
+    All values given at the entrance of each element specified in refpts.
+    Field values can be obtained with either
+    ``lindata['idx']`` or ``lindata.idx``
+
+    **ringdata** is a record array with fields:
+
+    =================   ======
+    **tune**            Fractional tunes
+    **chromaticity**    Chromaticities, only computed if get_chrom is
+                        :py:obj:`True`
+    **damping_time**    Damping times [s] (only if radiation is ON)
+    =================   ======
+
+    References:
+        **[9]** Etienne Forest, Phys. Rev. E 58, 2481 – Published 1 August 1998
+
+        **[10]** Andrzej Wolski, Phys. Rev. ST Accel. Beams 9, 024001 –
+        Published 3 February 2006
+
+        .. [11] Brian W. Montague Report LEP Note 165, CERN, 1979
     """
     return _linopt(ring, _analyze6, *args, **kwargs)
 
 
-def linopt_auto(ring, *args, **kwargs):
+def linopt_auto(ring: Lattice, *args, **kwargs):
     """
     This is a convenience function to automatically switch to the faster
-    linopt2 in case coupled=False and ring.radiation=False otherwise the
-    default linopt6 is used
+    :py:func:`linopt2` in case coupled=:py:obj:`False` **and**
+    ring.radiation=:py:obj:`False`. Otherwise the default :py:func:`linopt6`
+    is used
 
-    PARAMETERS
-        Same as linopt2 or linopt6
+    Parameters: Same as linopt2 or linopt6
 
-    KEYWORDS
-        coupled = True  If set to False H/V coupling will be ingnored to
-                        simplify the calculation, needs radiation OFF
+    Keyword Args;
+        coupled 5Optional[bool]):   If set to :py:obj:`False`, H/V coupling
+          will be ingnored to simplify the calculation, needs radiation OFF
 
-    OUTPUT
-        elemdata0       linear optics data at the entrance of the ring
-        beamdata        lattice properties
-        elemdata        linear optics at the points refered to by refpts, if
-                        refpts is None an empty elemdata structure is returned.
 
-    !!!WARNING!!!       Output varies depending whether linopt2 or linopt6 is
-                        called to be used with care
+    Returns:
+        elemdata0:      Linear optics data at the entrance of the ring
+        ringdata:       Lattice properties
+        elemdata:       Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+
+    Warning:
+        The output varies depending whether :py:func:`linopt2` or
+        :py:func:`linopt6` is called. To be used with care!
     """
     if not (kwargs.pop('coupled', True) or ring.radiation):
         return linopt2(ring, *args, **kwargs)
@@ -695,75 +761,85 @@ def linopt_auto(ring, *args, **kwargs):
         return linopt6(ring, *args, **kwargs)
 
 
-def get_optics(ring, refpts=None, dp=None, method=linopt6, **kwargs):
-    """Perform linear analysis of a fully coupled lattice
+def get_optics(ring: Lattice, refpts: Optional[Refpts] = None,
+               dp: Optional[float] = None,
+               method: Optional[Callable] = linopt6,
+               **kwargs):
+    """Linear analysis of a fully coupled lattice
 
-    elemdata0, beamdata, elemdata = get_optics(lattice, refpts, **kwargs)
+    Parameters:
+        ring:   Lattice description.
+        refpts (Optional[Refpts]): Elements at which data is returned.
+          It can be:
 
-    PARAMETERS
-        lattice         lattice description.
-        refpts=None     elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-    KEYWORDS
-        method=linopt6  Method used for the analysis of the transfer matrix.
-                        Can be None at.linopt2, at.linopt4, at.linopt6
-                        linopt2:    no longitudinal motion, no H/V coupling,
-                        linopt4:    no longitudinal motion, Sagan/Rubin
-                                    4D-analysis of coupled motion,
-                        linopt6:    with or without longitudinal motion, normal
-                                    mode analysis
-        dp=None         Ignored if radiation is ON. Momentum deviation.
-        dct=None        Ignored if radiation is ON. Path lengthening.
-                        If specified, dp is ignored and the off-momentum is
-                        deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        get_chrom=False compute chromaticities. Needs computing the tune at
-                        2 different momentum deviations around the central one.
-        get_w=False     computes chromatic amplitude functions (W) [4].
-                        Needs to compute the optics at 2 different momentum
-                        deviations around the central one.
-        keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
-        twiss_in=None   Initial conditions for transfer line optics. Record
-                        array as output by linopt, or dictionary. Keys:
-                        'R' or 'alpha' and 'beta'   (mandatory)
-                        'closed_orbit',             (default 0)
-                        'dispersion'                (default 0)
-                        If present, the attribute 'R' will be used, otherwise
-                        the attributes 'alpha' and 'beta' will be used. All
-                        other attributes are ignored.
-    OUTPUT
-        elemdata0       linear optics data at the entrance/end of the ring
-        beamdata        lattice properties
-        elemdata        linear optics at the points refered to by refpts, if
-                        refpts is None an empty elemdata structure is returned.
+          1. an integer in the range [-len(ring), len(ring)-1]
+             selecting the element according to python indexing rules.
+             As a special case, len(ring) is allowed and refers to the end
+             of the last element,
+          2. an ordered list of such integers without duplicates,
+          3. a numpy array of booleans of maximum length len(ring)+1,
+             where selected elements are :py:obj:`True`.
+        dp (Optional[float]):   Momentum deviation.
+        method (Optional[Callable]):  Method used for the analysis of the
+          transfer matrix. Can be ``at.linopt2``, ``at.linopt4``, ``at.linopt6``
 
-        elemdata is a record array with fields depending on the
-        selected method.
-        See the help for linopt6, linopt4, linopt2, linopt_auto.
+          linopt2
+            no longitudinal motion, no H/V coupling,
+          linopt4
+            no longitudinal motion, Sagan/Rubin 4D-analysis of coupled motion,
+          linopt6 (default)
+            with or without longitudinal motion, normal mode analysis
 
-        beamdata is a record with fields:
-        tune            Fractional tunes
-        chromaticity    Chromaticities
-        damping_time    Damping times [s] (only if radiation is ON)
+    Keyword Args:
+        dct (Optional[float]):  Path lengthening. If specified, ``dp`` is
+          ignored and the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
+        get_chrom (Optional[bool]): Compute chromaticities. Needs computing
+          the tune at 2 different momentum deviations around the central one.
+        get_w (Optional[bool]):     Computes chromatic amplitude functions
+          (W) [11]_. Needs to compute the optics at 2 different momentum
+          deviations around the central one.
+        keep_lattice (Optional[bool]):   Assume no lattice change since the
+          previous tracking. Defaults to :py:obj:`False`
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+        twiss_in:       Initial conditions for transfer line optics. Record
+          array as output by :py:func:`linopt2`, :py:func:`linopt6`, or
+          dictionary. Keys:
+
+          R or alpha, beta
+            mandatory
+          closed_orbit
+            Optional (6,) array, default 0
+          dispersion
+            Optional (6,) array, default 0
+
+          If present, the attribute **R**' will be used, otherwise the
+          attributes **alpha** and **beta** will be used. All other attributes
+          are ignored.
+
+    Returns:
+        elemdata0:      Linear optics data at the entrance of the ring
+        ringdata:       Lattice properties
+        elemdata:       Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+
+    Warning:
+        The format of output record arrays depends on the selected method.
+        See :py:func:`linopt2`, :py:func:`linopt4`, :py:func:`linopt6`.
     """
     return method(ring, refpts=refpts, dp=dp, **kwargs)
 
 
 # noinspection PyPep8Naming
 @check_radiation(False)
-def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
-    """Perform linear analysis of a H/V coupled lattice following Sagan/Rubin
-    4D-analysis of coupled motion
-
-    lindata0, tune, chrom, lindata = linopt(lattice, dp, refpts, **kwargs)
+def linopt(ring: Lattice, dp: Optional[float] = 0.0,
+           refpts: Optional[Refpts] = None,
+           get_chrom: Optional[Refpts] = False, **kwargs):
+    """Linear analysis of a H/V coupled lattice (deprecated)
 
     PARAMETERS
         lattice         lattice description.
@@ -775,7 +851,8 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
                            refers to the end of the last element,
                         2) an ordered list of such integers without duplicates,
                         3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
+                           len(ring)+1, where selected elements are
+                           :py:obj:`True`.
     KEYWORDS
         orbit           avoids looking for the closed orbit if is already known
                         ((6,) array)
@@ -785,12 +862,12 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
                         Needs to compute the optics at 2 different momentum
                         deviations around the central one.
         keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
+                        Defaults to :py:obj:`False`
         XYStep=1.0e-8   transverse step for numerical computation
         DPStep=1.0E-6   momentum deviation used for computation of
                         chromaticities and dispersion
-        coupled=True    if False, simplify the calculations by assuming
-                        no H/V coupling
+        coupled=True    if :py:obj:`False`, simplify the calculations by
+                        assuming no H/V coupling
         twiss_in=None   Initial conditions for transfer line optics. Record
                         array as output by linopt, or dictionary. Keys:
                         'alpha' and 'beta'  (mandatory)
@@ -802,7 +879,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
         tune            [tune_A, tune_B], linear tunes for the two normal modes
                         of linear motion [1]
         chrom           [ksi_A , ksi_B], chromaticities ksi = d(nu)/(dP/P).
-                        Only computed if 'get_chrom' is True
+                        Only computed if 'get_chrom' is :py:obj:`True`
         lindata         linear optics at the points refered to by refpts, if
                         refpts is None an empty lindata structure is returned.
 
@@ -818,7 +895,7 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
         mu              [mux, muy], betatron phase (modulo 2*pi)
         W               (2,) chromatic amplitude function (only if get_w==True)
         All values given at the entrance of each element specified in refpts.
-        In case coupled == True additional outputs are available:
+        In case coupled == :py:obj:`True` additional outputs are available:
         gamma           gamma parameter of the transformation to eigenmodes
         A               (2, 2) matrix A in [3]
         B               (2, 2) matrix B in [3]
@@ -832,6 +909,8 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
         [3] D.Sagan, D.Rubin Phys.Rev.Spec.Top.-Accelerators and beams,
             vol.2 (1999)
         [4] Brian W. Montague Report LEP Note 165, CERN, 1979
+
+    :meta private:
     """
     analyze = _analyze4 if kwargs.pop('coupled', True) else _analyze2
     eld0, bd, eld = _linopt(ring, analyze, refpts, dp=dp, get_chrom=get_chrom,
@@ -843,46 +922,68 @@ def linopt(ring, dp=0.0, refpts=None, get_chrom=False, **kwargs):
 
 # noinspection PyPep8Naming
 @check_radiation(False)
-def avlinopt(ring, dp=0.0, refpts=None, **kwargs):
-    """Perform linear analysis of a lattice and returns average
-    beta, dispersion and phase advance
+def avlinopt(ring: Lattice, dp: Optional[float] = 0.0,
+             refpts: Optional[Refpts] = None, **kwargs):
+    """Linear analysis of a lattice with average values
 
-    lindata,avebeta,avemu,avedisp,tune,chrom = avlinopt(lattice, dp, refpts)
+    :py:func:`avlinopt` returns average beta, mu, dispersion over the lattice
+    elements.
 
-    PARAMETERS
-        lattice         lattice description.
-        dp=0.0          momentum deviation.
-        refpts=None     elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
+    Parameters:
+        ring:       Lattice description.
+        dp:         Momentum deviation.
+        refpts:     Elements at which data is returned.
+          It can be:
 
-    KEYWORDS
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        keep_lattice    Assume no lattice change since the previous tracking.
-                        Defaults to False
-        XYStep=1.0e-8   transverse step for numerical computation
-        DPStep=1.0E-8   momentum deviation used for computation of
-                        chromaticities and dispersion
+          1. an integer in the range [-len(ring), len(ring)-1]
+             selecting the element according to python indexing rules.
+             As a special case, len(ring) is allowed and refers to the end
+             of the last element,
+          2. an ordered list of such integers without duplicates,
+          3. a numpy array of booleans of maximum length len(ring)+1,
+             where selected elements are :py:obj:`True`.
 
-    OUTPUT
-        lindata         linear optics at the points refered to by refpts, if
-                        refpts is None an empty lindata structure is returned.
-                        See linopt4 for details
-        avebeta         Average beta functions [betax,betay] at refpts
-        avemu           Average phase advances [mux,muy] at refpts
-        avedisp         Average dispersion [Dx,Dx',Dy,Dy'] at refpts
-        avespos         Average s position at refpts
-        tune            [tune_A, tune_B], linear tunes for the two normal modes
-                        of linear motion [1]
-        chrom           [ksi_A , ksi_B], chromaticities ksi = d(nu)/(dP/P).
+    Keyword Args:
+        dct (Optional[float]):  Path lengthening. If specified, ``dp`` is
+          ignored and the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
+        get_chrom (Optional[bool]): Compute chromaticities. Needs computing
+          the tune at 2 different momentum deviations around the central one.
+        get_w (Optional[bool]):     Computes chromatic amplitude functions
+          (W) [8]_. Needs to compute the optics at 2 different momentum
+          deviations around the central one.
+        keep_lattice (Optional[bool]):   Assume no lattice change since the
+          previous tracking. Defaults to :py:obj:`False`
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+        twiss_in:       Initial conditions for transfer line optics. Record
+          array as output by :py:func:`linopt2`, or dictionary. Keys:
 
-    See also linopt4, get_optics
+          alpha, beta
+            mandatory (2,) arrays
+          closed_orbit
+            Optional (6,) array, default 0
+          dispersion
+            Optional (6,) array, default 0
+
+          All other attributes are ignored.
+
+    Returns:
+        elemdata:   Linear optics at the points refered to by ``refpts``,
+          if refpts is :py:obj:`None` an empty lindata structure is returned.
+        avebeta:    Average beta functions [betax,betay] at ``refpts``
+        avemu:      Average phase advances [mux,muy] at ``refpts``
+        avedisp:    Average dispersion [Dx,Dx',Dy,Dy'] at ``refpts``
+        avespos:    Average s position at ``refpts``
+        tune:       [tune_A, tune_B], linear tunes for the two normal modes
+          of linear motion [1]
+        chrom:      [ksi_A , ksi_B], chromaticities
+
+    See also:
+        :py:func:`linopt4`, :py:func:`get_optics`
     """
     def get_strength(elem):
         try:
@@ -950,37 +1051,43 @@ def avlinopt(ring, dp=0.0, refpts=None, **kwargs):
     return lindata, avebeta, avemu, avedisp, aves, bd.tune, bd.chromaticity
 
 
-def get_tune(ring, method='linopt', dp=None, dct=None, orbit=None, **kwargs):
-    """gets the tune using several available methods
+def get_tune(ring: Lattice, method: Optional[str] = 'linopt',
+             dp: Optional[float] = None, dct: Optional[float] = None,
+             orbit: Optional[Orbit] = None, **kwargs):
+    """Computes the tunes using several available methods
 
-    PARAMETERS
-        ring            lattice description.
+    Parameters:
+        ring:       Lattice description.
+        method:     ``'linopt'`` returns the tunes from the :py:func:`linopt6`
+          function,
 
-    KEYWORDS
-        dp=None         Ignored if radiation is ON. Momentum deviation.
-        dct=None        Ignored if radiation is ON. Path lengthening.
-                        If specified, dp is ignored and the off-momentum is
-                        deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        method='linopt' 'linopt' returns the tunes from the linopt function
-                        'fft' tracks a single particle and computes the
-                        tunes with fft 'laskar' tracks a single particle
-                        and computes the tunes with NAFF
+          ``'fft'`` tracks a single particle and computes the tunes with fft,
 
-      for the 'fft' and 'laskar' methods only:
+          ``'laskar'`` tracks a single particle and computes the tunes with
+          NAFF.
+        dp:         Momentum deviation.
+        dct:        Path lengthening. If specified, ``dp`` is ignored and
+          the off-momentum is deduced from the path lengthening.
+        orbit (Optional[Orbit]): Avoids looking for the closed orbit if is
+          already known ((6,) array)
 
-        nturns=512      number of turns
-        amplitude=1.0E-6 amplitude of oscillation
-        remove_dc=False Remove the mean of oscillation data
-        num_harmonics   number of harmonic components to compute
-                        (before mask applied, default=20)
-        fmin/fmax       determine the boundaries within which the tune is
-                        located [default 0->1]
-        hann=False      flag to turn on Hanning window
+    for the ``'fft'`` and ``'laskar'`` methods only:
 
-    OUTPUT
-        tunes = np.array([Qx,Qy])
+    Keyword Args:
+        nturns (Optional[int]):         Number of turns. Default: 512
+        amplitude (Optional[float]):    Amplitude of oscillation.
+          Default: 1.E-6
+        remove_dc (Optional[bool]):     Remove the mean of oscillation data.
+          Default: :py:obj:`True`
+        num_harmonics (Optional[int]):  Number of harmonic components to
+          compute (before mask applied, default: 20)
+        fmin (Optional[float]):         Lower tune bound. Default: 0
+        fmax (Optional[float]):         Upper tune bound. Default: 1
+        hann (Optional[bool]):          Turn on Hanning window.
+          Default: :py:obj:`False`
+
+    Returns:
+        tunes (ndarray):                array([Qx,Qy])
     """
     # noinspection PyShadowingNames
     def gen_centroid(ring, ampl, nturns, remove_dc, ld):
@@ -1008,38 +1115,48 @@ def get_tune(ring, method='linopt', dp=None, dct=None, orbit=None, **kwargs):
     return tunes
 
 
-def get_chrom(ring, method='linopt', dp=0, dct=None, cavpts=None, **kwargs):
-    """gets the chromaticity using several available methods
+def get_chrom(ring: Lattice, method: Optional[str] = 'linopt',
+              dp: Optional[float] = None, dct: Optional[float] = None,
+              cavpts=None, **kwargs):
+    """Computes the chromaticities using several available methods
 
-    PARAMETERS
-        ring            lattice description.
+    Parameters:
+        ring:       Lattice description.
+        method:     ``'linopt'`` returns the tunes from the :py:func:`linopt6`
+          function,
 
-    KEYWORDS
-        dp=None         Ignored if radiation is ON. Momentum deviation.
-        dct=None        Ignored if radiation is ON. Path lengthening.
-                        If specified, dp is ignored and the off-momentum is
-                        deduced from the path lengthening.
-        orbit           avoids looking for the closed orbit if already known
-                        ((6,) array)
-        method='linopt' 'linopt' returns the tunes from the linopt function
-                        'laskar' tracks a single particle and computes the
-                        tunes with NAFF
-        DPStep=1.0E-6   momentum step used for the computation of
-                        chromaticities
+          ``'fft'`` tracks a single particle and computes the tunes with
+          :py:func:`~scipy.fftpack.fft`,
 
-      for the 'laskar' method only:
+          ``'laskar'`` tracks a single particle and computes the tunes with
+          NAFF.
+        dp:         Momentum deviation.
+        dct:        Path lengthening. If specified, ``dp`` is ignored and
+          the off-momentum is deduced from the path lengthening.
+        cavpts:     If :py:obj:`None`, look for ring.cavpts, or
+          otherwise take all cavities.
 
-        nturns=512      number of turns
-        amplitude=1.0E-6 amplitude of oscillation
-        remove_dc=False Remove the mean of oscillation data
-        num_harmonics   number of harmonic components to compute
-                        (before mask applied, default=20)
-        fmin/fmax       determine the boundaries within which the tune is
-                        located [default 0->1]
-        hann=False      flag to turn on Hanning window
+    Keyword Args:
+        DPStep (Optional[float]):       Momentum step for differentiation
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
 
-    OUTPUT
-        chromaticities = np.array([Q'x,Q'y])
+    for the ``'fft'`` and ``'laskar'`` methods only:
+
+    Keyword Args:
+        nturns (Optional[int]):         Number of turns. Default: 512
+        amplitude (Optional[float]):    Amplitude of oscillation.
+          Default: 1.E-6
+        remove_dc (Optional[bool]):     Remove the mean of oscillation data.
+          Default: :py:obj:`True`
+        num_harmonics (Optional[int]):  Number of harmonic components to
+          compute (before mask applied, default: 20)
+        fmin (Optional[float]):         Lower tune bound. Default: 0
+        fmax (Optional[float]):         Upper tune bound. Default: 1
+        hann (Optional[bool]):          Turn on Hanning window.
+          Default: :py:obj:`False`
+
+    Returns:
+        chromaticities (ndarray):       array([Q'x,Q'y])
     """
 
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -54,7 +54,7 @@ def find_m44(ring: Lattice, dp: Optional[float] = 0.0,
           matrices are between the entrance of the first element and the
           entrance of the selected element
         XYStep (Optional[float]):   Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
 
     Returns:
         m44:    full one-turn matrix at the entrance of the first element
@@ -125,9 +125,9 @@ def find_m66(ring: Lattice, refpts: Optional[Refpts] = None,
 
     Keyword Args:
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`.DConstant`.DPStep
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     Returns:
         m66:    full one-turn matrix at the entrance of the first element
@@ -188,7 +188,7 @@ def find_elem_m66(elem: Element,
 
     Keyword Args:
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
 
     Returns:
         m66:        6x6 transfer matrix

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -34,8 +34,8 @@ def find_m44(ring: Lattice, dp: Optional[float] = 0.0,
             (cavities , magnets with radiation, ...)
         2.  have any time dependence (localized impedance, fast kickers, ...)
 
-    Unless an input orbit is introduced, find_m44 assumes that the lattice is
-    a ring and first finds the closed orbit.
+    Unless an input orbit is introduced, :py:func:`find_m44` assumes that the
+    lattice is a ring and first finds the closed orbit.
 
     Parameters:
         ring:           Lattice description (radiation must be OFF)
@@ -44,8 +44,7 @@ def find_m44(ring: Lattice, dp: Optional[float] = 0.0,
         dct:            Path lengthening. If specified, ``dp`` is ignored and
           the off-momentum is deduced from the path lengthening.
         orbit:          Avoids looking for initial the closed orbit if it is
-          already known ((6,) array). :py:func:`find_orbit4` propagates it to
-          the specified ``refpts``.
+          already known ((6,) array).
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: False
 
@@ -55,15 +54,15 @@ def find_m44(ring: Lattice, dp: Optional[float] = 0.0,
           matrices are between the entrance of the first element and the
           entrance of the selected element
         XYStep (Optional[float]):   Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
 
     Returns:
-        M44:    full one-turn matrix at the entrance of the first element
-        M:      4x4 transfer matrices between the entrance of the first
+        m44:    full one-turn matrix at the entrance of the first element
+        ms:     4x4 transfer matrices between the entrance of the first
           element and each element indexed by refpts: (Nrefs, 4, 4) array
 
     See also:
-         :py:func:`find_m66`, :py:func:`find_orbit4`
+         :py:func:`find_m66`, :py:func:`.find_orbit4`
     """
 
     def mrotate(m):
@@ -112,7 +111,7 @@ def find_m66(ring: Lattice, refpts: Optional[Refpts] = None,
     :py:func:`find_m66` finds the 6x6 transfer matrix of an accelerator
     lattice by differentiation of trajectories near the closed orbit.
 
-    :py:func:`find_m66` uses :py:func:`find_orbit6` to search for the closed
+    :py:func:`find_m66` uses :py:func:`.find_orbit6` to search for the closed
     orbit in 6-D. In order for this to work the ring **MUST** have a ``Cavity``
     element
 
@@ -120,24 +119,23 @@ def find_m66(ring: Lattice, refpts: Optional[Refpts] = None,
         ring:           Lattice description
         refpts:         Observation points
         orbit:          Avoids looking for initial the closed orbit if it is
-          already known ((6,) array). :py:func:`find_sync_orbit` propagates it
-          to the specified ``refpts``.
+          already known ((6,) array).
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: False
 
     Keyword Args:
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`DConstant.DPStep`
+          Default: :py:data:`.DConstant`.DPStep
 
     Returns:
-        M66:    full one-turn matrix at the entrance of the first element
-        M:      6x6 transfer matrices between the entrance of the first
+        m66:    full one-turn matrix at the entrance of the first element
+        ms:     6x6 transfer matrices between the entrance of the first
           element and each element indexed by refpts: (Nrefs, 6, 6) array
 
     See also:
-         :py:func:`find_m44`, :py:func:`find_orbit6`
+         :py:func:`find_m44`, :py:func:`.find_orbit6`
     """
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
@@ -190,10 +188,10 @@ def find_elem_m66(elem: Element,
 
     Keyword Args:
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
 
     Returns:
-        M66:        6x6 transfer matrix
+        m66:        6x6 transfer matrix
     """
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     if orbit is None:
@@ -222,7 +220,7 @@ def gen_m66_elem(ring: Lattice,
         o4e:
 
     Returns:
-        M66:        6x6 transfer matrix
+        m66:        6x6 transfer matrix
     """
 
     dip_inds = get_refpts(ring, Bend)

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -4,67 +4,66 @@ transfer matrix related functions
 A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 import numpy
-from at.lattice import Lattice, uint32_refpts, get_refpts, DConstant
-from at.lattice.elements import Bend, M66
-from at.tracking import lattice_pass, element_pass
-from at.physics import find_orbit4, find_orbit6, jmat, symplectify
+from typing import Optional
+from ..lattice import Lattice, Element, get_refpts, DConstant, Refpts
+from ..lattice.elements import Bend, M66
+from ..tracking import lattice_pass, element_pass
+from . import Orbit
+from . import find_orbit4, find_orbit6, jmat, symplectify
 
 __all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'gen_m66_elem']
 
 _jmt = jmat(2)
 
 
-def find_m44(ring, dp=0.0, refpts=None, dct=None, orbit=None,
-             keep_lattice=False, **kwargs):
-    """find_m44 numerically finds the 4x4 transfer matrix of an accelerator
-    lattice for a particle with relative momentum deviation DP
+def find_m44(ring: Lattice, dp: Optional[float] = 0.0,
+             refpts: Optional[Refpts] = None,
+             dct: Optional[float] = None,
+             orbit: Optional[Orbit] = None,
+             keep_lattice: Optional[bool] = False, **kwargs):
+    """One turn 4x4 transfer matrix
 
-    IMPORTANT!!! find_m44 assumes constant momentum deviation.
-    PassMethod used for any element in the lattice SHOULD NOT
-    1.  change the longitudinal momentum dP
-        (cavities , magnets with radiation, ...)
-    2.  have any time dependence (localized impedance, fast kickers, ...)
+    :py:func:`find_m44` finds the 4x4 transfer matrix of an accelerator
+    lattice by differentiation of trajectories near the closed orbit.
 
-    m44, t = find_m44(lattice, dp=0.0, refpts)
-        return 4x4 transfer matrices between the entrance of the first element
-        and each element indexed by refpts.
-            m44:    full one-turn matrix at the entrance of the first element
-            t:      4x4 transfer matrices between the entrance of the first
-                    element and each element indexed by refpts:
-                    (Nrefs, 4, 4) array
+    Important:
+        :py:func:`find_m44` assumes constant momentum deviation.
+        The ``PassMethod`` used for any element **SHOULD NOT**:
+
+        1.  change the longitudinal momentum dP
+            (cavities , magnets with radiation, ...)
+        2.  have any time dependence (localized impedance, fast kickers, ...)
 
     Unless an input orbit is introduced, find_m44 assumes that the lattice is
     a ring and first finds the closed orbit.
 
-    PARAMETERS
-        ring            lattice description
-        dp              momentum deviation. Defaults to 0
-        refpts          elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-                        Defaults to None, if refpts is None an empty array is
-                        returned for mstack.
+    Parameters:
+        ring:           Lattice description (radiation must be OFF)
+        dp:             Momentum deviation. Defaults to 0
+        refpts:         Observation points
+        dct:            Path lengthening. If specified, ``dp`` is ignored and
+          the off-momentum is deduced from the path lengthening.
+        orbit:          Avoids looking for initial the closed orbit if it is
+          already known ((6,) array). :py:func:`find_orbit4` propagates it to
+          the specified ``refpts``.
+        keep_lattice:   Assume no lattice change since the previous tracking.
+          Default: False
 
-    KEYWORDS
-        dct=None        path lengthening. If specified, dp is ignored and
-                        the off-momentum is deduced from the path lengthening.
-        orbit=None      avoids looking for the closed orbit if is already known
-                        ((6,) array)
-        keep_lattice=False  When True, assume no lattice change since the
-                        previous tracking.
-        full=False      When True, matrices are full 1-turn matrices at
-                        the entrance of each
-                        element indexed by refpts.
-        orbit=None      Avoids looking for the closed orbit if is already
-                        known (6,) array
-        XYStep=1.e-8    transverse step for numerical computation
+    Keyword Args:
+        full (Optional[bool]):      If True, matrices are full 1-turn matrices
+          at the entrance of each element indexed by refpts. If False (Default),
+          matrices are between the entrance of the first element and the
+          entrance of the selected element
+        XYStep (Optional[float]):   Step size.
+          Default: :py:data:`DConstant.XYStep`
 
-    See also find_m66, find_orbit4
+    Returns:
+        M44:    full one-turn matrix at the entrance of the first element
+        M:      4x4 transfer matrices between the entrance of the first
+          element and each element indexed by refpts: (Nrefs, 4, 4) array
+
+    See also:
+         :py:func:`find_m66`, :py:func:`find_orbit4`
     """
 
     def mrotate(m):
@@ -86,7 +85,7 @@ def find_m44(ring, dp=0.0, refpts=None, dct=None, orbit=None,
     # Add the deltas to multiple copies of the closed orbit
     in_mat = orbit.reshape(6, 1) + dmat
 
-    refs = uint32_refpts(refpts, len(ring))
+    refs = ring.uint32_refpts(refpts)
     out_mat = numpy.rollaxis(
         numpy.squeeze(lattice_pass(ring, in_mat, refpts=refs,
                                    keep_lattice=keep_lattice), axis=3), -1
@@ -105,40 +104,40 @@ def find_m44(ring, dp=0.0, refpts=None, dct=None, orbit=None,
     return m44, mstack
 
 
-def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
-    """find_m66 numerically finds the 6x6 transfer matrix of an accelerator
-    lattice by differentiation of lattice_pass near the closed orbit.
-    find_m66 uses find_orbit6 to search for the closed orbit in 6-D
-    In order for this to work the ring MUST have a CAVITY element
+def find_m66(ring: Lattice, refpts: Optional[Refpts] = None,
+             orbit: Optional[Orbit] = None,
+             keep_lattice: Optional[bool] = False, **kwargs):
+    """One-turn 6x6 transfer matrix
 
-    m66, t = find_m66(lattice, refpts)
-        m66:    full one-turn 6-by-6 matrix at the entrance of the
-                first element.
-        t:      6x6 transfer matrices between the entrance of the first
-                element and each element indexed by refpts (nrefs, 6, 6) array.
+    :py:func:`find_m66` finds the 6x6 transfer matrix of an accelerator
+    lattice by differentiation of trajectories near the closed orbit.
 
-    PARAMETERS
-        ring            lattice description
-        dp              momentum deviation. Defaults to 0
-        refpts          elements at which data is returned. It can be:
-                        1) an integer in the range [-len(ring), len(ring)-1]
-                           selecting the element according to python indexing
-                           rules. As a special case, len(ring) is allowed and
-                           refers to the end of the last element,
-                        2) an ordered list of such integers without duplicates,
-                        3) a numpy array of booleans of maximum length
-                           len(ring)+1, where selected elements are True.
-                        Defaults to None, if refpts is None an empty array is
-                        returned for mstack.
+    :py:func:`find_m66` uses :py:func:`find_orbit6` to search for the closed
+    orbit in 6-D. In order for this to work the ring **MUST** have a ``Cavity``
+    element
 
-    KEYWORDS
-        keep_lattice=False  When True, assume no lattice change since the
-                            previous tracking.
-        orbit=None          Avoids looking for the closed orbit if is already
-                            known (6,) array
-        XYStep=1.e-8        transverse step for numerical computation
+    Parameters:
+        ring:           Lattice description
+        refpts:         Observation points
+        orbit:          Avoids looking for initial the closed orbit if it is
+          already known ((6,) array). :py:func:`find_sync_orbit` propagates it
+          to the specified ``refpts``.
+        keep_lattice:   Assume no lattice change since the previous tracking.
+          Default: False
 
-    See also find_m44, find_orbit6
+    Keyword Args:
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep`
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep`
+
+    Returns:
+        M66:    full one-turn matrix at the entrance of the first element
+        M:      6x6 transfer matrices between the entrance of the first
+          element and each element indexed by refpts: (Nrefs, 6, 6) array
+
+    See also:
+         :py:func:`find_m44`, :py:func:`find_orbit6`
     """
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
@@ -160,7 +159,7 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
 
     in_mat = orbit.reshape(6, 1) + dmat
 
-    refs = uint32_refpts(refpts, len(ring))
+    refs = ring.uint32_refpts(refpts)
     out_mat = numpy.rollaxis(
         numpy.squeeze(lattice_pass(ring, in_mat, refpts=refs,
                                    keep_lattice=keep_lattice), axis=3), -1
@@ -177,20 +176,24 @@ def find_m66(ring, refpts=None, orbit=None, keep_lattice=False, **kwargs):
     return m66, mstack
 
 
-def find_elem_m66(elem, orbit=None, **kwargs):
-    """
-    Numerically find the 6x6 transfer matrix of a single element
+def find_elem_m66(elem: Element,
+                  orbit: Optional[Orbit] = None,
+                  **kwargs):
+    """Single element 6x6 transfer matrix
 
-    INPUT
-        elem                AT element
+    Numerically finds the 6x6 transfer matrix of a single element
 
-    KEYWORDS
-        orbit=None          closed orbit at the entrance of the element,
-                            default: 0.0
-        XYStep=1.e-8        transverse step for numerical computation
+    Parameters:
+        elem:       AT element
+        orbit:      Closed orbit at the entrance of the element,
+          default: 0.0
 
-    OUTPUT
-        m66                 (6, 6) transfer matrix
+    Keyword Args:
+        XYStep (Optional[float]):       Step size.
+          Default: :py:data:`DConstant.XYStep`
+
+    Returns:
+        M66:        6x6 transfer matrix
     """
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
     if orbit is None:
@@ -208,9 +211,18 @@ def find_elem_m66(elem, orbit=None, **kwargs):
     return m66
 
 
-def gen_m66_elem(ring, o4b, o4e):
-    """
-    converts a ring to a linear 6x6 matrix tracking elemtn
+def gen_m66_elem(ring: Lattice,
+                 o4b: Orbit,
+                 o4e: Orbit) -> M66:
+    """Converts a ring to a linear 6x6 matrix
+
+    Parameters:
+        ring:       Lattice description
+        o4b:
+        o4e:
+
+    Returns:
+        M66:        6x6 transfer matrix
     """
 
     dip_inds = get_refpts(ring, Bend)
@@ -219,7 +231,7 @@ def gen_m66_elem(ring, o4b, o4e):
     s_pos = ring.get_s_pos()
     s = numpy.diff(numpy.array([s_pos[0], s_pos[-1]]))[0]
     i2 = numpy.sum(numpy.abs(theta * theta / lendp))
-    m66_mat, _ = find_m66(ring, [], o4b)
+    m66_mat, _ = find_m66(ring, [], orbit=o4b)
     if ring.radiation is False:
         m66_mat = symplectify(m66_mat)  # remove for damping
     lin_elem = M66('Linear', m66_mat, T1=-o4b, T2=o4e, Length=s, I2=i2)

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -2,15 +2,18 @@
 Closed orbit related functions
 """
 import numpy
-from typing import Optional, Sequence
+from typing import Optional
 from at.constants import clight
 from at.lattice import AtWarning, check_radiation, DConstant
 from at.lattice import Lattice, get_s_pos, uint32_refpts, Refpts
 from at.tracking import lattice_pass
-from at.physics import ELossMethod, get_timelag_fromU0
+from . import ELossMethod, get_timelag_fromU0
 import warnings
 
-__all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6', 'find_orbit']
+Orbit = numpy.ndarray
+
+__all__ = ['Orbit', 'find_orbit4', 'find_sync_orbit', 'find_orbit6',
+           'find_orbit']
 
 
 @check_radiation(False)
@@ -114,7 +117,7 @@ def _orbit_dct(ring, dct=None, guess=None, **kwargs):
 def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
                 refpts: Optional[Refpts] = None,
                 dct: Optional[float] = None,
-                orbit: Optional[Sequence[float]] = None,
+                orbit: Optional[Orbit] = None,
                 keep_lattice: Optional[bool] = False, **kwargs):
     r"""Gets the 4D closed orbit for a given dp
 
@@ -156,7 +159,7 @@ def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
           Default: False
 
     Keyword Args:
-        guess (Optional[Sequence[float]]):  (6,) initial value for the
+        guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
           Default: :py:data:`DConstant.OrbConvergence`
@@ -193,7 +196,7 @@ def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
 def find_sync_orbit(ring: Lattice, dct: Optional[float] = 0.0,
                     refpts: Optional[Refpts] = None,
                     dp: Optional[float] = None,
-                    orbit: Optional[Sequence[float]] = None,
+                    orbit: Optional[Orbit] = None,
                     keep_lattice: Optional[bool] = False, **kwargs):
     r"""Gets the 4D closed orbit for a given dct
 
@@ -235,7 +238,7 @@ def find_sync_orbit(ring: Lattice, dct: Optional[float] = 0.0,
           Default: False
 
     Keyword Args:
-        guess (Optional[Sequence[float]]):  (6,) initial value for the
+        guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
           Default: :py:data:`DConstant.OrbConvergence`
@@ -330,7 +333,7 @@ def _orbit6(ring: Lattice, cavpts=None, guess=None, keep_lattice=False,
 
 
 def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
-                orbit=None,
+                orbit: Optional[Orbit] = None,
                 dp: Optional[float] = None,
                 dct: Optional[float] = None,
                 keep_lattice: Optional[bool] = False, **kwargs):
@@ -370,7 +373,7 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
             the equilibrium RF phase. If there is no radiation it is 0.
 
     Parameters:
-        ring:           Lattice description (radiation must be OFF)
+        ring:           Lattice description
         refpts:         Observation points
         orbit:          Avoids looking for initial the closed orbit if it is
           already known ((6,) array). :py:func:`find_sync_orbit` propagates it
@@ -381,7 +384,7 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
           Default: False
 
     Keyword Args:
-        guess (Optional[Sequence[float]]):  (6,) initial value for the
+        guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
           Default: :py:data:`DConstant.OrbConvergence`
@@ -436,9 +439,12 @@ def find_orbit(ring, refpts=None, **kwargs):
         refpts:         Observation points
 
     Keyword Args:
-        dp (Optional[float]):             Momentum deviation. Defaults to None
-        dct (Optional[float]):            Path lengthening. Defaults to None
-        guess (Optional[Sequence[float]]):  (6,) initial value for the
+        orbit (Optional[Orbit]):       Avoids looking for initial the closed
+          orbit if it is already known. :py:func:`find_orbit` propagates it
+          to the specified ``refpts``.
+        dp (Optional[float]):           Momentum deviation. Defaults to None
+        dct (Optional[float]):          Path lengthening. Defaults to None
+        guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
           Default: :py:data:`DConstant.OrbConvergence`

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -162,11 +162,11 @@ def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`.DConstant`.OrbConvergence
+          Default: :py:data:`DConstant.OrbConvergence <.DConstant>`
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`.DConstant`.OrbMaxIter
+          Default: :py:data:`DConstant.OrbMaxIter <.DConstant>`
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
 
     Returns:
         orbit0:         (6,) closed orbit vector at the entrance of the
@@ -241,11 +241,11 @@ def find_sync_orbit(ring: Lattice, dct: Optional[float] = 0.0,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`.DConstant`.OrbConvergence
+          Default: :py:data:`DConstant.OrbConvergence <.DConstant>`
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`.DConstant`.OrbMaxIter
+          Default: :py:data:`DConstant.OrbMaxIter <.DConstant>`
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
 
     Returns:
         orbit0:         (6,) closed orbit vector at the entrance of the
@@ -387,13 +387,13 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`.DConstant`.OrbConvergence
+          Default: :py:data:`DConstant.OrbConvergence <.DConstant>`
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`.DConstant`.OrbMaxIter
+          Default: :py:data:`DConstant.OrbMaxIter <.DConstant>`
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`.DConstant`.DPStep
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
         method (Optional[ELossMethod]): Method for energy loss computation.
           See :py:class:`.ELossMethod`.
         cavpts (Optional[Refpts]):      Cavity location. If None, use all
@@ -447,13 +447,13 @@ def find_orbit(ring, refpts=None, **kwargs):
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`.DConstant`.OrbConvergence
+          Default: :py:data:`DConstant.OrbConvergence <.DConstant>`
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`.DConstant`.OrbMaxIter
+          Default: :py:data:`DConstant.OrbMaxIter <.DConstant>`
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`.DConstant`.XYStep
+          Default: :py:data:`DConstant.XYStep <.DConstant>`
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`.DConstant`.DPStep
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     For other keywords, refer to the underlying methods
 

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -123,7 +123,7 @@ def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
 
     Finds the closed orbit in the 4-d transverse phase space by numerically
     solving for a fixed point of the one turn map M calculated with
-    :py:func:`lattice_pass`.
+    :py:func:`.lattice_pass`.
 
     .. math:: \begin{pmatrix}x \\ p_x \\ y \\ p_y \\ dp \\ c\tau_2\end{pmatrix}
        =\mathbf{M} \cdot
@@ -162,11 +162,11 @@ def find_orbit4(ring: Lattice, dp: Optional[float] = 0.0,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`DConstant.OrbConvergence`
+          Default: :py:data:`.DConstant`.OrbConvergence
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`DConstant.OrbMaxIter`
+          Default: :py:data:`.DConstant`.OrbMaxIter
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
 
     Returns:
         orbit0:         (6,) closed orbit vector at the entrance of the
@@ -202,7 +202,7 @@ def find_sync_orbit(ring: Lattice, dct: Optional[float] = 0.0,
 
     Finds the closed orbit, synchronous with the RF cavity (first 5
     components of the phase space vector) by numerically solving for a fixed
-    point of the one turn map M calculated with :py:func:`lattice_pass`
+    point of the one turn map M calculated with :py:func:`.lattice_pass`
 
     .. math:: \begin{pmatrix}x \\ p_x \\ y \\ p_y \\ dp \\ c\tau_1+
        dc\tau\end{pmatrix} =\mathbf{M} \cdot
@@ -241,11 +241,11 @@ def find_sync_orbit(ring: Lattice, dct: Optional[float] = 0.0,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`DConstant.OrbConvergence`
+          Default: :py:data:`.DConstant`.OrbConvergence
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`DConstant.OrbMaxIter`
+          Default: :py:data:`.DConstant`.OrbMaxIter
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
 
     Returns:
         orbit0:         (6,) closed orbit vector at the entrance of the
@@ -341,7 +341,7 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
 
     Findsinds the closed orbit in the full 6-D phase space
     by numerically solving  for a fixed point of the one turn
-    map M calculated with :py:func:`lattice_pass`
+    map M calculated with :py:func:`.lattice_pass`
 
     .. math:: \begin{pmatrix}x \\ p_x \\ y \\ p_y \\ dp \\ c\tau_2\end{pmatrix}
        =\mathbf{M} \cdot
@@ -350,7 +350,7 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
     with constraint :math:`c\tau_2 - c\tau_1 = c.h (1/f_{RF} - 1/f_{RF_0})`
 
     Important:
-        py:func:`find_orbit6` is a realistic simulation:
+        :py:func:`find_orbit6` is a realistic simulation:
 
         1.  The requency in the RF cavities :math:`f_{RF}` (may be different
             from :math:`f_{RF_0}`) imposes the synchronous condition
@@ -387,15 +387,15 @@ def find_orbit6(ring: Lattice, refpts: Optional[Refpts] = None,
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`DConstant.OrbConvergence`
+          Default: :py:data:`.DConstant`.OrbConvergence
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`DConstant.OrbMaxIter`
+          Default: :py:data:`.DConstant`.OrbMaxIter
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`DConstant.DPStep`
+          Default: :py:data:`.DConstant`.DPStep
         method (Optional[ELossMethod]): Method for energy loss computation.
-          See :py:class:`ELossMethod`.
+          See :py:class:`.ELossMethod`.
         cavpts (Optional[Refpts]):      Cavity location. If None, use all
           cavities. This is used to compute the initial synchronous phase.
 
@@ -447,13 +447,13 @@ def find_orbit(ring, refpts=None, **kwargs):
         guess (Optional[Orbit]):        (6,) initial value for the
           closed orbit. It may help convergence. Default: (0, 0, 0, 0, 0, 0)
         convergence (Optional[float]):  Convergence criterion.
-          Default: :py:data:`DConstant.OrbConvergence`
+          Default: :py:data:`.DConstant`.OrbConvergence
         max_iterations (Optional[int]): Maximum number of iterations.
-          Default: :py:data:`DConstant.OrbMaxIter`
+          Default: :py:data:`.DConstant`.OrbMaxIter
         XYStep (Optional[float]):       Step size.
-          Default: :py:data:`DConstant.XYStep`
+          Default: :py:data:`.DConstant`.XYStep
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`DConstant.DPStep`
+          Default: :py:data:`.DConstant`.DPStep
 
     For other keywords, refer to the underlying methods
 

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -14,12 +14,13 @@ __all__ = ['frequency_control', 'get_mcf', 'get_slip_factor',
 def frequency_control(func):
     """Function to be used as decorator for ``func(ring, *args, **kwargs)``
 
-    If ``ring.radiation`` is ``True`` and ``dp``, ``dct`` or ``df`` is
-    specified, make a copy of ``ring`` with a modified RF frequency, remove
-    ``dp``, ``dct`` or ``df`` from ``kwargs`` and call ``func`` with the
-    modified ``ring``.
+    If ``ring.radiation`` is :py:obj:`True` **and** ``dp``, ``dct`` or ``df``
+    is specified in ``kwargs``, make a copy of ``ring`` with a modified
+    RF frequency, remove ``dp``, ``dct`` or ``df`` from ``kwargs`` and call
+    ``func`` with the modified ``ring``.
 
-    If ``ring.radiation`` is ``False``, ``func`` is called unchanged.
+    If ``ring.radiation`` is :py:obj:`False` **or** no ``dp``, ``dct`` or
+    ``df`` is specified in ``kwargs``, ``func`` is called unchanged.
 
     Examples::
 
@@ -48,13 +49,13 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
 
     Parameters:
         ring:           Lattice description (radiation must be OFF)
-        dp:             Momentum deviation. Defaults to None
+        dp:             Momentum deviation. Defaults to :py:obj:`None`
         keep_lattice:   Assume no lattice change since the previous tracking.
-          Default: False
+          Default: :py:obj:`False`
 
     Keyword Args:
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`.DConstant`.DPStep
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     Returns:
         mcf (float):    Momentum compaction factor :math:`\alpha`
@@ -79,7 +80,7 @@ def get_slip_factor(ring: Lattice, **kwargs) -> float:
     Keyword Args:
         dp (Optional[float]):       Momentum deviation
         DPStep (Optional[float]):       Momentum step size.
-          Default: :py:data:`.DConstant`.DPStep
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     Returns:
         eta (float):    Slip factor :math:`\eta`
@@ -96,8 +97,8 @@ def get_revolution_frequency(ring,
 
     Parameters:
         ring:       Lattice description
-        dp:         Momentum deviation. Defaults to None
-        dct:        Path lengthening. Defaults to None
+        dp:             Momentum deviation. Defaults to :py:obj:`None`
+        dct:            Path lengthening. Defaults to :py:obj:`None`
 
     Returns:
         frev:       Revolution frequency [Hz]
@@ -121,20 +122,22 @@ def set_rf_frequency(ring, frequency=None, dp=None, dct=None, **kwargs):
     Parameters:
         ring:           Lattice description
         frequency:      RF frequency [Hz]. Default: nominal frequency.
-        dp:             Momentum deviation. Defaults to None
-        dct:            Path lengthening. Defaults to None
+        dp:             Momentum deviation. Defaults to :py:obj:`None`
+        dct:            Path lengthening. Defaults to :py:obj:`None`
 
     Keyword Args:
-        cavpts (Optional[Refpts]):   If None, look for ring.cavpts, or otherwise
-          take all cavities.
-        array (Optional[bool]):     If False, frequency is applied to the
-          selected cavities with the lowest frequency. The frequency of all the
-          other selected cavities is scaled by the same ratio.
+        cavpts (Optional[Refpts]):  If :py:obj:`None`, look for ring.cavpts, or
+          otherwise take all cavities.
+        array (Optional[bool]):     If :py:obj:`False` (default), ``frequency``
+          is applied to the selected cavities with the lowest frequency. The
+          frequency of all the other selected cavities is scaled by the same
+          ratio.
 
-          If True, directly apply frequency to the selected cavities.
-          The value must be broadcastable to the number of cavities.
-        copy (Optional[bool]):     If True, returns a shallow copy of ``ring``
-          with new cavity elements. Otherwise, modify ``ring`` in-place
+          If :py:obj:`True`, directly apply ``frequency`` to the selected
+          cavities. The value must be broadcastable to the number of cavities.
+        copy (Optional[bool]):     If :py:obj:`True`, returns a shallow copy of
+          ``ring`` with new cavity elements. Otherwise (default), modify
+          ``ring`` in-place
     """
     if frequency is None:
         frequency = ring.get_revolution_frequency(dp=dp, dct=dct) \
@@ -150,5 +153,4 @@ Lattice.get_slip_factor = get_slip_factor
 Lattice.set_rf_frequency = set_rf_frequency
 Lattice.rf_frequency = property(get_rf_frequency, set_rf_frequency,
     doc="Fundamental RF frequency [Hz]. The special value "
-        ":py:class:`at.Frf.NOMINAL <at.lattice.cavity_access.Frf>` "
-        "means nominal frequency.")
+        ":py:class:`Frf.NOMINAL <.Frf>` means nominal frequency.")


### PR DESCRIPTION
Docstrings updated for the `amat`, `energy_loss`, `fasting`, `orbit`, `matrix`, `revolution` and `linear` modules.