### PR TITLE
Fix a build problem with numpy 1.23

### DIFF
--- a/pyat/pyproject.toml
+++ b/pyat/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
 requires = [
-    "numpy >= 1.16.6;python_version<'3.10'",
-    "numpy >= 1.21.5;python_version>='3.10'",
+    "numpy ~= 1.16.6;python_version<'3.8'",
+    "numpy ~= 1.17.3;python_version=='3.8'",
+    "numpy ~= 1.19.3;python_version=='3.9'",
+    "numpy ~= 1.21.3;python_version=='3.10'",
     "setuptools >= 45",
     "setuptools_scm >= 7;python_version>='3.7'",
     "setuptools_scm >= 6.4.2;python_version<'3.7'",

--- a/pyat/setup.cfg
+++ b/pyat/setup.cfg
@@ -23,8 +23,7 @@ packages = find:
 zip_safe = False
 install_requires =
     importlib-resources;python_version<'3.9'
-    numpy>=1.16.6;python_version<'3.10'
-    numpy>=1.21.5;python_version>='3.10'
+    numpy>=1.16.6
     scipy>=0.16
 
 [options.package_data]


### PR DESCRIPTION
#### Problem:
The recent release of `numpy` 1.23 (available for python 3.8 to 3.10) introduced a problem for users of python 3.8+ building from source.` pip install` runs in its own environment, and installs there the most recent numpy version, to compile the C-extensions of AT (so `numpy` 1.23 now). At run time, the code links with the release installed by the user in its environment, possibly an older one. It appears that `numpy` 1.23 changes something so that `at` fails to import:
```python
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xe
```
The only solution for the user is to upgrade `numpy`. Though usually this can be done without side effects, this should not be requested!

#### Proposed solution:
The solution proposed here is to select for building with each python version the oldest compatible `numpy` release. The version used at runtime will then always be more recent, ensuring full compatibility (except for documented deprecations). The following table is used:

| Python version | numpy release |
| :-------------: | :-------------: |
|                     3.6 |                 1.16.6 |
|                     3.7 |                 1.16.6 |
|                     3.8 |                 1.17.3 |
|                     3.9 |                 1.19.3 |
|                    3.10 |                1.21.3 |

This the version used for **building only** (compilation of C extensions), configured in the `[build-system]` section of `pyproject.toml`. The requirement for **running** PyAT (`install_requires` in `setup.cfg`) stays as it is: numpy > 1.16.6, to get the necessary features. Practically, it will be the current version at the time of 1st installation, but the user may upgrade as he wants.

#### Possible side effects:

- `python setup.py install` does not run in a separated environment. Instead, it will downgrade numpy in the user's environment. So **always use "`pip`" for installation !**
- This may prevent the C extensions to use the most recent features of `numpy`. However the AT C code does not call any numpy function, it just needs access to the internal structure of a `ndarray`. It's very unlikely that any new feature may improve (accelerate) this significantly. So this is not relevant.

