### PR TITLE
check_collective

### DIFF
--- a/pyat/at/acceptance/acceptance.py
+++ b/pyat/at/acceptance/acceptance.py
@@ -5,7 +5,7 @@ from .boundary import GridMode
 from .boundary import boundary_search
 from typing import Optional, Sequence
 import multiprocessing
-from ..lattice import Lattice, Refpts
+from ..lattice import Lattice, Refpts, check_collective
 from ..physics import frequency_control
 
 
@@ -14,6 +14,7 @@ __all__ = ['get_acceptance', 'get_1d_acceptance', 'get_horizontal_acceptance',
 
 
 @frequency_control
+@check_collective(False)
 def get_acceptance(
         ring: Lattice, planes, npoints, amplitudes,
         nturns: Optional[int] = 1024,

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -31,7 +31,7 @@ Key = Union[type, Element, str]
 
 
 __all__ = ['AtError', 'AtWarning', 'check_radiation', 'check_6d',
-           'set_radiation', 'set_6d',
+           'set_radiation', 'set_6d', 'check_collective',
            'make_copy', 'uint32_refpts', 'bool_refpts',
            'checkattr', 'checktype', 'checkname',
            'get_cells', 'get_elements', 'get_refpts', 'get_s_pos',
@@ -151,6 +151,45 @@ def set_6d(is_6d: bool) -> Callable:
                 return func(rg, *args, **kwargs)
             return wrapper
     return setrad_decorator
+    
+    
+def check_collective(is_collective: bool) -> Callable:
+    """Decorator for optics functions
+
+    Wraps a function like ``func(ring, *args, **kwargs)`` where ring is a
+    :py:class:`.Lattice` object. Raise :py:class:`.AtError` if
+    ``ring.is_collective`` is not the desired ``is_collective`` state.
+    No test is performed if ring is not a :py:class:`.Lattice`.
+
+    Parameters:
+        is_collective: Desired collective state
+
+    Raises:
+        AtError: if ``ring.is_collective`` is not ``is_collective``
+
+    Example:
+
+        .. code-block:: python
+
+            @check_collective(False)
+            def find_orbit4(ring, dct=None, guess=None, **kwargs):
+                ...
+
+        Raises :py:class:`.AtError` if ``ring.is_collective`` is :py:obj:`True`
+
+    See Also:
+        :py:func:`set_6d`
+    """
+    def collective_decorator(func):
+        @functools.wraps(func)
+        def wrapper(ring, *args, **kwargs):
+            ringcol = getattr(ring, 'is_collective', is_collective)
+            if ringcol != is_collective:
+                raise AtError('{0} needs "ring.is_collective" {1}'.format(
+                    func.__name__, is_collective))
+            return func(ring, *args, **kwargs)
+        return wrapper
+    return collective_decorator
 
 
 def make_copy(copy: bool) -> Callable:

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 import numpy
 from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts
-from at.lattice import check_radiation, AtError, AtWarning
+from at.lattice import check_6d, AtError, AtWarning
 from at.lattice import checktype, set_value_refpts, get_cells, refpts_len
 from at.constants import clight, Cgamma
 from at.tracking import lattice_pass
@@ -64,7 +64,7 @@ def get_energy_loss(ring: Lattice,
         return e_loss
 
     # noinspection PyShadowingNames
-    @check_radiation(True)
+    @check_6d(True)
     def tracking(ring):
         """Losses from tracking
         """

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -8,7 +8,8 @@ import warnings
 from scipy.linalg import solve
 from ..constants import clight
 from ..lattice import DConstant, get_s_pos, Refpts
-from ..lattice import AtWarning, Lattice, check_6d
+from ..lattice import AtWarning, Lattice
+from ..lattice import check_6d, check_collective
 from ..tracking import lattice_pass
 from .orbit import Orbit, find_orbit4, find_orbit6
 from .matrix import find_m44, find_m66
@@ -633,6 +634,7 @@ def linopt4(ring: Lattice, *args, **kwargs):
     return _linopt(ring, _analyze4, *args, **kwargs)
 
 
+@check_collective(False)
 def linopt6(ring: Lattice, *args, **kwargs):
     r"""Linear analysis of a fully coupled lattice using normal modes
 
@@ -1065,6 +1067,7 @@ def avlinopt(ring: Lattice, dp: float = None, refpts: Refpts = None, **kwargs):
     return lindata, avebeta, avemu, avedisp, aves, bd.tune, bd.chromaticity
 
 
+@check_collective(False) 
 def get_tune(ring: Lattice, *, method: str = 'linopt',
              dp: float = None, dct: float = None, df: float = None,
              orbit: Orbit = None, **kwargs):
@@ -1138,6 +1141,7 @@ def get_tune(ring: Lattice, *, method: str = 'linopt',
     return tunes
 
 
+@check_collective(False)
 def get_chrom(ring: Lattice, *, method: str = 'linopt',
               dp: float = None, dct: float = None, df: float = None,
               cavpts: Refpts = None, **kwargs):

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -6,6 +6,7 @@ A collection of functions to compute 4x4 and 6x6 transfer matrices
 import numpy
 from ..lattice import Lattice, Element, get_refpts, DConstant, Refpts
 from ..lattice.elements import Bend, M66
+from at.lattice import check_collective, check_6d
 from ..tracking import lattice_pass, element_pass
 from .orbit import Orbit, find_orbit4, find_orbit6
 from .amat import jmat, symplectify
@@ -15,6 +16,7 @@ __all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'gen_m66_elem']
 _jmt = jmat(2)
 
 
+@check_6d(False)
 def find_m44(ring: Lattice, dp: float = None, refpts: Refpts = None,
              dct: float = None, df: float = None,
              orbit: Orbit = None, keep_lattice: bool = False, **kwargs):
@@ -100,6 +102,7 @@ def find_m44(ring: Lattice, dp: float = None, refpts: Refpts = None,
     return m44, mstack
 
 
+@check_collective(False)
 def find_m66(ring: Lattice, refpts: Refpts = None,
              orbit: Orbit = None, keep_lattice: bool = False, **kwargs):
     """One-turn 6x6 transfer matrix

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -4,7 +4,7 @@ Non-linear optics
 import numpy
 from typing import Optional, Sequence
 from scipy.special import factorial
-from ..lattice import Element, Lattice
+from ..lattice import Element, Lattice, check_collective
 from ..tracking import lattice_pass
 from .orbit import Orbit, find_orbit
 from .linear import get_tune, get_chrom, linopt6
@@ -13,6 +13,7 @@ from .harmonic_analysis import get_tunes_harmonic
 __all__ = ['detuning', 'chromaticity', 'gen_detuning_elem']
 
 
+@check_collective(False)
 def tunes_vs_amp(ring: Lattice, amp: Optional[Sequence[float]] = None,
                  dim: Optional[int] = 0, window=1,
                  nturns: Optional[int] = 512) -> numpy.ndarray:

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,6 +4,7 @@ Closed orbit related functions
 import numpy
 from at.constants import clight
 from at.lattice import AtError, AtWarning, check_6d, DConstant
+from at.lattice import check_collective
 from at.lattice import Lattice, get_s_pos, uint32_refpts, Refpts
 from at.tracking import lattice_pass
 from . import ELossMethod, get_timelag_fromU0
@@ -299,6 +300,7 @@ def find_sync_orbit(ring: Lattice, dct: float = None, refpts: Refpts = None, *,
     return orbit, all_points
 
 
+@check_collective(False)
 def _orbit6(ring: Lattice, cavpts=None, guess=None, keep_lattice=False,
             **kwargs):
     """Solver for 6D motion"""

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -5,7 +5,7 @@ from math import sin, cos, tan, sqrt, sinh, cosh, pi
 import numpy
 from typing import Tuple
 from scipy.linalg import inv, det, solve_sylvester
-from at.lattice import Lattice, check_radiation, Refpts
+from at.lattice import Lattice, check_6d, Refpts, check_collective
 from at.lattice import Dipole, Wiggler, DConstant, Multipole, QuantumDiffusion
 from at.lattice import get_refpts, get_value_refpts
 from at.lattice import uint32_refpts, set_value_refpts
@@ -81,7 +81,8 @@ def _lmat(dmat):
     return lmat
 
 
-@check_radiation(True)
+@check_6d(True)
+@check_collective(False)
 def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
                   keep_lattice: bool = False):
     """Calculates the equilibrium beam envelope
@@ -197,6 +198,7 @@ def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
     return data0, r66data, data
 
 
+@check_collective(False)
 def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
         -> Tuple[float, float, float, float, float]:
     r"""Computes the 5 radiation integrals for uncoupled lattices.
@@ -356,7 +358,8 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
     return tuple(integrals)
 
 
-@check_radiation(True)
+@check_6d(True)
+@check_collective(False)
 def quantdiffmat(ring: Lattice, orbit: Orbit = None) -> numpy.ndarray:
     """Computes the diffusion matrix of the whole ring
 
@@ -373,7 +376,8 @@ def quantdiffmat(ring: Lattice, orbit: Orbit = None) -> numpy.ndarray:
     return numpy.round(diffmat[-1], 24)
 
 
-@check_radiation(True)
+@check_6d(True)
+@check_collective(False)
 def gen_quantdiff_elem(ring: Lattice, orbit: Orbit = None) -> QuantumDiffusion:
     """Generates a quantum diffusion element
 
@@ -391,7 +395,8 @@ def gen_quantdiff_elem(ring: Lattice, orbit: Orbit = None) -> QuantumDiffusion:
     return diff_elem
 
 
-@check_radiation(True)
+@check_6d(True)
+@check_collective(False)
 def tapering(ring: Lattice, multipoles: bool = True,
              niter: int = 1, **kwargs) -> None:
     """Scales magnet strengths

--- a/pyat/at/plot/specific.py
+++ b/pyat/at/plot/specific.py
@@ -1,5 +1,5 @@
 """AT plotting functions"""
-from ..lattice import Lattice, Refpts
+from ..lattice import Lattice, Refpts, check_collective
 from ..tracking import lattice_pass
 from ..physics import get_optics, Orbit
 from .generic import baseplot
@@ -177,6 +177,7 @@ def plot_linear(ring: Lattice, *keys, **kwargs):
 # --------- Example 3 --------
 
 # Here the data generating function is embedded in the convenience function
+@check_collective(False)
 def plot_trajectory(ring: Lattice, r_in, nturns: int = 1, **kwargs):
     """Plot a particle's trajectory
 


### PR DESCRIPTION
This PR prevent running single particle calculation with collective passmethods activated in the lattice.
This was causing some crashes in case a multi-bunch fillpattern was initialized as the passmethods were expecting nparticles >=nbunch.

This is a bit cumbersome, I may have overlooked some function, could you please check carefully that this is ok and that I not forgotten anything?
