### PR TITLE
Secure the emittance computation in atsummary and ringpara

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atx.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atx.m
@@ -19,6 +19,9 @@ function varargout=atx(ring,varargin)
 %BEAMDATA=ATX(RING,...,'dct',DCT)
 %   Specify the path lengthening
 %
+%BEAMDATA=ATX(RING,...,'df',DF)
+%   Specify the RF frequency deviation from nominal
+%
 %BEAMDATA=ATX(RING,...,'method',OPTICSFUN)
 %   Specify the method for linear optics. Default: @atlinopt6
 %   Allowed values are @atlinopt2, @atlinopt4, @atlinopt6


### PR DESCRIPTION
This is a follow-up of #463. `atsummary` and `ringpara` provide a computation of the equilibrium emittance based on the radiation integrals in dipoles. This value may be wrong for off-momentum lattices because it misses the contribution of quadrupoles in dispersive regions.

In this PR, the output of equilibrium emittance, energy spread and derived parameters is suppressed for off-momentum lattices, and a warning is issued.