### PR TITLE
Upgrade scipy requirement to 1.4.0

### DIFF
--- a/githubproject.toml
+++ b/githubproject.toml
@@ -11,6 +11,7 @@ requires = [
     "numpy ~= 1.21.3;python_version>='3.10'",
     "setuptools >= 62",
     "setuptools_scm >= 7",
+    "mpi4py; extra=='mpi'", # Does not work yet, so we need in-tree backend
     "wheel",
 ]
 # build-backend = "setuptools.build_meta"
@@ -46,7 +47,7 @@ Home="https://atcollab.github.io/at/"
 mpi = ["mpi4py"]
 plot = ["matplotlib"]
 dev = ["pytest >= 2.9", "pytest-lazy-fixture", "pytest-cov", "flake8"]
-doc = ["Sphinx >= 5.0.2", "myst-parser", "pydata-sphinx-theme < 0.10", "sphinx-copybutton"]
+doc = ["Sphinx ~= 5.3", "myst-parser", "pydata-sphinx-theme ~= 0.11.0", "sphinx-copybutton"]
 
 # tool.setuptools is still in BETA, so we keep temporarily setup.cfg
 

--- a/githubproject.toml
+++ b/githubproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.7"
 dependencies = [
     "importlib-resources;python_version<'3.9'",
     "numpy>=1.16.6",
-    "scipy>=0.16"
+    "scipy>=1.4.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.7"
 dependencies = [
     "importlib-resources;python_version<'3.9'",
     "numpy>=1.16.6",
-    "scipy>=0.16"
+    "scipy>=1.4.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
#517 reported a problem with scipy constants. Requiring scipy >= 1.4.0 solves this. Scipy 1.4.0 was issued on 17/12/2019 and includes the upgrade of all physical constants to the [CODATA 2018 values](https://physics.nist.gov/cuu/Constants/index.html).