### PR TITLE
Fix crash in pickling / unpickling Lattice objects

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -213,7 +213,6 @@ class Lattice(list):
         return newring
 
     def __iadd__(self, elems):
-        # elist = list(self._addition_filter(elems))
         return super(Lattice, self).__iadd__(self._addition_filter(elems))
 
     def __mul__(self, n):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -129,7 +129,6 @@ class Lattice(list):
                 runs through ``ringparam_filter(params, *args)``, looks for
                 energy and periodicity if not yet defined.
 """
-
         if iterator is None:
             arg1, = args or [[]]  # accept 0 or 1 argument
             if isinstance(arg1, Lattice):
@@ -214,8 +213,8 @@ class Lattice(list):
         return newring
 
     def __iadd__(self, elems):
-        elist = list(self._addition_filter({}, elems))
-        return super(Lattice, self).__iadd__(elist)
+        # elist = list(self._addition_filter(elems))
+        return super(Lattice, self).__iadd__(self._addition_filter(elems))
 
     def __mul__(self, n):
         """Repeats n times the lattice"""
@@ -232,9 +231,10 @@ class Lattice(list):
                        itertools.chain(*itertools.repeat(self, n)),
                        iterator=self.attrs_filter, periodicity=periodicity)
 
-    def _addition_filter(self, params: Dict, elems: Iterable[Element]):
+    def _addition_filter(self, elems: Iterable[Element]):
         cavities = []
         length = 0.0
+        params = {}
 
         for elem in type_filter(params, elems):
             if isinstance(elem, elements.RFCavity):
@@ -260,12 +260,16 @@ class Lattice(list):
 
     def insert(self, idx: SupportsIndex, elem: Element):
         # noinspection PyUnusedLocal
-        elist = list(self._addition_filter({}, [elem]))
-        super(Lattice, self).insert(idx, elem)
+        # scan the new element to update it
+        elist = list(self._addition_filter([elem]))
+        super().insert(idx, elem)
 
     def extend(self, elems: Iterable[Element]):
-        elist = list(self._addition_filter({}, elems))
-        super(Lattice, self).extend(elist)
+        if hasattr(self, '_energy'):
+            # When unpickling a Lattice, extend is called before the lattice
+            # is initialized. So skip this.
+            elems = self._addition_filter(elems)
+        super().extend(elems)
 
     def append(self, elem: Element):
         self.extend([elem])

--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -37,7 +37,7 @@ def pytest_report_header(config):
 @pytest.fixture(scope='session')
 def engine():
     try:
-        eng = connect_matlab('pytest')
+        eng = connect_matlab()
         # Keep the existing Matlab path
     except EngineError:
         eng = start_matlab()

--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -37,7 +37,7 @@ def pytest_report_header(config):
 @pytest.fixture(scope='session')
 def engine():
     try:
-        eng = connect_matlab()
+        eng = connect_matlab('pytest')
         # Keep the existing Matlab path
     except EngineError:
         eng = start_matlab()


### PR DESCRIPTION
The unpickling sequence creates a Lattice object without going through the __init__ constructor. This results in temporarily invalid Lattice objects. Consequences are:
- impossibility to store pickled Lattice in files,
- crashes when running `patpass` with the 'spawn' start method: with this method, the arguments are transmitted to the subprocesses as pickled objects.

This is now corrected: invalid Lattice objects are detected and specifically treated.