### PR TITLE
Silent atpass

### DIFF
--- a/pyat/at.c
+++ b/pyat/at.c
@@ -398,11 +398,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     outdims[0] = 6;
     outdims[1] = num_particles;
     outdims[2] = num_refpts;
-    if(silent){
-        outdims[3] = 1;
-    }else{
-        outdims[3] = num_turns;
-    }
+    outdims[3] = (silent) ? 1 : num_turns;
     rout = PyArray_EMPTY(4, outdims, NPY_DOUBLE, 1);
     drout = PyArray_DATA((PyArrayObject *)rout);
 

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -95,6 +95,7 @@ def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
           keep_counter is True. The turn number is necessary to compute the
           absolute path length used in RFCavityPass.
         losses (Optional[bool]):        Boolean to activate loss maps output
+        silent (Optional[bool]):        Boolean to activate silent output
         pool_size (Optional[int]):      number of processes. If None,
           ``min(npart,nproc)`` is used
         start_method (Optional[str]):   This parameter allows to change the
@@ -126,6 +127,9 @@ def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
           flag for particles lost (True -> particle lost), turn, element and
           coordinates at which the particle is lost. Set to zero for particles
           that survived
+          If silent is True, r_out: (6, N, R, 1) corresponds only the to the last
+          turn. This can be used for multi-particle tracking when the number of
+          macro-particles is very large to avoid memory issues
     """
     if not isinstance(ring, list):
         ring = list(ring)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -41,6 +41,7 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
           keep_counter is True. The turn number is necessary to compute the
           absolute path length used in RFCavityPass.
         losses (Optional[bool]):        Boolean to activate loss maps output
+        silent (Optional[bool]):        Boolean to activate silent output
         omp_num_threads (Optional[int]): number of OpenMP threads
           (default: automatic)
 
@@ -63,6 +64,9 @@ def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
           flag for particles lost (True -> particle lost), turn, element and
           coordinates at which the particle is lost. Set to zero for particles
           that survived
+          If silent is True, r_out: (6, N, R, 1) corresponds only the to the last
+          turn. This can be used for multi-particle tracking when the number of
+          macro-particles is very large to avoid memory issues
 
     Notes:
 
@@ -158,6 +162,7 @@ def atpass(*args, **kwargs):
         omp_num_threads (Optional[int]): number of OpenMP threads
           (default 0: automatic)
         losses (Optional[bool]):if True, process losses
+        silent (Optional[bool]):if True, only the last turn is returned
 
     Returns:
         r_out:  6 x n_particles x n_refpts x n_turns Fortran-ordered


### PR DESCRIPTION
An optional option `silent` is added to `atpass`.
In case it is activated only the last turn is returned. This allows to track large number of particles without allocating excessive memory and is a preparation for the implementation of multi-bunch collective effects simulations.