### PR TITLE
Elemrnt rotations

### DIFF
--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -720,6 +720,14 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
     the ``y``-axis.
     A positive angle represent a clockwise rotation when looking in
     the direction of the roation axis.
+    
+    The transformations are not all commmutative, the tilt is always the
+    last transformation applied.
+    
+    In case ``relative=True``, the previous angle and shifts are derived
+    form the R and T matrix and incremented by the input arguments.
+    
+    The shift is always conserved regardless of the value of ``relative``
 
     Parameters:
         elem:           Element to be tilted
@@ -742,10 +750,10 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         rr2 = rr1.T
         t1 = numpy.array([ay, -yaw, ap, -pitch, 0, 0])
         t2 = numpy.array([ay, yaw, ap, pitch, 0, 0])
-        rt1 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
+        rt1 = numpy.eye(6, order='F')
         rt1[1, 4] = ct*t1[1]
         rt1[3, 4] = ct*t1[3]
-        rt2 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
+        rt2 = numpy.eye(6, order='F')
         rt2[1, 4] = ct*t2[1]
         rt2[3, 4] = ct*t2[3]
         return rr1 @ rt1, rt2 @ rr2, t1, t2
@@ -756,7 +764,7 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
     t10 = numpy.zeros(6)
     t20 = numpy.zeros(6)
     if hasattr(elem, 'R1') and hasattr(elem, 'R2'):
-        rr10 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
+        rr10 = numpy.eye(6, order='F')
         rr10[:4, :4] = elem.R1[:4, :4]
         rt10 = rr10.T @ elem.R1
         tilt0 = numpy.arctan2(rr10[0, 2], rr10[0, 0])

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -724,8 +724,7 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         pitch:          Pitch angle [rd]
         yaw:            Yaw angle [rd]
         relative:       If True, the rotation is added to the previous one
-    """
-    
+    """ 
     def _get_rm_tv(le, tilt, pitch, yaw):
         ct = numpy.cos(tilt)
         st = numpy.sin(tilt)
@@ -745,18 +744,20 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         rt2[1, 4] =  ct*t2[1]
         rt2[3, 4] =  ct*t2[3]
         return rr1 @ rt1, rt2 @ rr2, t1, t2
-    
-    le = elem.Length
-    
-    if relative and hasattr(elem, 'R1') and hasattr(elem, 'R2'):
-        rr10 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
-        rr10[:4, :4] = elem.R1[:4, :4]
-        rt10 = rr10.T @ elem.R1     
-        tilt += numpy.arctan2(rr10[0, 2], rr10[0, 0])
-        yaw += rt10[1, 4]/rr10[0, 0]
-        pitch += rt10[3, 4]/rr10[0, 0]  
         
-    r1, r2, t1, t2 = _get_rm_tv(le, tilt, pitch, yaw)      
+    rr10 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
+    rr10[:4, :4] = elem.R1[:4, :4]
+    rt10 = rr10.T @ elem.R1     
+    tilt0 = numpy.arctan2(rr10[0, 2], rr10[0, 0])
+    yaw0 = rt10[1, 4]/rr10[0, 0]
+    pitch0 = rt10[3, 4]/rr10[0, 0]
+    _, _, t10, t20 = _get_rm_tv(elem.Length, tilt0, pitch0, yaw0)    
+  
+  
+    if relative and hasattr(elem, 'R1') and hasattr(elem, 'R2'):
+ 
+        
+    r1, r2, t1, t2 = _get_rm_tv(elem.Length, tilt, pitch, yaw)      
             
     if relative and hasattr(elem, 'T1') and hasattr(elem, 'T2'):
         t1 -= elem.T1

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -829,7 +829,7 @@ def set_rotation(ring: Sequence[Element], tilts=0.0,
     tilts = numpy.broadcast_to(tilts, (len(ring),))
     pitches = numpy.broadcast_to(tilts, (len(ring),))
     yaws = numpy.broadcast_to(tilts, (len(ring),))
-    for el, tilt, pitch, tilt in zip(ring, tilts, pitches, yaws):
+    for el, tilt, pitch, yaw in zip(ring, tilts, pitches, yaws):
         rotate_elem(el, tilt=tilt, pitch=pitch, yaw=yaw, relative=relative)
 
 def set_tilt(ring: Sequence[Element], tilts, relative=False) -> None:

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -725,6 +725,8 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         yaw:            Yaw angle [rd]
         relative:       If True, the rotation is added to the previous one
     """
+    
+    def _get_rmat(le, titl, pitch, yaw):
     le = elem.Length
     ct, cp, cy = numpy.cos(tilt), numpy.cos(pitch), numpy.cos(yaw)
     st, sp, sy = numpy.sin(tilt), numpy.sin(pitch), numpy.sin(yaw)
@@ -750,14 +752,12 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
     
     if relative:
         if hasattr(elem, 'R1') and hasattr(elem, 'R2'):
-            r10 = elem.R1
-            r20 = elem.R2
             rr10 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
-            rr10[:4, :4] = r10[:4, :4]
-            rt10 = rr10.T @ r10
-            rr20 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
-            rr20[:4, :4] = r20[:4, :4]
-            rt20 = rr20.T @ r20          
+            rr10[:4, :4] = elem.R1[:4, :4]
+            rt10 = rr10.T @ elem.R1     
+            titl0 = numpy.arctan2(rr10[0, 2], rr10[0, 0])
+            yaw0 = rt10[1, 4]/rr10[0, 0]
+            pitch0 = rt10[3, 4]/rr10[0, 0]  
         else:
             elem.R1 = r1
             elem.R2 = r2

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -766,10 +766,10 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         yaw += yaw0
     
     r1, r2, t1, t2 = _get_rm_tv(elem.Length, tilt, pitch, yaw)          
-    elem.R1 = numpy.round(r1, decimals = 15)
-    elem.R2 = numpy.round(r2, decimals = 15)
-    elem.T1 = numpy.round(t1+t10, decimals = 15)
-    elem.T2 = numpy.round(t2+t20, decimals = 15)
+    elem.R1 = r1
+    elem.R2 = r2
+    elem.T1 = t1+t10
+    elem.T2 = t2+t20
 
 
 def tilt_elem(elem: Element, rots: float, relative: bool = False) -> None:

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -726,6 +726,9 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         relative:       If True, the rotation is added to the previous one
     """ 
     def _get_rm_tv(le, tilt, pitch, yaw):
+        tilt = numpy.around(tilt, decimals=15)
+        pitch = numpy.around(pitch, decimals=15)
+        yaw = numpy.around(yaw, decimals=15)
         ct, st = numpy.cos(tilt), numpy.sin(tilt)
         ap, ay = -0.5*le*numpy.sin(pitch), -0.5*le*numpy.sin(yaw)      
         rr1 = numpy.asfortranarray(numpy.diag([ct, ct, ct, ct, 1.0, 1.0]))

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -308,8 +308,9 @@ def checkattr(attrname: str, attrvalue: Optional = None) \
     # noinspection PyUnresolvedReferences
     """Checks the presence or the value of an attribute
 
-        Returns a function to be used as an ``Element`` filter, which checks the
-        presence or the value of an attribute of the provided ``Element``.
+        Returns a function to be used as an ``Element`` filter, which
+        checks the presence or the value of an attribute of the
+        provided ``Element``.
         This function can be used to extract from a ring all elements
         having a given attribute.
 
@@ -373,8 +374,8 @@ def checkname(pattern: str) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     """Checks the name of an element
 
-        Returns a function to be used as an ``Element`` filter, which checks the
-        name of the provided ``Element``.
+        Returns a function to be used as an ``Element`` filter,
+        which checks the name of the provided ``Element``.
         This function can be used to extract from a ring all elements
         having a given name.
 
@@ -669,9 +670,11 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
             getattr(elem, attrname)[index] = value
 
     if increment:
-        attrvalues += get_value_refpts(ring, refpts, attrname, index=index)
+        attrvalues += get_value_refpts(ring, refpts,
+                                       attrname, index=index)
     else:
-        attrvalues = numpy.broadcast_to(attrvalues, (refpts_len(ring, refpts),))
+        attrvalues = numpy.broadcast_to(attrvalues,
+                                        (refpts_len(ring, refpts),))
 
     # noinspection PyShadowingNames
     @make_copy(copy)
@@ -707,8 +710,8 @@ def get_s_pos(ring: Sequence[Element], refpts: Optional[Refpts] = None) \
     s_pos = numpy.concatenate(([0.0], s_pos))
     refpts = _uint32_refs(ring, refpts)
     return s_pos[refpts]
-    
-    
+
+
 def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
                 yaw: float = 0.0, relative: bool = False) -> None:
     r"""Set the tilt, pitch and yaw angle of an ``Element``.
@@ -724,51 +727,51 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
         pitch:          Pitch angle [rd]
         yaw:            Yaw angle [rd]
         relative:       If True, the rotation is added to the previous one
-    """ 
+    """
     def _get_rm_tv(le, tilt, pitch, yaw):
         tilt = numpy.around(tilt, decimals=15)
         pitch = numpy.around(pitch, decimals=15)
         yaw = numpy.around(yaw, decimals=15)
         ct, st = numpy.cos(tilt), numpy.sin(tilt)
-        ap, ay = -0.5*le*numpy.sin(pitch), -0.5*le*numpy.sin(yaw)      
+        ap, ay = -0.5*le*numpy.sin(pitch), -0.5*le*numpy.sin(yaw)
         rr1 = numpy.asfortranarray(numpy.diag([ct, ct, ct, ct, 1.0, 1.0]))
         rr1[0, 2] = st
-        rr1[1, 3] = st 
+        rr1[1, 3] = st
         rr1[2, 0] = -st
         rr1[3, 1] = -st
-        rr2 = rr1.T      
+        rr2 = rr1.T
         t1 = numpy.array([ay, -yaw, ap, -pitch, 0, 0])
-        t2 = numpy.array([ay, yaw, ap, pitch, 0, 0])     
+        t2 = numpy.array([ay, yaw, ap, pitch, 0, 0])
         rt1 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
-        rt1[1, 4] =  ct*t1[1]
-        rt1[3, 4] =  ct*t1[3]       
+        rt1[1, 4] = ct*t1[1]
+        rt1[3, 4] = ct*t1[3]
         rt2 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
-        rt2[1, 4] =  ct*t2[1]
-        rt2[3, 4] =  ct*t2[3]
+        rt2[1, 4] = ct*t2[1]
+        rt2[3, 4] = ct*t2[3]
         return rr1 @ rt1, rt2 @ rr2, t1, t2
-    
-    tilt0 = 0.0    
+
+    tilt0 = 0.0
     pitch0 = 0.0
-    yaw0 = 0.0    
+    yaw0 = 0.0
     t10 = numpy.zeros(6)
-    t20 = numpy.zeros(6)   
+    t20 = numpy.zeros(6)
     if hasattr(elem, 'R1') and hasattr(elem, 'R2'):
         rr10 = numpy.asfortranarray(numpy.diag(numpy.ones(6)))
         rr10[:4, :4] = elem.R1[:4, :4]
-        rt10 = rr10.T @ elem.R1     
+        rt10 = rr10.T @ elem.R1
         tilt0 = numpy.arctan2(rr10[0, 2], rr10[0, 0])
         yaw0 = -rt10[1, 4]/rr10[0, 0]
-        pitch0 = -rt10[3, 4]/rr10[0, 0]       
-        _, _, t10, t20 = _get_rm_tv(elem.Length, tilt0, pitch0, yaw0)      
+        pitch0 = -rt10[3, 4]/rr10[0, 0]
+        _, _, t10, t20 = _get_rm_tv(elem.Length, tilt0, pitch0, yaw0)
     if hasattr(elem, 'T1') and hasattr(elem, 'T2'):
         t10 = elem.T1-t10
-        t20 = elem.T2-t20      
+        t20 = elem.T2-t20
     if relative:
         tilt += tilt0
         pitch += pitch0
         yaw += yaw0
-    
-    r1, r2, t1, t2 = _get_rm_tv(elem.Length, tilt, pitch, yaw)          
+
+    r1, r2, t1, t2 = _get_rm_tv(elem.Length, tilt, pitch, yaw)
     elem.R1 = r1
     elem.R2 = r2
     elem.T1 = t1+t10
@@ -815,7 +818,8 @@ def shift_elem(elem: Element, deltax: float = 0.0, deltaz: float = 0.0,
         elem.T1 = -tr
         elem.T2 = tr
 
-def set_rotation(ring: Sequence[Element], tilts=0.0, 
+
+def set_rotation(ring: Sequence[Element], tilts=0.0,
                  pitches=0.0, yaws=0.0, relative=False) -> None:
     """Sets the tilts of a list of elements.
 
@@ -834,6 +838,7 @@ def set_rotation(ring: Sequence[Element], tilts=0.0,
     yaws = numpy.broadcast_to(tilts, (len(ring),))
     for el, tilt, pitch, yaw in zip(ring, tilts, pitches, yaws):
         rotate_elem(el, tilt=tilt, pitch=pitch, yaw=yaw, relative=relative)
+
 
 def set_tilt(ring: Sequence[Element], tilts, relative=False) -> None:
     """Sets the tilts of a list of elements.


### PR DESCRIPTION
This PR is a follow-up of #512. It was pointed out that there was no function to provide pitch and yaw in python. The proposed solution was using the wrong coordinate system and needed to be improved.

The change of coordinate from angle (input argument) to momentum is done using the `R1` and `R2` matrices.

`relative` option is still available but a bit tricky because some of the transformations are not commutative. 
This implementation is a at the stage of a proposal, ideas and suggestions welcome!

If we are happy with this, it can easily be ported to matlab.