### PR TITLE
at.beam improvement

### DIFF
--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -203,7 +203,7 @@ def beam(nparts: int, sigma, orbit: Orbit = None):
                 # Try x-delta 4x4 matrix
                 sel = [0, 1, 4, 5]
                 idx = np.ix_(sel, sel)
-                lmat[idx] = cholesky(idx)
+                lmat[idx] = cholesky(sigma[idx])
                 lmat[2:4, 2:4] = _get_single_plane(slice(2, 4))
                 print("h, delta")
             except LinAlgError:


### PR DESCRIPTION
`at.beam` again ! The present version processes either fully coupled 6x6 sigma matrices, or fully decoupled (3 2x2 independent matrices). But it misses two common cases:

1. coupled h/v motion with zero bunch length and energy spread,
2. zero vertical emittance, but H-&delta; coupling  always appear in dispersive regions.

In both cases, 6x6 analysis fails and `at.beam` falls back the the uncoupled case, which is wrong.

In this PR, we try in order the following cases:

1. 6x6 H-V-&delta; matrix
2. 4x4 H-V matrix
4. 4x4 H-&delta; matrix
5. fully decoupled

(The coupled V-&delta; case where &epsilon;<sub>x</sub>=0 is not handled but looks unrealistic).

The following figures show the improvement. We consider a simplified radiation source: equilibrium emittance in horizontal and longitudinal planes, zero vertical emittance. The &Sigma;-matrix is built with `at.sigma_matrix` using the `twiss_in` keyword argument, looking at a dispersive region of the ring. With `at.beam` we generate a particle distribution (1000 particles), and we rebuild the &Sigma;-matrix from the particle distribution (`at.sigma_matrix` with the `beam` keyword argument).

### Figure 1: master branch

![Figure_1](https://user-images.githubusercontent.com/20038121/205911917-1ffb5816-337a-4aa6-ae4a-842daef6936d.png)

The original projection of the &Sigma;-matrix on the x-&delta; plane shows the correlation. The particle distribution has the right &sigma;<sub>x</sub> and &sigma;<sub>&delta;</sub> but not the right correlation, so the rebuilt &Sigma;-matrix is wrong.

### Figure 2: this branch
![Figure_2](https://user-images.githubusercontent.com/20038121/205912997-49088937-ab08-488b-a924-8070c2d28347.png)
Now the particle distribution has the right correlation, and the re-built &Sigma; is very close to the initial one, even with only 1000 particles.

Note: the figures above make use of a `at.plot.plot_sigma()` function which appear in another pull request