### PR TITLE
Fix Matlab tests

### DIFF
--- a/pyat/test_matlab/conftest.py
+++ b/pyat/test_matlab/conftest.py
@@ -37,7 +37,7 @@ def pytest_report_header(config):
 @pytest.fixture(scope='session')
 def engine():
     try:
-        eng = connect_matlab()
+        eng = connect_matlab('pytest')
         # Keep the existing Matlab path
     except EngineError:
         eng = start_matlab()

--- a/pyat/test_matlab/test_cmp_avlinopt.py
+++ b/pyat/test_matlab/test_cmp_avlinopt.py
@@ -8,7 +8,7 @@ import pytest
 def _ml_refs(refpts, nelems):
     """Convert refpoints to Matlab"""
     uintrefs = at.uint32_refpts(refpts, nelems)
-    return matlab.double([ref+1 for ref in uintrefs])
+    return matlab.double([float(ref+1) for ref in uintrefs])
 
 
 @pytest.mark.parametrize('dp', (-0.01, 0.0, 0.01))

--- a/pyat/test_matlab/test_cmp_linopt6.py
+++ b/pyat/test_matlab/test_cmp_linopt6.py
@@ -13,7 +13,7 @@ def _py_data(ml_data):
 def _ml_refs(ring, py_refs):
     """Convert refpoints to Matlab"""
     uintrefs = ring.uint32_refpts(py_refs)
-    return matlab.double([ref+1 for ref in uintrefs])
+    return matlab.double([float(ref+1) for ref in uintrefs])
 
 
 def _compare_4d(py_data, ml_data, fields, atol=1.e-12, rtol=1.e-7):

--- a/pyat/test_matlab/test_cmp_physics.py
+++ b/pyat/test_matlab/test_cmp_physics.py
@@ -14,7 +14,7 @@ def _py_data(ml_data):
 def _ml_refs(refpts, nelems):
     """Convert refpoints to Matlab"""
     uintrefs = uint32_refpts(refpts, nelems)
-    return matlab.double([ref+1 for ref in uintrefs])
+    return matlab.double([float(ref+1) for ref in uintrefs])
 
 
 def _compare_physdata(py_data, ml_data, fields, atol=12, rtol=1.e-7):

--- a/pyat/test_matlab/test_orbit_matrices.py
+++ b/pyat/test_matlab/test_orbit_matrices.py
@@ -14,7 +14,7 @@ def _py_data(ml_data):
 def _ml_refs(refpts, nelems):
     """Convert refpoints to Matlab"""
     uintrefs = uint32_refpts(refpts, nelems)
-    return matlab.double([ref+1 for ref in uintrefs])
+    return matlab.double([float(ref+1) for ref in uintrefs])
 
 
 @pytest.mark.parametrize('ct', (-0.0002, 0.0002))


### PR DESCRIPTION
Matlab 2022a is more strict in type conversions than the previous versions. This PR adds an explicit conversion uint32 -> float in refpts arrays.