### PR TITLE
pyAT Bugfix: 1D acceptance for recursive grid + help improve

### DIFF
--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -362,7 +362,7 @@ def recursive_boundary_search(ring, planes, npoints, amplitudes, nturns=1024,
                 if not survived[i] and fact[i] > ftol:
                     deltas = cs[:, i]*rsteps[:]*min(1, 2*fact[i])
                     if numpy.any(abs(deltas) > abs(part[planesi, i])):
-                        part[planesi, i] = numpy.zeros(2)
+                        part[planesi, i] = numpy.zeros(len(planesi))
                     else:
                         for j, pi in enumerate(planesi):
                             part[pi, i] -= deltas[j]

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -128,9 +128,9 @@ def get_lifetime(ring, emity, bunch_curr, emitx=None, sigs=None, sigp=None,
         epsabs, epsrel:  integral absolute and relative tolerances
 
     Returns:
-        touschek lifetime: double, expressed in seconds 
-        momentum aperture: (len(refpts), 2) array
-        refpts at which the aperture was computed: (len(refpts), ) array
+        tl: touschek lifetime, double expressed in seconds 
+        ma: momentum aperture (len(refpts), 2) array
+        refpts: refpts used for ma calcualtion (len(refpts), ) array
     """
 
     epsabs = kwargs.pop('epsabs', 1.0e-16)

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -124,12 +124,13 @@ def get_lifetime(ring, emity, bunch_curr, emitx=None, sigs=None, sigp=None,
                          ``lattice_pass``). In case multi-processing is not
                          enabled ``GridMode`` is forced to
                          ``RECURSIVE`` (most efficient in single core)
-        verbose=True:    Print out some inform
+        verbose=False:   Print out some inform
         epsabs, epsrel:  integral absolute and relative tolerances
 
     Returns:
         Returns the touschek lifetime in seconds, the momentum aperture
-        and the refpts at which the aperture was computed
+        with shape(len(refpts), 2), and the refpts (len(refpts),) at which
+        the aperture was computed
     """
 
     epsabs = kwargs.pop('epsabs', 1.0e-16)

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -128,9 +128,9 @@ def get_lifetime(ring, emity, bunch_curr, emitx=None, sigs=None, sigp=None,
         epsabs, epsrel:  integral absolute and relative tolerances
 
     Returns:
-        Returns the touschek lifetime in seconds, the momentum aperture
-        with shape(len(refpts), 2), and the refpts (len(refpts),) at which
-        the aperture was computed
+        touschek lifetime: double, expressed in seconds 
+        momentum aperture: (len(refpts), 2) array
+        refpts at which the aperture was computed: (len(refpts), ) array
     """
 
     epsabs = kwargs.pop('epsabs', 1.0e-16)


### PR DESCRIPTION
This PR fixed #475 and #472.
There reset to zero to avoid the recursive grid to go negative was not accounting for the number of planes: 1D case mishandled.
The help of ring.get_lifetime() now gives more details on the output