### PR TITLE
Failure of GitHub action for Matlab compilation error

### DIFF
--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -6,7 +6,7 @@ function githubsetup()
 % user workflow.
 
 savepath('pathdef.m');
-atmexall;
+atmexall -fail
 if ispc
     execfile=fullfile(getenv('pythonLocation'),'pythonw.exe');
     execmode='InProcess';


### PR DESCRIPTION
As discussed [here](https://github.com/atcollab/at/pull/527#issuecomment-1333434260), the "Run Matlab tests" GitHub action fails if Matlab fails to compile AT

There is a new `-fail` flag in atmexall to stop at the 1st error:
```Matlab
atmexall -fail
```

The failure in this branch demonstrate that, but should not prevent merging !