### PR TITLE
random generators compatibility with parallel processing

### DIFF
--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -104,8 +104,6 @@ void VariableThinMPolePass(double *r, struct elem *Elem, double t0, int turn, in
     struct elemab *ElemA = Elem->ElemA;
     struct elemab *ElemB = Elem->ElemB;
     double *ramps = Elem->Ramps;
-    
-    init_seed(seed);
 
     for(i=0;i<maxorder+1;i++){
         pola[i]=get_pol(ElemA, ramps, mode, t, turn, seed, i, periodic);

--- a/atintegrators/atrandom.c
+++ b/atintegrators/atrandom.c
@@ -32,7 +32,7 @@
 #define AT_RNG_INC 0xda3e39cb94b95bdbULL
 
 #define COMMON_PCG32_INITIALIZER   { AT_RNG_STATE, AT_RNG_INC }
-#define THREAD_PCG32_INITIALIZER   { AT_RNG_STATE, 0ULL }
+#define THREAD_PCG32_INITIALIZER   { AT_RNG_STATE, 1ULL }
 
 struct pcg_state_setseq_64 {    // Internals are *Private*.
     uint64_t state;             // RNG state.  All values are possible.

--- a/atintegrators/atrandom.c
+++ b/atintegrators/atrandom.c
@@ -27,6 +27,13 @@
 #define TWOPI  6.28318530717959
 #endif /*TWOPI*/
 
+/* initial RNG definitions */
+#define AT_RNG_STATE 0x853c49e6748fea9bULL
+#define AT_RNG_INC 0xda3e39cb94b95bdbULL
+
+#define COMMON_PCG32_INITIALIZER   { AT_RNG_STATE, AT_RNG_INC }
+#define THREAD_PCG32_INITIALIZER   { AT_RNG_STATE, 0ULL }
+
 struct pcg_state_setseq_64 {    // Internals are *Private*.
     uint64_t state;             // RNG state.  All values are possible.
     uint64_t inc;               // Controls which RNG sequence (stream) is
@@ -36,7 +43,7 @@ typedef struct pcg_state_setseq_64 pcg32_random_t;
 
 // If you *must* statically initialize it, here's one.
 
-#define PCG32_INITIALIZER   { 0x853c49e6748fea9bULL, 0xda3e39cb94b95bdbULL }
+#define PCG32_INITIALIZER   { AT_RNG_STATE, AT_RNG_INC }
 
 static pcg32_random_t pcg32_global = PCG32_INITIALIZER;
 
@@ -156,7 +163,3 @@ static inline int atrandp(double lamb)
 {
     return atrandp_r(&pcg32_global, lamb);
 }
-
-/* initial RNG definitions */
-#define AT_RNG_STATE 0x853c49e6748fea9bULL
-#define AT_RNG_INC 28502542541ULL

--- a/atintegrators/atrandom.c
+++ b/atintegrators/atrandom.c
@@ -1,24 +1,99 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
 #include <math.h>
+#include <stdint.h>
 
-void init_seed(int seed){
-    static int initseed=1;
-    if(initseed)
-    {
-        srand(seed);
-        initseed=0;
-    }
+#ifndef TWOPI
+#define TWOPI  6.28318530717959
+#endif /*TWOPI*/
+
+struct pcg_state_setseq_64 {    // Internals are *Private*.
+    uint64_t state;             // RNG state.  All values are possible.
+    uint64_t inc;               // Controls which RNG sequence (stream) is
+                                // selected. Must *always* be odd.
+};
+typedef struct pcg_state_setseq_64 pcg32_random_t;
+
+// If you *must* statically initialize it, here's one.
+
+#define PCG32_INITIALIZER   { 0x853c49e6748fea9bULL, 0xda3e39cb94b95bdbULL }
+
+static pcg32_random_t pcg32_global = PCG32_INITIALIZER;
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+static uint32_t pcg32_random_r(pcg32_random_t* rng)
+{
+    uint64_t oldstate = rng->state;
+    rng->state = oldstate * 6364136223846793005ULL + rng->inc;
+    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+    uint32_t rot = oldstate >> 59u;
+    return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
 }
 
-double atdrand(void)   /* uniform distribution, (0..1] */
+static uint32_t pcg32_random()
 {
-    return (rand()+1.0)/(RAND_MAX+1.0);
+    return pcg32_random_r(&pcg32_global);
 }
 
-double atrandn() /* gaussian distribution, sigma=1, mean=0 */
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+static void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate, uint64_t initseq)
 {
+    rng->state = 0U;
+    rng->inc = (initseq << 1u) | 1u;
+    pcg32_random_r(rng);
+    rng->state += initstate;
+    pcg32_random_r(rng);
+}
+
+static void pcg32_srandom(uint64_t seed, uint64_t seq)
+{
+    pcg32_srandom_r(&pcg32_global, seed, seq);
+}
+
+/* Functions for uniform, normal and Poisson distributions with
+   external state variable */
+
+static double atrandd_r(pcg32_random_t* rng)
+/* Uniform [0, 1] distribution */
+{
+    return ldexp(pcg32_random_r(rng), -32);
+}
+
+static double atrandn_r(pcg32_random_t* rng)
+/* gaussian distribution, sigma=1, mean=0 */
+{
+    /* Marsaglia polar method: https://en.wikipedia.org/wiki/Marsaglia_polar_method */
+
 	static bool hasSpare = false;
 	static double spare;
-	static double u, v, s;
+	double u, v, s;
 
 	if (hasSpare) {
 		hasSpare = false;
@@ -27,46 +102,53 @@ double atrandn() /* gaussian distribution, sigma=1, mean=0 */
 
 	hasSpare = true;	
 	do {
-		u = (rand() / (double) RAND_MAX) * 2.0 - 1.0;
-		v = (rand() / (double) RAND_MAX) * 2.0 - 1.0;
+		u = 2.0 * atrandd_r(rng) - 1.0;
+		v = 2.0 * atrandd_r(rng) - 1.0;
 		s = u * u + v * v;
 	}
-	while( (s >= 1.0) || (s == 0.0) );
+	while ((s >= 1.0) || (s == 0.0));
 	s = sqrt(-2.0 * log(s) / s);
 	spare = v * s;
 	return u * s;
 }
 
-int atrandp(double lamb) /* poisson distribution */
+static int atrandp_r(pcg32_random_t* rng, double lamb)
+/* poisson distribution */
 {
-    
-    int pk,k;
-    double l,p,u,u1,u2,twopi;
-    
-    l = -lamb;
-    k = 0;
-    p = 0.0;
-    twopi = 4.0*asin(1.0);
-    pk=0;
-    
-    if(lamb<11){
-        
-        do{
-            k = k + 1;
-            u = atdrand();
-            p = p + log(u);
-        }while(p>l);
-        
+    int pk;
+
+    if (lamb<11) {
+        double l = -lamb;
+        int k = 0;
+        double p = 0;
+        do {
+            k += 1;
+            p += log(atrandd_r(rng));
+        } while (p>l);
         pk = k-1;
-        
-    }else{
-        u1 = atdrand();
-        u2 = atdrand();
-        if(u1==0.0){
-            u1 = 1e-18;
-        };
-        pk = (int)floor((sqrt(-2.0*log(u1))*cos(twopi*u2))*sqrt(lamb)+lamb);
     }
-    
-    return pk;    
+    else {      /* Gaussian approximation */
+        pk = (int)floor(atrandn_r(rng)*sqrt(lamb)+lamb);
+    }
+
+    return pk;
 }
+
+/* Functions for uniform, normal and Poisson distributions with
+   internal state variable */
+
+static inline double atrandd(void)
+{
+    return atrandd_r(&pcg32_global);
+}
+
+static inline double atrandn(void)
+{
+    return atrandn_r(&pcg32_global);
+}
+
+static inline int atrandp(double lamb)
+{
+    return atrandp_r(&pcg32_global, lamb);
+}
+

--- a/atintegrators/attypes.h
+++ b/atintegrators/attypes.h
@@ -20,6 +20,8 @@ struct parameters
   int nbunch;
   double *bunch_spos;
   double *bunch_currents;
+  struct pcg_state_setseq_64 *common_rng;
+  struct pcg_state_setseq_64 *thread_rng;
 };
 
 #endif /*ATTYPES_H*/

--- a/atmat/attrack/atpass.c
+++ b/atmat/attrack/atpass.c
@@ -56,9 +56,6 @@ typedef double mxDouble;
 									exceeds this limit it is marked as lost */
 #define C0  	2.99792458e8
 
-#define COMMON_INITIALIZER   { AT_RNG_STATE, AT_RNG_INC }
-#define THREAD_INITIALIZER   { AT_RNG_STATE, 0ULL }
-
 
 typedef int*(*pass_function)(mxArray*, int*, double*, int, int);
 typedef struct elem*(*track_function)(mxArray*, struct elem*, double*, int, struct parameters*);
@@ -72,8 +69,8 @@ static pass_function *pass_list = NULL;
 static int **field_numbers_ptr = NULL;
 
 /* state buffers for RNGs */
-static pcg32_random_t common_state = COMMON_INITIALIZER;
-static pcg32_random_t thread_state = THREAD_INITIALIZER;
+static pcg32_random_t common_state = COMMON_PCG32_INITIALIZER;
+static pcg32_random_t thread_state = THREAD_PCG32_INITIALIZER;
 
 static struct LibraryListElement {
     const char *MethodName;

--- a/docs/p/api/at.tracking.atpass.rst
+++ b/docs/p/api/at.tracking.atpass.rst
@@ -9,3 +9,6 @@ at.tracking.atpass
 
       atpass
       elempass
+      reset_rng
+      common_rng
+      thread_rng

--- a/docs/p/api/at.tracking.atpass.rst
+++ b/docs/p/api/at.tracking.atpass.rst
@@ -7,7 +7,5 @@ at.tracking.atpass
 
    .. autosummary::
 
-      isopenmp
-      ismpi
       atpass
       elempass

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -9,9 +9,6 @@
 #include <string.h>
 #include <omp.h>
 #endif /*_OPENMP*/
-#ifdef MPI
-#include <mpi.h>
-#endif /*MPI*/
 #include "attypes.h"
 #include <stdbool.h> 
 #include <math.h>
@@ -335,7 +332,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"line","rin","nturns","refpts","turn",
                              "energy", "particle", "keep_counter",
                              "reuse","omp_num_threads","losses",
-                             "bunch_spos", "bunch_currents", "id", NULL};
+                             "bunch_spos", "bunch_currents", NULL};
     static double lattice_length = 0.0;
     static int last_turn = 0;
     static int valid = 0;
@@ -369,7 +366,6 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     int keep_counter=0;
     int counter=0;
     int losses=0;
-    int id=0;
     npy_intp outdims[4];
     npy_intp pdims[1];
     npy_intp lxdims[2];
@@ -386,12 +382,12 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     bspos=NULL;
     bcurrents=NULL;
     
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O!i|O!$iO!O!ppIpO!O!i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O!i|O!$iO!O!ppIpO!O!", kwlist,
         &PyList_Type, &lattice, &PyArray_Type, &rin, &num_turns,
         &PyArray_Type, &refs, &counter,
         &PyFloat_Type ,&energy, particle_type, &particle,
         &keep_counter, &keep_lattice, &omp_num_threads, &losses,
-        &PyArray_Type, &bspos, &PyArray_Type, &bcurrents, &id)) {
+        &PyArray_Type, &bspos, &PyArray_Type, &bcurrents)) {
         return NULL;
     }
     if (PyArray_DIM(rin,0) != 6) {
@@ -403,10 +399,6 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     if ((PyArray_FLAGS(rin) & NPY_ARRAY_FARRAY_RO) != NPY_ARRAY_FARRAY_RO) {
         return PyErr_Format(PyExc_ValueError, "rin is not Fortran-aligned");
     }
-
-#ifdef MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &id);
-#endif /*MPI)*/
 
     param.common_rng=&common_state;
     param.thread_rng=&thread_state;

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -69,8 +69,8 @@ static PyObject *particle_type;
 static PyObject *element_type;
 
 /* state buffers for RNGs */
-static pcg32_random_t common_state = PCG32_INITIALIZER;
-static pcg32_random_t thread_state = PCG32_INITIALIZER;
+static pcg32_random_t common_state = COMMON_PCG32_INITIALIZER;
+static pcg32_random_t thread_state = THREAD_PCG32_INITIALIZER;
 
 /* Directly copied from atpass.c */
 static struct LibraryListElement {

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -691,28 +691,7 @@ static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
     return (PyObject *) rin;
 }
 
-
-static PyObject *isopenmp(PyObject *self)
-{
-#ifdef _OPENMP
-    Py_RETURN_TRUE;
-#else
-    Py_RETURN_FALSE;
-#endif /*_OPENMP)*/
-}
-
-
-static PyObject *ismpi(PyObject *self)
-{
-#ifdef MPI
-    Py_RETURN_TRUE;
-#else
-    Py_RETURN_FALSE;
-#endif /*MPI)*/
-}
-
-
-/* Boilerplate to register methods. */
+/* Method table */
 
 static PyMethodDef AtMethods[] = {
     {"atpass",  (PyCFunction)at_atpass, METH_VARARGS | METH_KEYWORDS,
@@ -751,14 +730,6 @@ static PyMethodDef AtMethods[] = {
               "    charge:  particle charge [elementary charge]\n\n"
               ":meta private:"
             )},
-    {"isopenmp",  (PyCFunction)isopenmp, METH_NOARGS,
-    PyDoc_STR("isopenmp()\n\n"
-              "Return whether OpenMP is active.\n"
-             )},
-    {"ismpi",  (PyCFunction)ismpi, METH_NOARGS,
-    PyDoc_STR("ismpi()\n\n"
-              "Return whether MPI is active.\n"
-             )},
    {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pyat/at/cconfig.c
+++ b/pyat/at/cconfig.c
@@ -1,0 +1,55 @@
+/*
+ * This file provides function returning configuration variables
+ * of the C compiler
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+static PyObject *isopenmp(PyObject *self)
+{
+#ifdef _OPENMP
+    Py_RETURN_TRUE;
+#else
+    Py_RETURN_FALSE;
+#endif /*_OPENMP)*/
+}
+
+
+static PyObject *ismpi(PyObject *self)
+{
+#ifdef MPI
+    Py_RETURN_TRUE;
+#else
+    Py_RETURN_FALSE;
+#endif /*MPI)*/
+}
+
+static PyMethodDef methods[] = {
+    {"isopenmp",  (PyCFunction)isopenmp, METH_NOARGS,
+    PyDoc_STR("isopenmp()\n\n"
+              "Return whether OpenMP is active.\n"
+             )},
+    {"ismpi",  (PyCFunction)ismpi, METH_NOARGS,
+    PyDoc_STR("ismpi()\n\n"
+              "Return whether MPI is active.\n"
+             )},
+   {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+PyMODINIT_FUNC PyInit_cconfig(void)
+{
+    PyObject *integ_path_obj;
+
+    static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "cconfig",    /* m_name */
+    PyDoc_STR("C configuration"),      /* m_doc */
+    -1,           /* m_size */
+    methods,    /* m_methods */
+    NULL,         /* m_slots */
+    NULL,         /* m_traverse */
+    NULL,         /* m_clear */
+    NULL,         /* m_free */
+    };
+    return PyModule_Create(&moduledef);
+}

--- a/pyat/at/cconfig.c
+++ b/pyat/at/cconfig.c
@@ -38,8 +38,6 @@ static PyMethodDef methods[] = {
 
 PyMODINIT_FUNC PyInit_cconfig(void)
 {
-    PyObject *integ_path_obj;
-
     static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "cconfig",    /* m_name */

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -1,11 +1,11 @@
 """
 Helper functions for working with AT lattices.
 
-A lattice as understood by pyAT is any sequence of elements.  These functions
-are useful for working with these sequences.
+A :py:class:`.Lattice` in pyAT is a sequence of :py:class:`.Element` objects.
+These functions are useful for building ad manipulating these sequences.
 """
 import sys
-from .options import DConstant
+from .options import DConstant, random
 from .particle_object import Particle
 from .elements import *
 from .utils import *

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -1,6 +1,24 @@
 """Global set of constants"""
+# noinspection PyUnresolvedReferences
+from ..cconfig import ismpi, isopenmp
+from numpy.random import Generator, PCG64, SeedSequence
 import os
 import multiprocessing
+
+if ismpi():
+    from mpi4py import MPI
+    _comm = MPI.COMM_WORLD
+    _sz = _comm.Get_size()
+    _rank = _comm.Get_rank()
+else:
+    _sz = 1
+    _rank = 0
+
+
+def _newgen(seed=12345):
+    ss = SeedSequence(seed)
+    seeds = ss.spawn(_sz+1)
+    return Generator(PCG64(seeds[0])), Generator(PCG64(seeds[_rank+1]))
 
 
 class _Dst(object):
@@ -21,6 +39,24 @@ class _Dst(object):
     def reset(self, name):
         delattr(self, name)
 
+    @property
+    def mpi(self):
+        return ismpi()
+
+    @property
+    def openmp(self):
+        return isopenmp()
+
+
+class _Random(object):
+    """Random generators for AT"""
+    def __init__(self):
+        self.reset()
+
+    @classmethod
+    def reset(cls, seed=12345):
+        cls.common, cls.thread = _newgen(seed)
+
 
 DConstant = _Dst()
 """
@@ -32,4 +68,37 @@ Attributes:
     OrbConvergence:     Convergence criterion for orbit
     OrbMaxIter:         Max. number of iterations for orbit
     omp_num_threads:    Default number of OpenMP threads
+    patpass_poolsize:   Default size of multiprocessing pool
+    mpi:               :py:obj:`True` if MPI is active
+    openmp:            :py:obj:`True` if OpenMP is active
+
+Methods:
+    reset(attrname):    Reset the attribute to its default value
+"""
+
+random = _Random()
+"""
+Random generators for AT
+
+Attributes:
+    common(:py:class:`~numpy.random.Generator`): random generator common to
+        all threads
+    thread(:py:class:`~numpy.random.Generator`): random generator specific to
+        each thread
+
+Methods:
+    reset(seed=None):   Reset the generators.
+
+Examples:
+    >>> at.random.common.random()
+    0.8699988509120198
+    
+    Generates a random number in [0, 1) which is identical in all threads
+
+    >>> at.random.thread.normal(size=5)
+    array([-0.02326275, -0.89806482, -1.69086929, -0.74399398,  0.70156743])
+    
+    Generates an array of Gaussian random values which is specific to
+    each thread
+    
 """

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -8,17 +8,17 @@ import multiprocessing
 if ismpi():
     from mpi4py import MPI
     _comm = MPI.COMM_WORLD
-    _sz = _comm.Get_size()
-    _rank = _comm.Get_rank()
+    _MPI_sz = _comm.Get_size()
+    _MPI_rk = _comm.Get_rank()
 else:
-    _sz = 1
-    _rank = 0
+    _MPI_sz = 1
+    _MPI_rk = 0
 
 
 def _newgen(seed=12345):
     ss = SeedSequence(seed)
-    seeds = ss.spawn(_sz+1)
-    return Generator(PCG64(seeds[0])), Generator(PCG64(seeds[_rank+1]))
+    seeds = ss.spawn(_MPI_sz + 1)
+    return Generator(PCG64(seeds[0])), Generator(PCG64(seeds[_MPI_rk + 1]))
 
 
 class _Dst(object):
@@ -31,6 +31,7 @@ class _Dst(object):
     OrbMaxIter = 20          # Max. number of iterations for orbit
     omp_num_threads = int(os.environ.get('OMP_NUM_THREADS', '0'))
     patpass_poolsize = multiprocessing.cpu_count()
+    _rank = _MPI_rk         # MPI rank
 
     def __setattr__(self, name, value):
         _ = getattr(self, name)     # make sure attribute exists
@@ -46,6 +47,10 @@ class _Dst(object):
     @property
     def openmp(self):
         return isopenmp()
+
+    @property
+    def rank(self):
+        return self._rank
 
 
 class _Random(object):

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -1,6 +1,19 @@
 """
 Tracking functions
 """
+# noinspection PyUnresolvedReferences
+from ..cconfig import ismpi
+# noinspection PyUnresolvedReferences
+from .atpass import reset_rng, common_rng, thread_rng
 from .patpass import patpass
 from .track import *
 from .particles import *
+
+# initialise the C random generators
+if ismpi():
+    from mpi4py import MPI
+    _comm = MPI.COMM_WORLD
+    _rank = _comm.Get_rank()
+else:
+    _rank = 0
+reset_rng(_rank)

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -1,8 +1,7 @@
 """
 Tracking functions
 """
-# noinspection PyUnresolvedReferences
-from ..cconfig import ismpi
+from ..lattice import DConstant
 # noinspection PyUnresolvedReferences
 from .atpass import reset_rng, common_rng, thread_rng
 from .patpass import patpass
@@ -10,10 +9,4 @@ from .track import *
 from .particles import *
 
 # initialise the C random generators
-if ismpi():
-    from mpi4py import MPI
-    _comm = MPI.COMM_WORLD
-    _rank = _comm.Get_rank()
-else:
-    _rank = 0
-reset_rng(_rank)
+reset_rng(DConstant.rank)

--- a/pyat/at/tracking/__init__.py
+++ b/pyat/at/tracking/__init__.py
@@ -1,19 +1,6 @@
 """
 Tracking functions
 """
-
-# noinspection PyUnresolvedReferences
-from .atpass import isopenmp, ismpi
 from .patpass import patpass
 from .track import *
 from .particles import *
-# noinspection PyProtectedMember
-from ..lattice.options import _Dst
-
-if ismpi():
-    # if AT is compiled with mpicc this is required
-    # noinspection PyUnresolvedReferences
-    from mpi4py import MPI
-
-_Dst.openmp = property(lambda self: isopenmp())
-_Dst.mpi = property(lambda self: ismpi())

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -3,18 +3,18 @@ Simple parallelisation of atpass() using multiprocessing.
 """
 from functools import partial
 import multiprocessing
-from at.lattice import uint32_refpts
+from ..lattice import AtWarning, Element, uint32_refpts, DConstant, random
+from ..lattice import Refpts
 from warnings import warn
 # noinspection PyUnresolvedReferences
-from .atpass import atpass as _atpass
+from .atpass import reset_rng, atpass as _atpass, common_rng, thread_rng
 from .track import fortran_align
-from at.lattice import AtWarning, DConstant
+from typing import Iterable
 import numpy as np
-
 
 __all__ = ['patpass']
 
-_atpassf = fortran_align(_atpass)
+_imax = np.iinfo(int).max
 
 globring = None
 
@@ -32,113 +32,130 @@ def format_results(results, r_in, losses):
         return np.concatenate(lout, axis=1)
 
 
-def _atpass_one(ring, rin, **kwargs):
-    kwargs['id'] = multiprocessing.current_process().ident
-    if ring is None:
-        result = _atpass(globring, rin, **kwargs)
-    else:
-        result = _atpass(ring, rin, **kwargs)
+def _atpass_fork(seed, rank, rin, **kwargs):
+    """Single forked job"""
+    reset_rng(rank, seed=seed)
+    result = _atpass(globring, rin, **kwargs)
     return rin, result
 
 
-@fortran_align
+def _atpass_spawn(ring, seed, rank, rin, **kwargs):
+    """Single spawned job"""
+    reset_rng(rank, seed=seed)
+    result = _atpass(ring, rin, **kwargs)
+    return rin, result
+
+
 def _pass(ring, r_in, pool_size, start_method, **kwargs):
     ctx = multiprocessing.get_context(start_method)
-    args = np.array_split(r_in, pool_size, axis=1)
+    # Split input in as many slices as processes
+    args = enumerate(np.array_split(r_in, pool_size, axis=1))
+    # Generate a new starting point for C RNGs
+    seed = random.common.integers(0, high=_imax, dtype=int)
+    global globring
+    globring = ring
     if ctx.get_start_method() == 'fork':
-        global globring
-        globring = ring
-        with ctx.Pool(pool_size) as pool:
-            results = pool.map(partial(_atpass_one, None, **kwargs), args)
-        globring = None
+        passfunc = partial(_atpass_fork, seed, **kwargs)
     else:
-        with ctx.Pool(pool_size) as pool:
-            results = pool.map(partial(_atpass_one, ring, **kwargs), args)
+        passfunc = partial(_atpass_spawn, ring, seed, **kwargs)
+    # Start the parallel jobs
+    with ctx.Pool(pool_size) as pool:
+        results = pool.starmap(passfunc, args)
+    globring = None
+    # Gather the results
     losses = kwargs.pop('losses', False)
     return format_results(results, r_in, losses)
 
 
-# noinspection PyIncorrectDocstring
-def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
-            start_method=None, **kwargs):
+@fortran_align
+def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
+            refpts: Refpts = None, pool_size: int = None,
+            start_method: str = None, **kwargs):
     """
-    patpass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
-    keep_counter=False, turn=0, losses=False, omp_num_threads=None,
-    pool_size=None, start_method=None)
+    Simple parallel implementation of :py:func:`.lattice_pass`.
+    If more than one particle is supplied, use multiprocessing. For a
+    single particle or if the lattice contains :py:class:`.Collective`
+    elements, :py:func:`.atpass` is used.
 
-    Simple parallel implementation of atpass().  If more than one particle
-    is supplied, use multiprocessing to run each particle in a separate
-    process. In case a single particle is provided or the ring contains
-    ImpedanceTablePass element, atpass() is returned
-
-    ``patpass`` tracks particles through each element of a lattice
+    :py:func:`patpass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's
-    ``PassMethod`` field.
+    *PassMethod* field.
 
     Parameters:
-        lattice (Iterable[Element]): list of elements
-        r_in:                   6 x n_particles Fortran-ordered numpy array.
-          On return, rin contains the final coordinates of the particles
-        nturns (int):           number of turns to be tracked
-        refpts (Uint32_refs):   numpy array of indices of elements where
+        lattice:                list of elements
+        r_in:                   (6, N) array: input coordinates of N particles.
+          *r_in* is modified in-place and reports the coordinates at
+          the end of the element. For the best efficiency, *r_in*
+          should be given as F_CONTIGUOUS numpy array.
+        nturns:                 number of turns to be tracked
+        refpts:                 numpy array of indices of elements where
           output is desired:
 
+          * len(line) means end of the last element (default)
           * 0 means entrance of the first element
-          * len(line) means end of the last element
+        pool_size:              number of processes. If None,
+          ``min(npart,nproc)`` is used
+        start_method:           python multiprocessing start method.
+          :py:obj:`None` uses the python default that is considered safe.
+          Available values: '``fork'``, ``'spawn'``, ``'forkserver'``.
+          Default for linux is ``'fork'``, default for macOS and  Windows is
+          ``'spawn'``. ``'fork'`` may be used on MacOS to speed up the
+          calculation or to solve Runtime Errors, however it is considered
+          unsafe.
 
     Keyword arguments:
-        keep_lattice (Optional[bool]):  use elements persisted from a previous
+        keep_lattice (bool):    Use elements persisted from a previous
           call. If True, assume that the lattice has not changed since
           the previous call.
-        keep_counter (Optional[bool]):  Keep the turn number from the previous
+        keep_counter (bool):    Keep the turn number from the previous
           call.
-        turn (Optional[int]):           Starting turn number. Ignored if
+        turn (int):             Starting turn number. Ignored if
           keep_counter is True. The turn number is necessary to compute the
           absolute path length used in RFCavityPass.
-        losses (Optional[bool]):        Boolean to activate loss maps output
-        pool_size (Optional[int]):      number of processes. If None,
-          ``min(npart,nproc)`` is used
-        start_method (Optional[str]):   This parameter allows to change the
-          python multiprocessing start method, default=None uses the python
-          defaults that is considered safe. Available parameters:
-          '``fork'``, ``'spawn'``, ``'forkserver'``. Default for linux is
-          ``'fork'``, default for macOS and  Windows is ``'spawn'``. ``'fork'``
-          may be used for macOS to speed up the calculation or to solve
-          Runtime Errors, however it is considered unsafe.
-        omp_num_threads (Optional[int]): number of OpenMP threads
+        losses (bool):          Boolean to activate loss maps output
+        omp_num_threads (int):  Number of OpenMP threads
           (default: automatic)
 
     The following keyword arguments overload the Lattice values
 
     Keyword arguments:
-        particle (Optional[Particle]):  circulating particle.
-          Default: ``lattice.particle`` if existing,
-          otherwise ``Particle('relativistic')``
-        energy (Optiona[float]):        lattice energy. Default 0.
+        particle (Particle):    circulating particle.
+          Default: *lattice.particle* if existing,
+          otherwise *Particle('relativistic')*
+        energy (float):         lattice energy. Default 0.
 
-    If ``energy`` is not available, relativistic tracking if forced,
-    ``rest_energy`` is ignored.
+    If *energy* is not available, relativistic tracking if forced,
+    *rest_energy* is ignored.
 
     Returns:
         r_out: (6, N, R, T) array containing output coordinates of N particles
           at R reference points for T turns.
+        loss_map: If *losses* is :py:obj:`True`: dictionary with the
+          following key:
 
-          If losses ==True: {islost,turn,elem,coord} dictionary containing
-          flag for particles lost (True -> particle lost), turn, element and
-          coordinates at which the particle is lost. Set to zero for particles
-          that survived
+          ==============    ===================================================
+          **islost**        (npart,) bool array indicating lost particles
+          **turn**          (npart,) int array indicating the turn at
+                            which the particle is lost
+          **element**       ((npart,) int array indicating the element at
+                            which the particle is lost
+          **coord**         (6, npart) float array giving the coordinates at
+                            which the particle is lost (zero for surviving
+                            particles)
+          ==============    ===================================================
 
     .. note::
 
        * For multiparticle tracking with large number of turn the size of
-         ``r_out`` may increase excessively. To avoid memory issues
+         *r_out* may increase excessively. To avoid memory issues
          ``patpass(lattice, r_in, refpts=[])`` can be used. An empty list
          is returned and the tracking results of the last turn are stored in
-         ``r_in``.
-       * By default, ``patpass`` will use all the available CPUs, to change
-         the number of cores used in ALL functions using ``patpass``
-         (``acceptance`` module for example) it is possible to set
-         ``at.DConstant.patpass_poolsize`` to the desired value
+         *r_in*.
+       * By default, :py:func:`patpass` will use all the available CPUs.
+         To change the number of cores used in ALL functions using
+         :py:func:`patpass` (:py:mod:`~at.acceptance.acceptance` module for
+         example) it is possible to set ``at.DConstant.patpass_poolsize``
+         to the desired value.
 
     """
     def collective(rg) -> bool:
@@ -148,25 +165,26 @@ def patpass(ring, r_in, nturns=1, refpts=None, pool_size=None,
                 return True
         return False
 
-    if not isinstance(ring, list):
-        ring = list(ring)
+    if not isinstance(lattice, list):
+        lattice = list(lattice)
     if refpts is None:
-        refpts = len(ring)
-    refpts = uint32_refpts(refpts, len(ring))
-    bunch_currents = getattr(ring, 'bunch_currents', np.zeros(1))
-    bunch_spos = getattr(ring, 'bunch_spos', np.zeros(1))
+        refpts = len(lattice)
+    refpts = uint32_refpts(refpts, len(lattice))
+    bunch_currents = getattr(lattice, 'bunch_currents', np.zeros(1))
+    bunch_spos = getattr(lattice, 'bunch_spos', np.zeros(1))
     kwargs.update(bunch_currents=bunch_currents, bunch_spos=bunch_spos)
-    any_collective = collective(ring)
+    kwargs['reuse'] = kwargs.pop('keep_lattice', False)
+    any_collective = collective(lattice)
     rshape = r_in.shape
     if len(rshape) >= 2 and rshape[1] > 1 and not any_collective:
         if pool_size is None:
             pool_size = min(len(r_in[0]), multiprocessing.cpu_count(),
                             DConstant.patpass_poolsize)
-        return _pass(ring, r_in, pool_size, start_method, nturns=nturns,
+        return _pass(lattice, r_in, pool_size, start_method, nturns=nturns,
                      refpts=refpts, **kwargs)
     else:
         if any_collective:
             warn(AtWarning('Collective PassMethod found: use single process'))
         else:
             warn(AtWarning('no parallel computation for a single particle'))
-        return _atpassf(ring, r_in, nturns=nturns, refpts=refpts, **kwargs)
+        return _atpass(lattice, r_in, nturns=nturns, refpts=refpts, **kwargs)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -3,8 +3,8 @@ import functools
 from warnings import warn
 # noinspection PyUnresolvedReferences
 from .atpass import atpass as _atpass, elempass as _elempass
-from ..lattice import DConstant, uint32_refpts, get_elements
-from ..lattice import BeamMoments
+from ..lattice import Element, Particle, Refpts, uint32_refpts
+from typing import Iterable
 
 
 __all__ = ['fortran_align', 'lattice_pass', 'element_pass', 'atpass',
@@ -13,15 +13,20 @@ __all__ = ['fortran_align', 'lattice_pass', 'element_pass', 'atpass',
 DIMENSION_ERROR = 'Input to lattice_pass() must be a 6xN array.'
 
 
-def _set_beam_monitors(ring, nturns):
-    monitors = get_elements(ring, BeamMoments)
-    for m in monitors:
-        m.set_buffers(nturns, ring.nbunch)
-    return len(monitors) == 0
-
-
 def fortran_align(func):
-    """Ensure that r_in is Fortran-aligned"""
+    """decorator to ensure that *r_in* is Fortran-aligned
+
+    :py:func:`fortran_align` ensures that the 2nd argument (usually *r_in*) of
+    the decorated function is Fortran-aligned before calling the function
+
+    Example:
+
+        >>> @fortran_align
+        ... def element_pass(element: Element, r_in, **kwargs):
+        ... ...
+
+        Ensure than *r_in* is Fortran-aligned
+    """
     @functools.wraps(func)
     def wrapper(lattice, r_in, *args, **kwargs):
         assert r_in.shape[0] == 6 and r_in.ndim in (1, 2), DIMENSION_ERROR
@@ -36,118 +41,120 @@ def fortran_align(func):
     return wrapper
 
 
-# noinspection PyIncorrectDocstring
 @fortran_align
-def lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
-                 omp_num_threads=None, **kwargs):
+def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
+                 refpts: Refpts = None, **kwargs):
     """
-    lattice_pass(lattice, r_in, nturns=1, refpts=None, keep_lattice=False,
-    keep_counter=False, turn=0, losses=False, omp_num_threads=None)
-
-    lattice_pass tracks particles through each element of a lattice
+    :py:func:`lattice_pass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's
-    ``PassMethod`` field.
+    *PassMethod* field.
 
     Parameters:
-        lattice (Iterable[Element]): list of elements
-        r_in:                   6 x n_particles Fortran-ordered numpy array.
-          On return, rin contains the final coordinates of the particles
-        nturns (int):           number of turns to be tracked
-        refpts (Uint32_refs):   numpy array of indices of elements where
+        lattice:                list of elements
+        r_in:                   (6, N) array: input coordinates of N particles.
+          *r_in* is modified in-place and reports the coordinates at
+          the end of the element. For the best efficiency, *r_in*
+          should be given as F_CONTIGUOUS numpy array.
+        nturns:                 number of turns to be tracked
+        refpts:                 numpy array of indices of elements where
           output is desired:
 
+          * len(line) means end of the last element (default)
           * 0 means entrance of the first element
-          * len(line) means end of the last element
 
     Keyword arguments:
-        keep_lattice (Optional[bool]):  use elements persisted from a previous
+        keep_lattice (bool):    Use elements persisted from a previous
           call. If True, assume that the lattice has not changed since
           the previous call.
-        keep_counter (Optional[bool]):  Keep the turn number from the previous
+        keep_counter (bool):    Keep the turn number from the previous
           call.
-        turn (Optional[int]):           Starting turn number. Ignored if
+        turn (int):             Starting turn number. Ignored if
           keep_counter is True. The turn number is necessary to compute the
           absolute path length used in RFCavityPass.
-        losses (Optional[bool]):        Boolean to activate loss maps output
-        omp_num_threads (Optional[int]): number of OpenMP threads
+        losses (bool):          Boolean to activate loss maps output
+        omp_num_threads (int):  Number of OpenMP threads
           (default: automatic)
 
     The following keyword arguments overload the Lattice values
 
     Keyword arguments:
-        particle (Optional[Particle]):  circulating particle.
-          Default: ``lattice.particle`` if existing,
-          otherwise ``Particle('relativistic')``
-        energy (Optiona[float]):        lattice energy. Default 0.
+        particle (Particle):    circulating particle.
+          Default: *lattice.particle* if existing,
+          otherwise *Particle('relativistic')*
+        energy (float):         lattice energy. Default 0.
 
-    If ``energy`` is not available, relativistic tracking if forced,
-    ``rest_energy`` is ignored.
+    If *energy* is not available, relativistic tracking if forced,
+    *rest_energy* is ignored.
 
     Returns:
         r_out: (6, N, R, T) array containing output coordinates of N particles
           at R reference points for T turns.
+        loss_map: If *losses* is :py:obj:`True`: dictionary with the
+          following key:
 
-          If losses is True: {islost,turn,elem,coord} dictionary containing
-          flag for particles lost (True -> particle lost), turn, element and
-          coordinates at which the particle is lost. Set to zero for particles
-          that survived
+          ==============    ===================================================
+          **islost**        (npart,) bool array indicating lost particles
+          **turn**          (npart,) int array indicating the turn at
+                            which the particle is lost
+          **element**       ((npart,) int array indicating the element at
+                            which the particle is lost
+          **coord**         (6, npart) float array giving the coordinates at
+                            which the particle is lost (zero for surviving
+                            particles)
+          ==============    ===================================================
 
     .. note::
 
        * ``lattice_pass(lattice, r_in, refpts=len(line))`` is the same as
          ``lattice_pass(lattice, r_in)`` since the reference point len(line) is
          the exit of the last element.
-       * ``lattice_pass(lattice, r_in, refpts=0)`` is a copy of ``r_in`` since
+       * ``lattice_pass(lattice, r_in, refpts=0)`` is a copy of *r_in* since
          the reference point 0 is the entrance of the first element.
        * To resume an interrupted tracking (for instance to get intermediate
-         results), one must use one of the ``turn`` or ``keep_counter``
+         results), one must use one of the *turn* or *keep_counter*
          keywords to ensure the continuity of the turn number.
        * For multiparticle tracking with large number of turn the size of
-         ``r_out`` may increase excessively. To avoid memory issues
+         *r_out* may increase excessively. To avoid memory issues
          ``lattice_pass(lattice, r_in, refpts=[])`` can be used. An empty list
          is returned and the tracking results of the last turn are stored in
-         ``r_in``.
+         *r_in*.
 
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
     if refpts is None:
         refpts = len(lattice)
-    if omp_num_threads is None:
-        omp_num_threads = DConstant.omp_num_threads
     refs = uint32_refpts(refpts, len(lattice))
-    no_bm = _set_beam_monitors(lattice, nturns)
-    keep_lattice = keep_lattice and no_bm
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))
     bunch_spos = getattr(lattice, 'bunch_spos', numpy.zeros(1))
-    kwargs.update({'bunch_currents': bunch_currents,
-                   'bunch_spos': bunch_spos})
-    # atpass returns 6xAxBxC array where n = x*y*z;
-    # * A is number of particles;
-    # * B is number of refpts
-    # * C is the number of turns
-    return _atpass(lattice, r_in, nturns, refpts=refs, reuse=keep_lattice,
-                   omp_num_threads=omp_num_threads, **kwargs)
+    kwargs.update(bunch_currents=bunch_currents, bunch_spos=bunch_spos)
+    kwargs['reuse'] = kwargs.pop('keep_lattice', False)
+    # atpass returns 6xNxRxT array
+    # * N is number of particles;
+    # * R is number of refpts
+    # * T is the number of turns
+    return _atpass(lattice, r_in, nturns, refpts=refs, **kwargs)
 
 
 @fortran_align
-def element_pass(element, r_in, **kwargs):
+def element_pass(element: Element, r_in, **kwargs):
     """Tracks particles through a single element.
 
     Parameters:
-        element (Element):  AT element
-        r_in:               (6, N) array: input coordinates of N particles.
-          r_in is modified in-place and reports the coordinates at
-          the end of the element. For the best efficiency, r_in
+        element:                AT element
+        r_in:                   (6, N) array: input coordinates of N particles.
+          *r_in* is modified in-place and reports the coordinates at
+          the end of the element. For the best efficiency, *r_in*
           should be given as F_CONTIGUOUS numpy array.
 
     Keyword arguments:
-        particle (Optional[Particle]):  circulating particle.
-          Default: Particle('relativistic')
-        energy (Optiona[float]):        lattice energy
+        particle (Particle):    circulating particle.
+          Default: *lattice.particle* if existing,
+          otherwise *Particle('relativistic')*
+        energy (float):         lattice energy. Default 0.
 
-    If ``energy`` is not available, relativistic tracking if forced,
-    ``rest_energy`` is ignored.
+    If *energy* is not available, relativistic tracking if forced,
+    *rest_energy* is ignored.
 
     Returns:
         r_out:              (6, N) array containing output the coordinates of
@@ -159,10 +166,9 @@ def element_pass(element, r_in, **kwargs):
 # noinspection PyIncorrectDocstring
 def atpass(*args, **kwargs):
     """
-    atpass(line, r in, nturns, refpts=[], reuse=False, omp_num_threads=0)
+    atpass(line, r_in, nturns, refpts=[], reuse=False, omp_num_threads=0)
 
-    Track input particles ``rin`` along line for ``nturns`` turns.
-    Record 6D phase space at elements corresponding to refpts for each turn.
+    Track input particles *r_in* along line for *nturns* turns.
 
     Parameters:
         line (Sequence[Element]): list of elements
@@ -180,11 +186,11 @@ def atpass(*args, **kwargs):
         energy:                 nominal energy [eV]
         rest_energy:            rest_energy of the particle [eV]
         charge:                 particle charge [elementary charge]
-        reuse (Optional[bool]): if True, use previously cached description
+        reuse (bool):           if True, use previously cached description
           of the lattice.
-        omp_num_threads (Optional[int]): number of OpenMP threads
+        omp_num_threads (int):  number of OpenMP threads
           (default 0: automatic)
-        losses (Optional[bool]):if True, process losses
+        losses (bool):          if True, process losses
 
     Returns:
         r_out:  6 x n_particles x n_refpts x n_turns Fortran-ordered
@@ -198,9 +204,9 @@ def atpass(*args, **kwargs):
 
 # noinspection PyIncorrectDocstring
 def elempass(*args, **kwargs):
-    """elempass(element, rin)
+    """elempass(element, r_in)
 
-    Tracks input particles rin through a single element.
+    Track input particles *r_in* through a single element.
 
     Parameters:
         element (Element):  AT element

--- a/pyat/test/test_patpass.py
+++ b/pyat/test/test_patpass.py
@@ -9,7 +9,7 @@ import pytest
 def test_patpass_multiple_particles_and_turns():
     nturns = 10
     nparticles = 10
-    rin = numpy.zeros((6, nparticles), order='F')
+    rin = numpy.zeros((6, nparticles))
     d = elements.Drift('drift', 1.0)
     lattice = [d]
     rin[1, 0] = 1e-6

--- a/pyat/test/test_patpass.py
+++ b/pyat/test/test_patpass.py
@@ -9,7 +9,7 @@ import pytest
 def test_patpass_multiple_particles_and_turns():
     nturns = 10
     nparticles = 10
-    rin = numpy.zeros((6, nparticles))
+    rin = numpy.zeros((6, nparticles), order='F')
     d = elements.Drift('drift', 1.0)
     lattice = [d]
     rin[1, 0] = 1e-6

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,13 @@ at = Extension(
     extra_link_args=omp_lflags
 )
 
+cconfig = Extension(
+    'at.cconfig',
+    sources=[join('pyat', 'at', 'cconfig.c')],
+    define_macros=macros + omp_macros + mpi_macros,
+    extra_compile_args=cflags + omp_cflags,
+)
+
 diffmatrix = Extension(
     name='at.physics.diffmatrix',
     sources=[diffmatrix_source],
@@ -142,7 +149,7 @@ diffmatrix = Extension(
 )
 
 setup(
-    ext_modules=[at, diffmatrix] +
+    ext_modules=[at, cconfig, diffmatrix] +
                 [c_integrator_ext(pm) for pm in c_pass_methods] +
                 [cpp_integrator_ext(pm) for pm in cpp_pass_methods],
 )


### PR DESCRIPTION
The simple random number generators (RNG) used up to now are not compatible with parallel processing: the streams of numbers in the different threads are likely to be identical. We'll try here to solve this problem.