### PR TITLE
quantpass bugfixes

### DIFF
--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -80,9 +80,6 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
         double *r6 = r+c*6;
         if (!atIsNaN(r6[0])) {
             int m;
-            double p_norm = 1/(1+r6[4]);
-            double NormL1 = L1*p_norm;
-            double NormL2 = L2*p_norm;
             /*  misalignment at entrance  */
             if (T1) ATaddvv(r6,T1);
             if (R1) ATmultmv(r6,R1);
@@ -104,9 +101,12 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
                 double ng, ec, de, energy, gamma, cstec, cstng;
                 double ds, rho, dxp, dyp;
                 int nph;
+                double p_norm = 1/(1+r6[4]);
+                double NormL1 = L1*p_norm;
+                double NormL2 = L2*p_norm;
                 double dpp0 = r6[4];
-                double xp0 = r6[1]/(1+r6[4]);
-                double yp0 = r6[3]/(1+r6[4]);
+                double xp0 = r6[1]*p_norm;
+                double yp0 = r6[3]*p_norm;
                 double s0 = r6[5];
                 
                 fastdrift(r6, NormL1);
@@ -123,8 +123,8 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
                 cstec = 3.0*gamma*gamma*gamma*clight/(2.0)*hbar/qe;
                 cstng = 5.0*sqrt(3.0)*alpha0*gamma/(6.0);
                 
-                dxp = r6[1]/(1+r6[4])-xp0 - irho*SL;
-                dyp = r6[3]/(1+r6[4])-yp0;
+                dxp = r6[1]*p_norm-xp0 - irho*SL;
+                dyp = r6[3]*p_norm-yp0;
                 ds = r6[5]-s0;
                 
                 rho = (SL+ds)/sqrt(dxp*dxp+dyp*dyp);
@@ -138,12 +138,10 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
                     for(i=0;i<nph;i++){
                         de = de + getEnergy(ec);
                     };
-                };
-                
-                r6[1] = r6[1]/(1+r6[4])*(1+r6[4]-de/E0);
-                r6[3] = r6[3]/(1+r6[4])*(1+r6[4]-de/E0);
+                };                
                 r6[4] = r6[4]-de/E0;
-                
+                r6[1] = r6[1]*p_norm*(1+r6[4]);
+                r6[3] = r6[3]*p_norm*(1+r6[4]);                
             }
             /* quadrupole gradient fringe */
             if (FringeQuadExit && B[1]!=0) {

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -129,8 +129,8 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
                 
                 rho = (SL+ds)/sqrt(dxp*dxp+dyp*dyp);
                 
-                ng =  cstng*1/rho*(SL+ds);
-                ec =  cstec*1/rho;
+                ng =  cstng/rho*(SL+ds);
+                ec =  cstec/rho;
                 
                 nph = poissonRandomNumber(ng);
                 de = 0.0;

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -134,11 +134,9 @@ void BndMPoleSymplectic4QuantPass(double *r, double le, double irho, double *A, 
                 
                 nph = poissonRandomNumber(ng);
                 de = 0.0;
-                if(nph>0){
-                    for(i=0;i<nph;i++){
-                        de = de + getEnergy(ec);
-                    };
-                };                
+                for(i=0;i<nph;i++){
+                    de = de + getEnergy(ec);
+                };
                 r6[4] = r6[4]-de/E0;
                 r6[1] = r6[1]*p_norm*(1+r6[4]);
                 r6[3] = r6[3]*p_norm*(1+r6[4]);                

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -114,26 +114,26 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
                 cstec = 3.0*gamma*gamma*gamma*clight/(2.0)*hbar/qe;
                 cstng = 5.0*sqrt(3.0)*alpha0*gamma/(6.0);
                 
-                dxp = r6[1]/(1+r6[4])-xp0;
-                dyp = r6[3]/(1+r6[4])-yp0;
+                dxp = r6[1]*p_norm-xp0;
+                dyp = r6[3]*p_norm-yp0;
                 ds = r6[5]-s0;
                 
                 rho = (SL+ds)/sqrt(dxp*dxp+dyp*dyp);
                 
-                ng =  cstng*1/rho*(SL+ds);
-                ec =  cstec*1/rho;
+                ng =  cstng/rho*(SL+ds);
+                ec =  cstec/rho;
                 
                 nph = poissonRandomNumber(ng);
+                
                 de = 0.0;
                 if(nph>0){
                     for(i=0;i<nph;i++){
                         de = de + getEnergy(ec);
                     };
                 };
-                
-                r6[1] = r6[1]*p_norm*(1+r6[4]-de/E0);
-                r6[3] = r6[3]*p_norm*(1+r6[4]-de/E0);
                 r6[4] = r6[4]-de/E0;
+                r6[1] = r6[1]*p_norm*(1+r6[4]);
+                r6[3] = r6[3]*p_norm*(1+r6[4]);
             }
             if (FringeQuadExit && B[1]!=0) {
                 if (useLinFrEleExit) /*Linear fringe fields from elegant*/

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -119,12 +119,12 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
                 ds = r6[5]-s0;
                 
                 rho = (SL+ds)/sqrt(dxp*dxp+dyp*dyp);
-                
+
                 ng =  cstng/rho*(SL+ds);
                 ec =  cstec/rho;
-                
+
                 nph = poissonRandomNumber(ng);
-                
+
                 de = 0.0;
                 if(nph>0){
                     for(i=0;i<nph;i++){

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -1,6 +1,6 @@
 #include "atelem.c"
 #include "atlalib.c"
-#include "driftkickrad.c"	/* drift6.c, strthinkickrad.c */
+#include "driftkick.c"	/* drift6.c, strthinkickrad.c */
 #include "quadfringe.c"		/* QuadFringePassP, QuadFringePassN */
 #include "atquantlib.c"
 
@@ -92,18 +92,21 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
                 double ng, ec, de, energy, gamma, cstec, cstng;
                 double ds, rho, dxp, dyp;
                 int nph;
+                double p_norm = 1.0/(1.0+r6[4]);
+                double NormL1 = L1*p_norm;
+                double NormL2 = L2*p_norm;
                 double dpp0 = r6[4];
-                double xp0 = r6[1]/(1+r6[4]);
-                double yp0 = r6[3]/(1+r6[4]);
+                double xp0 = r6[1]*p_norm;
+                double yp0 = r6[3]*p_norm;
                 double s0 = r6[5];
                 
-                ATdrift6(r6,L1);
-                strthinkickrad(r6, A, B, K1, E0, max_order);
-                ATdrift6(r6,L2);
-                strthinkickrad(r6, A, B, K2, E0, max_order);
-                ATdrift6(r6,L2);
-                strthinkickrad(r6, A, B, K1, E0, max_order);
-                ATdrift6(r6,L1);
+                fastdrift(r6, NormL1);
+                strthinkick(r6, A, B,  K1, max_order);
+                fastdrift(r6, NormL2);
+                strthinkick(r6, A, B, K2, max_order);
+                fastdrift(r6, NormL2);
+                strthinkick(r6, A, B,  K1, max_order);
+                fastdrift(r6, NormL1);
                 
                 energy = dpp0*E0+E0;
                 
@@ -128,8 +131,8 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
                     };
                 };
                 
-                r6[1] = r6[1]/(1+r6[4])*(1+r6[4]-de/E0);
-                r6[3] = r6[3]/(1+r6[4])*(1+r6[4]-de/E0);
+                r6[1] = r6[1]*p_norm*(1+r6[4]-de/E0);
+                r6[3] = r6[3]*p_norm*(1+r6[4]-de/E0);
                 r6[4] = r6[4]-de/E0;
             }
             if (FringeQuadExit && B[1]!=0) {

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -126,10 +126,8 @@ void StrMPoleSymplectic4QuantPass(double *r, double le, double *A, double *B,
                 nph = poissonRandomNumber(ng);
 
                 de = 0.0;
-                if(nph>0){
-                    for(i=0;i<nph;i++){
-                        de = de + getEnergy(ec);
-                    };
+                for(i=0;i<nph;i++){
+                    de = de + getEnergy(ec);
                 };
                 r6[4] = r6[4]-de/E0;
                 r6[1] = r6[1]*p_norm*(1+r6[4]);

--- a/atintegrators/atquantlib.c
+++ b/atintegrators/atquantlib.c
@@ -466,7 +466,7 @@ static double getEnergy(double ec){
     
     
     ub = 0.99999;
-    lb = 0.02;
+    lb = 0.21;
     cst0=1.23159;
     ran = drand();
     mini = 0.0;


### PR DESCRIPTION
This PR is a follow-up of #502. It was found that `*QuantPass.c` passmethods had erratic behavior and were producing wrong results.

Few bugs were identified and are fixed in the proposal. 
A more detailed code review and testing might be necessary for validation.