### PR TITLE
Take "QuantPass" into account when checking 6D motion

### DIFF
--- a/atmat/atphysics/Radiation/atdisable_6d.m
+++ b/atmat/atphysics/Radiation/atdisable_6d.m
@@ -103,7 +103,8 @@ end
         
         function elem=varelem(elem)
             % 'auto' multipole modification
-            elem.PassMethod=strrep(elem.PassMethod,'RadPass','Pass');
+            strrep(elem.PassMethod,'QuantPass','Pass)')
+            elem.PassMethod=strrep(strrep(elem.PassMethod,'QuantPass','Pass'),'RadPass','Pass');
             if isfield(elem,'Energy'), elem=rmfield(elem,'Energy'); end
         end
         

--- a/atmat/atphysics/Radiation/atenable_6d.m
+++ b/atmat/atphysics/Radiation/atenable_6d.m
@@ -107,7 +107,7 @@ end
         function elem=varelem(elem)
             % 'auto' multipole modification
             if ~(endsWith(elem.PassMethod,'RadPass') || (isfield(elem,'BendingAngle') && elem.BendingAngle == 0))
-                elem.PassMethod=strrep(elem.PassMethod,'Pass','RadPass');
+                elem.PassMethod=strrep(strrep(elem.PassMethod,'QuantPass','Pass'),'Pass','RadPass');
                 elem.Energy=energy;
             end
         end

--- a/atmat/lattice/atparamscan.m
+++ b/atmat/lattice/atparamscan.m
@@ -67,7 +67,7 @@ pvals=cellfun(@getany, varargin, 'UniformOutput', false);
                 if isfield(store,'is_6d')
                     v=store.is_6d;
                 else
-                    v=getradcav(ring,{'RadPass', 'QuantDiffPass', 'CavityPass'});
+                    v=getradcav(ring,{'RadPass', 'QuantPass', 'QuantDiffPass', 'CavityPass'});
                     store.is_6d=v;
                 end
             case 'has_cavity'

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -50,10 +50,11 @@ class LongtMotion(ABC):
         """Enable/Disable longitudinal motion
 
         Parameters:
-            enable:     ``True`` for enabling, ``False`` for disabling
+            enable:     :py:obj:`True`: for enabling, :py:obj:`False` for
+              disabling
             new_pass:   New PassMethod:
 
-              * ``None``: makes no change,
+              * :py:obj:`None`: makes no change,
               * ``'auto'``: Uses the default conversion,
               * Anything else is used as the new PassMethod.
             copy:       If True, returns a modified copy of the element,
@@ -79,8 +80,8 @@ class _DictLongtMotion(LongtMotion):
 
     * a :py:meth:`set_longt_motion` method setting the PassMethod according
       to the ``default_pass`` dictionary.
-    * a :py:obj:`.longt_motion` property set to ``True`` when the PassMethod
-      is ``default_pass[True]``
+    * a :py:obj:`.longt_motion` property set to :py:obj:`True` when the
+      PassMethod is ``default_pass[True]``
 
     The class must have a ``default_pass`` class attribute, a dictionary
     such that:
@@ -137,14 +138,17 @@ class _Radiative(LongtMotion):
     """
 
     def _get_longt_motion(self):
-        return self.PassMethod.endswith('RadPass')
+        return self.PassMethod.endswith(('RadPass', 'QuantPass'))
 
     def _autopass(self, enable):
-        rad = self.longt_motion
-        if enable and not rad:
-            return ''.join((self.PassMethod[:-4], 'RadPass'))
-        elif not enable and rad:
-            return ''.join((self.PassMethod[:-7], 'Pass'))
+        if enable:
+            root = self.PassMethod.replace('QuantPass', 'Pass').\
+                replace('RadPass', 'Pass')
+            return ''.join((root[:-4], 'RadPass'))
+        elif self.longt_motion:
+            root = self.PassMethod.replace('QuantPass', 'Pass').\
+                replace('RadPass', 'Pass')
+            return root
         else:
             return None
 
@@ -199,7 +203,7 @@ class Radiative(_Radiative):
 class Collective(_DictLongtMotion):
     """Mixin class for elements representing collective effects
 
-    Derived classes will automatically set the :py:obj:`is_collective`
+    Derived classes will automatically set the :py:attr:`~Element.is_collective`
     property when the element is active.
 
     The class must have a ``default_pass`` class attribute, a dictionary such
@@ -217,7 +221,8 @@ class Collective(_DictLongtMotion):
         ...
         ...     default_pass = {False: 'IdentityPass', True: 'WakeFieldPass'}
 
-        Defines a class where the :py:obj:`is_collective` property is handled
+        Defines a class where the :py:attr:`~Element.is_collective` property is
+        handled
     """
 
     def _get_collective(self):
@@ -336,8 +341,8 @@ class Element(object):
         for k, v in vars(self).items():
             yield k, v
 
-    def is_compatible(self, other) -> bool:
-        """Checks if another Element can be merged"""
+    def is_compatible(self, other: "Element") -> bool:
+        """Checks if another :py:class:`Element` can be merged"""
         return False
 
     def merge(self, other) -> None:
@@ -356,13 +361,13 @@ class Element(object):
         return False
 
     @property
-    def longt_motion(self):
-        """``True`` if longitudinal motion is affected by the element"""
+    def longt_motion(self) -> bool:
+        """:py:obj:`True` if longitudinal motion is affected by the element"""
         return self._get_longt_motion()
 
     @property
-    def is_collective(self):
-        """``True`` if the element involves collective effects"""
+    def is_collective(self) -> bool:
+        """:py:obj:`True` if the element involves collective effects"""
         return self._get_collective()
 
 
@@ -473,7 +478,7 @@ class Drift(LongElement):
 
               1. the location where the center of the element
                  will be inserted, given as a fraction of the Drift length.
-              2. an element to be inserted at that location. If ``None``,
+              2. an element to be inserted at that location. If :py:obj:`None`,
                  the drift will be divided but no element will be inserted.
 
         Returns:
@@ -1005,7 +1010,7 @@ class QuantumDiffusion(_DictLongtMotion, Element):
         Args:
             family_name:    Name of the element
             lmatp      :    Diffusion matrix for generation (see
-                               ``at.physics.radiation.gen_quandiff_elem``)
+                               :py:func:`.gen_quantdiff_elem`)
 
         Default PassMethod: ``QuantDiffPass``
         """


### PR DESCRIPTION
The passmethods ending in `QuantPass` are forgotten when checking for 6D motion or disabling it. this PR fixes that. It upgrades:

- **Matlab**: `check_6d`, `check_radiation`, `atenable_6d`, `atdisable_6d`, `atradon`, `atradoff`
- **python**: `check_6d`, `check_radiation`, `Lattice.enable_6d`, `Lattice.disable_6d`, `Element.get_longt_motion`, `Element.set_longt_motion`

`enable_6d` is unchanged: by default it enables "classical" radiation by setting '*RadPass', possibly replacing '*QuantPass' if necessary.

Enabling *QuantPass can be explicitly required, but an easier way to do that is still to be discussed.