### PR TITLE
New Lattice.reduce method

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -152,8 +152,9 @@ class Element(object):
     def merge(self, other) -> None:
         """Merge another element"""
         if not self.is_compatible(other):
+            badname = getattr(other, 'FamName', type(other))
             raise TypeError('Cannot merge {0} and {1}'.format(self.FamName,
-                                                              other.FamName))
+                                                              badname))
 
 
 class LongElement(Element):
@@ -509,9 +510,9 @@ class Dipole(Multipole):
         def invrho(dip: Dipole):
             return dip.BendingAngle / dip.Length
 
-        return super().is_compatible(other) and \
-               self.ExitAngle == -other.EntranceAngle and \
-               abs(invrho(self) - invrho(other)) <= 1.e-6
+        return (super().is_compatible(other) and
+                self.ExitAngle == -other.EntranceAngle and
+                abs(invrho(self) - invrho(other)) <= 1.e-6)
 
     def merge(self, other) -> None:
         super().merge(other)
@@ -654,9 +655,9 @@ class RFCavity(LongElement):
         return pp
 
     def is_compatible(self, other) -> bool:
-        return super().is_compatible(other) and \
-               self.Frequency == other.Frequency and \
-               self.TimeLag == other.TimeLag
+        return (super().is_compatible(other) and
+                self.Frequency == other.Frequency and
+                self.TimeLag == other.TimeLag)
 
     def merge(self, other) -> None:
         super().merge(other)

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -8,7 +8,7 @@ responsibility to ensure that the appropriate attributes are present.
 import re
 import numpy
 import copy
-from typing import Optional, Generator, Tuple, Union, List, Iterable
+from typing import Optional, Generator, Tuple, List, Iterable
 from inspect import getmembers, isdatadescriptor
 
 
@@ -76,7 +76,7 @@ class Element(object):
         attrs = dict(self.items())
         keywords = ['\t{0} : {1!s}'.format(k, attrs.pop(k)) for k in first3]
         keywords += ['\t{0} : {1!s}'.format(k, v) for k, v in attrs.items()]
-        return '\n'.join((self.__class__.__name__ + ':', '\n'.join(keywords)))
+        return '\n'.join((type(self).__name__ + ':', '\n'.join(keywords)))
 
     def __repr__(self):
         attrs = dict(self.items())
@@ -103,15 +103,15 @@ class Element(object):
 
         Parameters:
             frac:           length of each slice expressed as a fraction of the
-                            initial length. ``sum(frac)`` may differ from 1.
+              initial length. ``sum(frac)`` may differ from 1.
 
         Returns:
             elem_list:  a list of elements equivalent to the original.
 
-        Examples:
+        Example:
 
-        >>> Drift('dr', 0.5).divide([0.2, 0.6, 0.2])
-        [Drift('dr', 0.1), Drift('dr', 0.3), Drift('dr', 0.1)]
+            >>> Drift('dr', 0.5).divide([0.2, 0.6, 0.2])
+            [Drift('dr', 0.1), Drift('dr', 0.3), Drift('dr', 0.1)]
         """
         # Bx default, the element is indivisible
         return [self]
@@ -145,6 +145,16 @@ class Element(object):
             if not k.startswith('_'):
                 yield k, getattr(self, k)
 
+    def is_compatible(self, other) -> bool:
+        """Checks if another Element can be merged"""
+        return False
+
+    def merge(self, other) -> None:
+        """Merge another element"""
+        if not self.is_compatible(other):
+            raise TypeError('Cannot merge {0} and {1}'.format(self.FamName,
+                                                              other.FamName))
+
 
 class LongElement(Element):
     """pyAT long element
@@ -173,21 +183,6 @@ class LongElement(Element):
         return pp
 
     def divide(self, frac) -> List[Element]:
-        """split the element in len(frac) pieces whose length
-        is frac[i]*self.Length
-
-        Parameters:
-            frac:           length of each slice expressed as a fraction of the
-                            initial length. ``sum(frac)`` may differ from 1.
-
-        Returns:
-            elem_list:  a list of elements equivalent to the original.
-
-        Examples:
-
-        >>> Drift('dr', 0.5).divide([0.2, 0.6, 0.2])
-        [Drift('dr', 0.1), Drift('dr', 0.3), Drift('dr', 0.1)]
-        """
         def popattr(element, attr):
             val = getattr(element, attr)
             delattr(element, attr)
@@ -208,6 +203,14 @@ class LongElement(Element):
         for key, value in fout.items():
             setattr(element_list[-1], key, value)
         return element_list
+
+    def is_compatible(self, other) -> bool:
+        return type(other) is type(self) and \
+               self.PassMethod == other.PassMethod
+
+    def merge(self, other) -> None:
+        super().merge(other)
+        self.Length += other.Length
 
 
 class Marker(Element):
@@ -251,7 +254,7 @@ class Drift(LongElement):
         super(Drift, self).__init__(family_name, length, **kwargs)
 
     def insert(self,
-               insert_list: Iterable[Tuple[float, Union[Element, None]]]) \
+               insert_list: Iterable[Tuple[float, Optional[Element]]]) \
             -> List[Element]:
         """insert elements inside a drift
 
@@ -271,14 +274,15 @@ class Drift(LongElement):
 
         Examples:
 
-        >>> Drift('dr', 2.0).insert(((0.25, None), (0.75, None)))
-        [Drift('dr', 0.5), Drift('dr', 1.0), Drift('dr', 0.5)]
+            >>> Drift('dr', 2.0).insert(((0.25, None), (0.75, None)))
+            [Drift('dr', 0.5), Drift('dr', 1.0), Drift('dr', 0.5)]
 
-        >>> Drift('dr', 2.0).insert(((0.0, Marker('m1')), (0.5, Marker('m2'))))
-        [Marker('m1'), Drift('dr', 1.0), Marker('m2'), Drift('dr', 1.0)]
+            >>> Drift('dr', 2.0).insert(((0.0, Marker('m1')),
+            ... (0.5, Marker('m2'))))
+            [Marker('m1'), Drift('dr', 1.0), Marker('m2'), Drift('dr', 1.0)]
 
-        >>> Drift('dr', 2.0).insert(((0.5, Quadrupole('qp', 0.4, 0.0)),))
-        [Drift('dr', 0.8), Quadrupole('qp', 0.4), Drift('dr', 0.8)]
+            >>> Drift('dr', 2.0).insert(((0.5, Quadrupole('qp', 0.4, 0.0)),))
+            [Drift('dr', 0.8), Quadrupole('qp', 0.4), Drift('dr', 0.8)]
         """
         frac, elements = zip(*insert_list)
         lg = [0.0 if el is None else el.Length for el in elements]
@@ -289,7 +293,7 @@ class Drift(LongElement):
         drifts = numpy.ndarray((len(drfrac),), dtype='O')
         drifts[long_elems] = self.divide(drfrac[long_elems])
         nline = len(drifts) + len(elements)
-        line = [None] * nline           # type: List[Union[Element, None]]
+        line = [None] * nline           # type: List[Optional[Element]]
         line[::2] = drifts
         line[1::2] = elements
         return [el for el in line if el is not None]
@@ -402,6 +406,18 @@ class Multipole(LongElement, ThinMultipole):
         super(Multipole, self).__init__(family_name, length,
                                         poly_a, poly_b, **kwargs)
 
+    def is_compatible(self, other) -> bool:
+        if super().is_compatible(other) and \
+           self.MaxOrder == other.MaxOrder:
+            for i in range(self.MaxOrder):
+                if self.PolynomB[i] != other.PolynomB[i]:
+                    return False
+                if self.PolynomA[i] != other.PolynomA[i]:
+                    return False
+            return True
+        else:
+            return False
+
     # noinspection PyPep8Naming
     @property
     def K(self) -> float:
@@ -489,6 +505,19 @@ class Dipole(Multipole):
         pp.ExitAngle = 0.0
         return pp
 
+    def is_compatible(self, other) -> bool:
+        def invrho(dip: Dipole):
+            return dip.BendingAngle / dip.Length
+
+        return super().is_compatible(other) and \
+               self.ExitAngle == -other.EntranceAngle and \
+               abs(invrho(self) - invrho(other)) <= 1.e-6
+
+    def merge(self, other) -> None:
+        super().merge(other)
+        self.ExitAngle = other.ExitAngle
+        self.BendingAngle += other.BendingAngle
+
 
 # Bend is a synonym of Dipole.
 Bend = Dipole
@@ -567,7 +596,8 @@ class Sextupole(Multipole):
 
     # noinspection PyPep8Naming
     @property
-    def H(self):
+    def H(self) -> float:
+        """Sextupolar strength"""
         return self.PolynomB[2]
 
     # noinspection PyPep8Naming
@@ -622,6 +652,15 @@ class RFCavity(LongElement):
         pp = super(RFCavity, self)._part(fr, sumfr)
         pp.Voltage = fr * self.Voltage
         return pp
+
+    def is_compatible(self, other) -> bool:
+        return super().is_compatible(other) and \
+               self.Frequency == other.Frequency and \
+               self.TimeLag == other.TimeLag
+
+    def merge(self, other) -> None:
+        super().merge(other)
+        self.Voltage += other.Voltage
 
 
 class M66(Element):

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -410,7 +410,7 @@ class Multipole(LongElement, ThinMultipole):
     def is_compatible(self, other) -> bool:
         if super().is_compatible(other) and \
            self.MaxOrder == other.MaxOrder:
-            for i in range(self.MaxOrder):
+            for i in range(self.MaxOrder+1):
                 if self.PolynomB[i] != other.PolynomB[i]:
                     return False
                 if self.PolynomA[i] != other.PolynomA[i]:
@@ -516,6 +516,7 @@ class Dipole(Multipole):
 
     def merge(self, other) -> None:
         super().merge(other)
+        # noinspection PyAttributeOutsideInit
         self.ExitAngle = other.ExitAngle
         self.BendingAngle += other.BendingAngle
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -27,18 +27,18 @@ from .particle_object import Particle
 from .utils import AtError, AtWarning, Refpts
 # noinspection PyProtectedMember
 from .utils import _uint32_refs, _bool_refs, Uint32Refpts
-from .utils import refpts_iterator, refpts_len
+from .utils import refpts_iterator, refpts_len, checktype
 from .utils import get_s_pos, get_elements, get_cells, get_refpts
 from .utils import get_value_refpts, set_value_refpts
 from .utils import set_shift, set_tilt
 from . import elements
-from .elements import Element
+from .elements import Element, Monitor
 
 _TWO_PI_ERROR = 1.E-4
 Filter = Callable[..., Iterable[Element]]
 
 __all__ = ['Lattice', 'type_filter', 'params_filter', 'lattice_filter',
-           'no_filter']
+           'elem_generator', 'no_filter']
 
 # Don't warn on floating-pont errors
 numpy.seterr(divide='ignore', invalid='ignore')
@@ -54,9 +54,9 @@ class Lattice(list):
     Attributes:
         name: Name of the lattice
         energy: Particle energy
-        periodicity: Number of super-periods to describe the full ring
+        periodicity: Number of super-periods to describe the full self
         particle: Circulating particle
-        harmonic_number: Harmonic number of the full ring (periodicity x cells)
+        harmonic_number: Harmonic number of the full self (periodicity x cells)
     """
     # Attributes displayed:
     _disp_attributes = ('name', 'energy', 'particle', 'periodicity',
@@ -138,7 +138,7 @@ class Lattice(list):
         if iterator is None:
             arg1, = args or [[]]  # accept 0 or 1 argument
             if isinstance(arg1, Lattice):
-                elems = arg1.attrs_filter(kwargs, arg1)
+                elems = lattice_filter(kwargs, arg1)
             else:
                 elems = params_filter(kwargs, type_filter, arg1)
         else:
@@ -184,7 +184,8 @@ class Lattice(list):
                 rg = range(*key.indices(len(self)))
             else:                           # Array of integers or boolean
                 rg = _uint32_refs(self, key)
-            return Lattice((super(Lattice, self).__getitem__(i) for i in rg),
+            return Lattice(elem_generator,
+                           (super(Lattice, self).__getitem__(i) for i in rg),
                            iterator=self.attrs_filter)
 
     def __setitem__(self, key, values):
@@ -232,7 +233,8 @@ class Lattice(list):
                                'city set to 1'.format(self.periodicity, n)))
                 periodicity = 1
         # noinspection PyTypeChecker
-        return Lattice(itertools.chain(*itertools.repeat(self, n)),
+        return Lattice(elem_generator,
+                       itertools.chain(*itertools.repeat(self, n)),
                        iterator=self.attrs_filter, periodicity=periodicity)
 
     def _addition_filter(self, params: Dict, elems: Iterable[Element]):
@@ -329,7 +331,7 @@ class Lattice(list):
         Returns:
             newring:    New Lattice object
         """
-        def slice_iter(ibeg, iend):
+        def slice_generator(_, ibeg, iend):
             yield from self[:ibeg]
             for elem in self[ibeg:iend]:
                 nslices = int(math.ceil(elem.Length / size))
@@ -346,26 +348,24 @@ class Lattice(list):
             smin, smax = s_range
             size = (smax - smin) / slices
         i_range = self.i_range
-        return Lattice(slice_iter(i_range[0], i_range[-1]),
+        return Lattice(slice_generator, i_range[0], i_range[-1],
                        iterator=self.attrs_filter, s_range=s_range)
 
-    def attrs_filter(self, params: dict, elems: Iterable[Element]) \
+    def attrs_filter(self, params: dict, elem_filter: Filter, *args) \
             -> Iterable[Element]:
         """Filter function which duplicates the lattice attributes
 
         Parameters:
-            params:     Dictionary of Lattice attributes
-            elems:      iterable of lattice ``Elements``
-
-        Returns:
-            elems:  **elems** unchanged
+            params:         Dictionary of Lattice attributes
+            elem_filter:    Element filter
+            *args:          Arguments provided to ``elem_filter``
         """
         for key in self._std_attributes:
             try:
                 params.setdefault(key, getattr(self, key))
             except AttributeError:
                 pass
-        return elems
+        return elem_filter(params, *args)
 
     @property
     def s_range(self):
@@ -421,7 +421,7 @@ class Lattice(list):
 
     @property
     def circumference(self) -> float:
-        """Ring circumference (full ring) [m]"""
+        """Ring circumference (full self) [m]"""
         return self.periodicity * self.get_s_pos(len(self))[0]
 
     @property
@@ -444,7 +444,7 @@ class Lattice(list):
 
     @property
     def harmonic_number(self):
-        """Ring harmonic number (full ring)"""
+        """Ring harmonic number (full self)"""
         try:
             return self.periodicity * self._cell_harmnumber
         except AttributeError:
@@ -537,7 +537,7 @@ class Lattice(list):
         def lattice_copy(params):
             """Custom iterator for the creation of a new lattice"""
             radiate = False
-            for elem in self.attrs_filter(params, self):
+            for elem in self:
                 attrs = elem_modify(elem)
                 if attrs is not None:
                     elem = elem.copy()
@@ -549,7 +549,7 @@ class Lattice(list):
             params['_radiation'] = radiate
 
         if copy:
-            return Lattice(iterator=lattice_copy, **kwargs)
+            return Lattice(lattice_copy, iterator=self.attrs_filter, **kwargs)
         else:
             lattice_modify(**kwargs)
 
@@ -735,13 +735,13 @@ class Lattice(list):
             newring:    A new lattice with new elements inserted at breakpoints
         """
 
-        def sbreak_iterator(params):
+        def sbreak_iterator(_, itmk):
             """Iterate over elements and breaks where necessary"""
 
             def next_mk():
                 """Extract the next element to insert"""
                 try:
-                    return next(iter_mk)
+                    return next(itmk)
                 except StopIteration:
                     return sys.float_info.max, None
 
@@ -752,7 +752,7 @@ class Lattice(list):
             while smk < s_end:
                 smk, mk = next_mk()
 
-            for elem in self.attrs_filter(params, self):
+            for elem in self:
                 s_end += elem.Length
                 # loop over all insertions within the element
                 while smk < s_end:
@@ -776,7 +776,48 @@ class Lattice(list):
         # and create an iterator over the elements to be inserted
         iter_mk = zip(*numpy.broadcast_arrays(break_s, break_elems))
 
-        return Lattice(iterator=sbreak_iterator, **kwargs)
+        return Lattice(sbreak_iterator, iter_mk,
+                       iterator=self.attrs_filter, **kwargs)
+
+    def reduce(self, **kwargs) -> "Lattice":
+        """Removes unnecessary elements and merges consecutive similar ones
+
+        Removes all elements with an ``IdentityPass`` PassMethod, merges
+        compatible consecutive elements.
+
+        Keyword Args:
+            keep (Refpts):      Keep the selected elements, even with
+              ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
+
+        Warning:
+            If radiation is OFF, RF cavities have an ``IdentityPass``
+            PassMethod, and are therefore removed, unless they are selected in
+            ``keep``
+        """
+        def reduce_filter(_, itelem):
+            try:
+                elem = next(itelem).copy()
+            except StopIteration:
+                return
+            for nxt in itelem:
+                try:
+                    elem.merge(nxt)
+                except TypeError:
+                    yield elem
+                    elem = nxt.copy()
+            yield elem
+
+        kp = self.get_cells(lambda el: el.PassMethod != 'IdentityPass')
+        print(kp.shape)
+        try:
+            keep = self.bool_refpts(kwargs.pop('keep'))[:-1]
+            print(keep.shape)
+        except KeyError:
+            keep = self.get_cells(checktype(Monitor))
+            print(keep.shape)
+
+        return Lattice(reduce_filter, self.select(kp | keep),
+                       iterator=self.attrs_filter, **kwargs)
 
     def replace(self, refpts: Refpts, **kwargs) -> "Lattice":
         """Return a shallow copy of the lattice replacing the selected
@@ -790,7 +831,8 @@ class Lattice(list):
         else:
             check = iter(_bool_refs(self, refpts))
         elems = (el.deepcopy() if ok else el for el, ok in zip(self, check))
-        return Lattice(elems, iterator=self.attrs_filter, **kwargs)
+        return Lattice(elem_generator, elems,
+                       iterator=self.attrs_filter, **kwargs)
 
 
 def lattice_filter(params, lattice):
@@ -803,11 +845,11 @@ def lattice_filter(params, lattice):
     Yields:
         lattice ``Elements``
     """
-    return lattice.attrs_filter(params, lattice)
+    return lattice.attrs_filter(params, elem_generator, lattice)
 
 
 # noinspection PyUnusedLocal
-def no_filter(params, elems: Iterable[Element]) -> Iterable[Element]:
+def elem_generator(params, elems: Iterable[Element]) -> Iterable[Element]:
     """Run through all elements without any check
 
     Parameters:
@@ -818,6 +860,9 @@ def no_filter(params, elems: Iterable[Element]) -> Iterable[Element]:
         lattice ``Elements``
     """
     return elems
+
+
+no_filter = elem_generator  # provided for backward compatibility
 
 
 def type_filter(params, elems: Iterable[Element]) \

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -778,6 +778,12 @@ class Lattice(list):
         """Removes all elements with an ``IdentityPass`` PassMethod and merges
         compatible consecutive elements.
 
+        The "reduced" lattice has the same optics as the original one, but
+        fewer elements. Compatible elements must have the same ``PolynomA``,
+        ``PolynomB`` and bending radius, so that the optics is preserved. But
+        magnet misalignments are not preserved, so this method should be
+        applied to lattices without errors.
+
         Keyword Args:
             keep (Refpts):      Keep the selected elements, even with
                 ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
@@ -797,13 +803,10 @@ class Lattice(list):
             yield elem
 
         kp = self.get_cells(lambda el: el.PassMethod != 'IdentityPass')
-        print(kp.shape)
         try:
-            keep = self.bool_refpts(kwargs.pop('keep'))[:-1]
-            print(keep.shape)
+            keep = self.bool_refpts(kwargs.pop('keep'))
         except KeyError:
             keep = self.get_cells(checktype((Monitor, RFCavity)))
-            print(keep.shape)
 
         return Lattice(reduce_filter, self.select(kp | keep),
                        iterator=self.attrs_filter, **kwargs)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -780,14 +780,13 @@ class Lattice(list):
                        iterator=self.attrs_filter, **kwargs)
 
     def reduce(self, **kwargs) -> "Lattice":
-        """Removes unnecessary elements and merges consecutive similar ones
-
-        Removes all elements with an ``IdentityPass`` PassMethod, merges
+        """Removes all elements with an ``IdentityPass`` PassMethod and merges
         compatible consecutive elements.
 
         Keyword Args:
             keep (Refpts):      Keep the selected elements, even with
               ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
+              elements
 
         Warning:
             If radiation is OFF, RF cavities have an ``IdentityPass``

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -32,7 +32,7 @@ from .utils import get_s_pos, get_elements, get_cells, get_refpts
 from .utils import get_value_refpts, set_value_refpts
 from .utils import set_shift, set_tilt
 from . import elements
-from .elements import Element, Monitor
+from .elements import Element, Monitor, RFCavity
 
 _TWO_PI_ERROR = 1.E-4
 Filter = Callable[..., Iterable[Element]]
@@ -46,17 +46,12 @@ numpy.seterr(divide='ignore', invalid='ignore')
 
 # noinspection PyAttributeOutsideInit
 class Lattice(list):
-    """Lattice object
+    """Lattice object.
 
-    An AT lattice is a sequence of AT elements which accepts extended indexing
-    (as a numpy ndarray). It has the following attributes:
-
-    Attributes:
-        name: Name of the lattice
-        energy: Particle energy
-        periodicity: Number of super-periods to describe the full self
-        particle: Circulating particle
-        harmonic_number: Harmonic number of the full self (periodicity x cells)
+    An AT lattice is a sequence of AT elements. In addition to :py:class:`list`
+    methods, :py:class:`Lattice` supports
+    `extended indexing <https://numpy.org/doc/stable/user/basics.indexing.html
+    #advanced-indexing>`_ as a numpy :py:obj:`~numpy.ndarray`.
     """
     # Attributes displayed:
     _disp_attributes = ('name', 'energy', 'particle', 'periodicity',
@@ -785,8 +780,8 @@ class Lattice(list):
 
         Keyword Args:
             keep (Refpts):      Keep the selected elements, even with
-              ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
-              elements
+                ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
+                and :py:class:`.RFCavity` elements
 
         Warning:
             If radiation is OFF, RF cavities have an ``IdentityPass``
@@ -812,7 +807,7 @@ class Lattice(list):
             keep = self.bool_refpts(kwargs.pop('keep'))[:-1]
             print(keep.shape)
         except KeyError:
-            keep = self.get_cells(checktype(Monitor))
+            keep = self.get_cells(checktype((Monitor, RFCavity)))
             print(keep.shape)
 
         return Lattice(reduce_filter, self.select(kp | keep),

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -782,11 +782,6 @@ class Lattice(list):
             keep (Refpts):      Keep the selected elements, even with
                 ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
                 and :py:class:`.RFCavity` elements
-
-        Warning:
-            If radiation is OFF, RF cavities have an ``IdentityPass``
-            PassMethod, and are therefore removed, unless they are selected in
-            ``keep``
         """
         def reduce_filter(_, itelem):
             try:

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -17,7 +17,7 @@ returned values are given at the entrance of each element specified in refpts;
 """
 import numpy
 import functools
-from typing import Callable, Optional, Sequence, Iterator, TypeVar, Union
+from typing import Callable, Optional, Sequence, Iterator, TypeVar, Union, Tuple
 from itertools import compress
 from fnmatch import fnmatch
 from .elements import Element
@@ -288,7 +288,7 @@ def checkattr(attrname: str, attrvalue: Optional = None) \
     return testf
 
 
-def checktype(eltype: type) -> ElementFilter:
+def checktype(eltype: Union[type, Tuple[type, ...]]) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     """Checks the type of an element
 
@@ -659,8 +659,10 @@ def tilt_elem(elem: Element, rots: float, relative: bool = False) -> None:
 
     The rotation matrices are stored in the ``R1`` and ``R2`` attributes
 
-    :math:`R_1=\begin{pmatrix} cos\theta & sin\theta \\ -sin\theta & cos\theta \end{pmatrix}`,
-    :math:`R_2=\begin{pmatrix} cos\theta & -sin\theta \\ sin\theta & cos\theta \end{pmatrix}`
+    :math:`R_1=\begin{pmatrix} cos\theta & sin\theta \\
+    -sin\theta & cos\theta \end{pmatrix}`,
+    :math:`R_2=\begin{pmatrix} cos\theta & -sin\theta \\
+    sin\theta & cos\theta \end{pmatrix}`
 
     Parameters:
         elem:           Element to be tilted

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -371,11 +371,9 @@ def get_cells(ring: Sequence[Element], *args) -> BoolRefpts:
             Returns a numpy array of booleans where all elements having a ``K``
             attribute equal to 0.0 are True
         """
-    if callable(args[0]):
-        testf = args[0]
-    else:
-        testf = checkattr(*args)
-    return numpy.array(tuple(map(testf, ring)), dtype=bool)
+    testf = args[0] if callable(args[0]) else checkattr(*args)
+    return numpy.append(numpy.fromiter(map(testf, ring), dtype=bool,
+                                       count=len(ring)), False)
 
 
 def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -84,11 +84,11 @@ def test_checktype(simple_ring):
 
 
 def test_get_cells(simple_ring):
-    a = numpy.ones(6, dtype=bool)
+    a = numpy.array([True, True, True, True, True, True, False])
     numpy.testing.assert_equal(get_cells(simple_ring, checkattr('Length')), a)
-    a = numpy.array([False, True, False, False, False, False])
+    a = numpy.array([False, True, False, False, False, False, False])
     numpy.testing.assert_equal(get_cells(simple_ring, 'attr'), a)
-    a = numpy.array([True, False, False, False, False, False])
+    a = numpy.array([True, False, False, False, False, False, False])
     numpy.testing.assert_equal(get_cells(simple_ring, 'FamName', 'D1'), a)
 
 


### PR DESCRIPTION
The `Lattice.reduce` method is similar to the `atreduce` Matlab function: it removed all elements with an `IdentityPass` passmethod, and then merges compatible consecutive elements.

A keep keyword allows to keep selected elements even if they have an `IdentityPass` passmethod. By default, `Lattice.reduce` keeps `Monitor` and `RFCavity` elements.