### PR TITLE
relax chromaticity test for numpy 1.24

### DIFF
--- a/pyat/test/test_linopt6.py
+++ b/pyat/test/test_linopt6.py
@@ -12,7 +12,7 @@ def test_linopt6_norad(lattice):
     ld02, rd2, ld2 = linopt2(lattice, refpts, get_w=True)
     ld06, rd6, ld6 = linopt6(lattice, refpts, get_w=True)
     assert_close(rd2.tune, rd6.tune, atol=1e-12, rtol=0)
-    assert_close(rd2.chromaticity, rd6.chromaticity, atol=1e-12, rtol=0)
+    assert_close(rd2.chromaticity, rd6.chromaticity, atol=5e-11, rtol=0)
 
     for field in ['s_pos', 'closed_orbit', 'dispersion',
                   'alpha', 'beta', 'mu']:


### PR DESCRIPTION
The linopt6 test suddenly started failing on Ubuntu. This is correlated with the release of numpy 1.24. The same code (stub branch) was running before merging:
```
Run python -m pytest test --cov-report term-missing --cov=at
============================= test session starts ==============================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
system: Linux 5.15.0-1024-azure
numpy version: 1.23.5
rootdir: /home/runner/work/at/at
plugins: lazy-fixture-0.6.3, cov-4.0.0
collected 295 items
```
But now fails with a new numpy version:
```
Run python -m pytest test --cov-report term-missing --cov=at
============================= test session starts ==============================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
system: Linux 5.15.0-1024-azure
numpy version: 1.24.0
rootdir: /home/runner/work/at/at
plugins: lazy-fixture-0.6.3, cov-4.0.0
collected 295 items
```

The chromaticity test between `linopt2` and `linopt6` must be relaxed from `atol=1.e-12` to `atol=5.e-11`.
The accuracy is still good enough, but it's worrying that results may change with time…

The problem seems to be specific to Ubuntu
