### PR TITLE
Update of setuptools_scm

### DIFF
--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,15 +1,6 @@
 """Python port of the Accelerator Toolbox"""
 
-import sys
-if sys.version_info.minor < 8:
-    from importlib_metadata import version, PackageNotFoundError
-else:
-    from importlib.metadata import version, PackageNotFoundError
-try:
-    __version__ = version('accelerator-toolbox')
-except PackageNotFoundError:
-    __version__ = "0.0.0"
-# from ._version import version as __version__
+from ._version import __version__, __version_tuple__
 # Make all functions visible in the at namespace:
 from .lattice import *
 from .tracking import *

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,6 +1,12 @@
 """Python port of the Accelerator Toolbox"""
 
-from ._version import __version__, __version_tuple__
+try:
+    # setuptools_scm >= 7 for python >= 3.7
+    from ._version import __version__, __version_tuple__
+except ImportError:
+    # setuptools_scm < 7 for python 3.6
+    from ._version import version as __version__
+    from ._version import version_tuple as __version_tuple__
 # Make all functions visible in the at namespace:
 from .lattice import *
 from .tracking import *

--- a/pyat/pyproject.toml
+++ b/pyat/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "numpy >= 1.16.6;python_version<'3.10'",
     "numpy >= 1.21.5;python_version>='3.10'",
     "setuptools >= 45",
-    "setuptools_scm>=6.2",
+    "setuptools_scm>=7",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -20,6 +20,6 @@ archs = ["x86_64", "arm64"]
 
 [tool.setuptools_scm]
 root = ".."
-# write_to = "pyat/at/_version.py"
+write_to = "pyat/at/_version.py"
 git_describe_command = "git describe --dirty --tags --long --match pyat-[0-9]*"
 fallback_version = "0.0.0"

--- a/pyat/pyproject.toml
+++ b/pyat/pyproject.toml
@@ -3,7 +3,8 @@ requires = [
     "numpy >= 1.16.6;python_version<'3.10'",
     "numpy >= 1.21.5;python_version>='3.10'",
     "setuptools >= 45",
-    "setuptools_scm>=7",
+    "setuptools_scm >= 7;python_version>='3.7'",
+    "setuptools_scm >= 6.4.2;python_version<'3.7'",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -22,7 +22,6 @@ python_requires = >= 3.6.0
 packages = find:
 zip_safe = False
 install_requires =
-    importlib-metadata;python_version<'3.8'
     importlib-resources;python_version<'3.9'
     numpy>=1.16.6;python_version<'3.10'
     numpy>=1.21.5;python_version>='3.10'


### PR DESCRIPTION
The versioning of pyat is handled by `setuptools_scm`. Up to now, a bug prevented storing the generated version number in a python file `_version.py` (just because pyat is not at the root of the git repository). This is now corrected. As a consequence, at run time, we can now import the version number from the `_version` module, rather than extracting it from the metadata of the package. This makes the import of `at` simpler and faster.

There is still a trick to handle python 3.6. Another question is: how long do we still need to support python 3.6?