### PR TITLE
fix empty orbit in atlinopt

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt.m
+++ b/atmat/atphysics/LinearOptics/atlinopt.m
@@ -114,7 +114,7 @@ if isempty(twiss_in)        % Circular machine
     [orbitP,o1P]=findorbit4(RING,dp+0.5*DPStep,REFPTS,orbitin,'XYStep',XYStep);
     [orbitM,o1M]=findorbit4(RING,dp-0.5*DPStep,REFPTS,orbitin,'XYStep',XYStep);
 else                        % Transfer line
-    if ~isempty(orbitin)
+    if isempty(orbitin)
         orbitin=zeros(6,1);
     end
     try
@@ -123,8 +123,10 @@ else                        % Transfer line
         disp0=zeros(4,1);
     end
     dorbit=0.5*[DPStep*disp0;DPStep;0];
-    orbitP=linepass(RING,orbitin+dorbit,REFPTS);
-    orbitM=linepass(RING,orbitin-dorbit,REFPTS,'KeepLattice');
+    o1P = orbitin+dorbit;
+    o1M = orbitin-dorbit;
+    orbitP=linepass(RING,o1P,REFPTS);
+    orbitM=linepass(RING,o1M,REFPTS,'KeepLattice');
 end
 orbit=linepass(RING,orbitin,REFPTS);
 dispersion = (orbitP-orbitM)/DPStep;

--- a/atmat/atphysics/LinearOptics/atlinopt.m
+++ b/atmat/atphysics/LinearOptics/atlinopt.m
@@ -116,6 +116,10 @@ if isempty(twiss_in)        % Circular machine
 else                        % Transfer line
     if isempty(orbitin)
         orbitin=zeros(6,1);
+        if isfield(twiss_in, 'ClosedOrbit')
+            lo=length(twiss_in.ClosedOrbit);
+            orbitin(1:lo)=twiss_in.ClosedOrbit;
+        end
     end
     try
         disp0=twiss_in.Dispersion;

--- a/atmat/atplot/atplot.m
+++ b/atmat/atplot/atplot.m
@@ -119,11 +119,7 @@ args=getdparg(args(1:funcarg-1));
 
         function [s,plotdata]=ringplot(ring,dpp,plotfun,varargin)
             [linargs,vargs] = opticsoptions(varargin);
-            if isfield(linargs{2}, 'R')
-                [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
-            else
-                [lindata, nu, ksi]=atlinopt(ring,dpp,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
-            end
+            [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
             s=cat(1,lindata.SPos);
             plotdata=plotfun(lindata,ring,dpp,vargs{:});
         end

--- a/atmat/atplot/atplot.m
+++ b/atmat/atplot/atplot.m
@@ -119,7 +119,11 @@ args=getdparg(args(1:funcarg-1));
 
         function [s,plotdata]=ringplot(ring,dpp,plotfun,varargin)
             [linargs,vargs] = opticsoptions(varargin);
-            [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
+            if isfield(linargs{2}, 'R')
+                [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
+            else
+                [lindata, nu, ksi]=atlinopt(ring,dpp,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
+            end
             s=cat(1,lindata.SPos);
             plotdata=plotfun(lindata,ring,dpp,vargs{:});
         end


### PR DESCRIPTION
This PR fixes an issue with `atlinopt` with `twiss_in` activated. 
When orbit_in was not provided an empty list was returned instead of 6 zeros.
~~The implementation could be further improved by using twiss_in.ClosedOrbit instead of zeros(6,1), to be discussed~~
If present the default is  `twiss_in.ClosedOrbit`