### PR TITLE
Improvement of the "refpts" argument

### DIFF
--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -12,6 +12,7 @@ from .utils import *
 from .lattice_object import *
 from .cavity_access import *
 from .variable_elements import *
+from .deprecated import *
 # Define the module "lattice.constants" for backward compatibility
 # noinspection PyUnresolvedReferences
 from .. import constants

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -3,7 +3,7 @@ from enum import Enum
 import numpy
 from typing import Optional
 from .elements import RFCavity
-from .utils import AtError, checktype, make_copy, get_cells, Refpts
+from .utils import AtError, make_copy, Refpts
 from .lattice_object import Lattice
 
 __all__ = ['get_rf_frequency', 'get_rf_voltage', 'set_rf_voltage',
@@ -21,7 +21,7 @@ def _select_cav(ring: Lattice, cavpts):
         try:
             cavpts = ring.cavpts
         except AttributeError:
-            cavpts = get_cells(ring, checktype(RFCavity))
+            cavpts = ring.get_bool_refpts(RFCavity)
     return cavpts
 
 

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -3,7 +3,7 @@ from enum import Enum
 import numpy
 from typing import Optional
 from .elements import RFCavity
-from .utils import AtError, make_copy, Refpts
+from .utils import AtError, make_copy, Refpts, get_bool_index
 from .lattice_object import Lattice
 
 __all__ = ['get_rf_frequency', 'get_rf_voltage', 'set_rf_voltage',
@@ -21,7 +21,7 @@ def _select_cav(ring: Lattice, cavpts):
         try:
             cavpts = ring.cavpts
         except AttributeError:
-            cavpts = ring.get_bool_refpts(RFCavity)
+            cavpts = get_bool_index(ring, RFCavity)
     return cavpts
 
 

--- a/pyat/at/lattice/deprecated.py
+++ b/pyat/at/lattice/deprecated.py
@@ -1,7 +1,7 @@
 from .lattice_object import Lattice
 from .elements import Element
 from .utils import Refpts, BoolRefpts, Uint32Refpts
-from .utils import checkattr, get_uint32_refpts, get_bool_refpts
+from .utils import checkattr, get_uint32_index, get_bool_index
 from typing import Sequence
 
 __all__ = ['get_cells', 'get_refpts']
@@ -53,7 +53,7 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
     """
     if isinstance(refpts, str):
         refpts = checkattr(refpts, *args)
-    return get_bool_refpts(ring, refpts)
+    return get_bool_index(ring, refpts)
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
@@ -77,10 +77,10 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
     See also:
         :py:meth:`.Lattice.uint32_refpts`, :py:meth:`.Lattice.bool_refpts`
     """
-    return get_uint32_refpts(ring, refpts)
+    return get_uint32_index(ring, refpts)
 
 
-Lattice.uint32_refpts = get_uint32_refpts
-Lattice.bool_refpts = get_bool_refpts
+Lattice.uint32_refpts = get_uint32_index
+Lattice.bool_refpts = get_bool_index
 Lattice.get_cells = get_cells
 Lattice.get_refpts = get_refpts

--- a/pyat/at/lattice/deprecated.py
+++ b/pyat/at/lattice/deprecated.py
@@ -1,0 +1,86 @@
+from .lattice_object import Lattice
+from .elements import Element
+from .utils import Refpts, BoolRefpts, Uint32Refpts
+from .utils import checkattr, get_uint32_refpts, get_bool_refpts
+from typing import Sequence
+
+__all__ = ['get_cells', 'get_refpts']
+
+
+# noinspection PyIncorrectDocstring
+def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
+    # noinspection PyShadowingNames
+    r"""
+    get_cells(ring, filtfunc) -> BoolRefpts
+    get_cells(ring, element_type) -> BoolRefpts
+    get_cells(ring, attrname) -> BoolRefpts
+    get_cells(ring, attrname, attrvalue) -> BoolRefpts
+    Returns a bool array of element indices, selecting ring elements.
+
+    Deprecated: :pycode:`get_cells(ring, refpts)` is
+    :pycode:`ring.bool_refpts(refpts)` except for :py:obj:`str` arguments:
+    :pycode:`get_cells(ring, attrname [, attrvalue])` is
+    :pycode:`ring.bool_refpts(checkattr(strkey [, attrvalue]))`
+
+    Parameters:
+        ring (Sequence[Element]):       Lattice description
+        filtfunc (ElementFilter):       Filter function. Selects
+          :py:class:`.Element`\ s satisfying the filter function
+        element_type (Type[Element]):   Element type
+        attrname (str):                 Attribute name
+        attrvalue (Any):                Attribute value. If absent, select the
+          presence of an *attrname* attribute. If present, select
+          :py:class:`.Element`\ s with :pycode:`attrname == attrvalue`.
+
+    Returns:
+        bool_refs (BoolRefpts):  numpy Array of :py:obj:`bool` with length
+          len(ring)+1
+
+    Examples:
+
+        >>> refpts = get_cells(ring, 'Frequency')
+
+        Returns a numpy array of booleans where all elements having a
+        :pycode:`Frequency` attribute are :py:obj:`True`
+
+        >>> refpts = get_cells(ring, 'K', 0.0)
+
+        Returns a numpy array of booleans where all elements having a
+        :pycode:`K` attribute equal to 0.0 are :py:obj:`True`
+
+    See also:
+        :py:meth:`.Lattice.bool_refpts`, :py:meth:`.Lattice.uint32_refpts`
+    """
+    if isinstance(refpts, str):
+        refpts = checkattr(refpts, *args)
+    return get_bool_refpts(ring, refpts)
+
+
+# noinspection PyUnusedLocal,PyIncorrectDocstring
+def get_refpts(ring: Sequence[Element], refpts: Refpts,
+               quiet=True) -> Uint32Refpts:
+    r"""Return a :py:obj:`~numpy.uint32` array of element indices selecting
+    ring elements.
+
+    Deprecated: :pycode:`get_elements(ring, refpts)` is
+    :pycode:`ring.uint32_refpts(refpts)`
+
+    Parameters:
+        ring:           Lattice description
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
+
+    Returns:
+        uint32_refs (Uint32Refs):    :py:obj:`~numpy.uint32` numpy array as
+          long as the number of refpts
+
+    See also:
+        :py:meth:`.Lattice.uint32_refpts`, :py:meth:`.Lattice.bool_refpts`
+    """
+    return get_uint32_refpts(ring, refpts)
+
+
+Lattice.uint32_refpts = get_uint32_refpts
+Lattice.bool_refpts = get_bool_refpts
+Lattice.get_cells = get_cells
+Lattice.get_refpts = get_refpts

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -26,7 +26,7 @@ from ..constants import clight, e_mass
 from .particle_object import Particle
 from .utils import AtError, AtWarning, Refpts
 # noinspection PyProtectedMember
-from .utils import get_uint32_refpts, get_bool_refpts, _refcount, Uint32Refpts
+from .utils import get_uint32_index, get_bool_index, _refcount, Uint32Refpts
 from .utils import refpts_iterator, checktype
 from .utils import get_s_pos, get_elements
 from .utils import get_value_refpts, set_value_refpts
@@ -230,7 +230,7 @@ class Lattice(list):
             if isinstance(key, slice):      # Slice
                 rg = range(*key.indices(len(self)))
             else:                           # Array of integers or boolean
-                rg = get_uint32_refpts(self, key, endpoint=False)
+                rg = get_uint32_index(self, key, endpoint=False)
             return Lattice(elem_generator,
                            (super(Lattice, self).__getitem__(i) for i in rg),
                            iterator=self.attrs_filter)
@@ -239,7 +239,7 @@ class Lattice(list):
         try:                                # Integer or slice
             super(Lattice, self).__setitem__(key, values)
         except TypeError:                   # Array of integers or boolean
-            rg = get_uint32_refpts(self, key, endpoint=False)
+            rg = get_uint32_index(self, key, endpoint=False)
             for i, v in zip(*numpy.broadcast_arrays(rg, values)):
                 super(Lattice, self).__setitem__(i, v)
 
@@ -247,7 +247,7 @@ class Lattice(list):
         try:                                # Integer or slice
             super(Lattice, self).__delitem__(key)
         except TypeError:                   # Array of integers or boolean
-            rg = get_uint32_refpts(self, key, endpoint=False)
+            rg = get_uint32_index(self, key, endpoint=False)
             for i in reversed(rg):
                 super(Lattice, self).__delitem__(i)
 
@@ -454,7 +454,7 @@ class Lattice(list):
         except AttributeError:
             self.s_range = None
             i_range = self._i_range
-        return get_uint32_refpts(self, i_range)
+        return get_uint32_index(self, i_range)
 
     @property
     def energy(self) -> float:
@@ -1141,11 +1141,11 @@ class Lattice(list):
                     elem = nxt.copy()
             yield elem
 
-        kp = get_bool_refpts(self, lambda el: el.PassMethod != 'IdentityPass')
+        kp = get_bool_index(self, lambda el: el.PassMethod != 'IdentityPass')
         try:
-            keep = get_bool_refpts(self, kwargs.pop('keep'))
+            keep = get_bool_index(self, kwargs.pop('keep'))
         except KeyError:
-            keep = get_bool_refpts(self, checktype((elt.Monitor, elt.RFCavity)))
+            keep = get_bool_index(self, checktype((elt.Monitor, elt.RFCavity)))
 
         return Lattice(reduce_filter, self.select(kp | keep),
                        iterator=self.attrs_filter, **kwargs)
@@ -1157,7 +1157,7 @@ class Lattice(list):
         Parameters:
             refpts: element selector
         """
-        check = get_bool_refpts(self, refpts)
+        check = get_bool_index(self, refpts)
         elems = (el.deepcopy() if ok else el for el, ok in zip(self, check))
         return Lattice(elem_generator, elems,
                        iterator=self.attrs_filter, **kwargs)
@@ -1348,8 +1348,8 @@ def params_filter(params, elem_filter: Filter, *args) \
         params['periodicity'] = periodicity
 
 
-Lattice.get_uint32_refpts = get_uint32_refpts
-Lattice.get_bool_refpts = get_bool_refpts
+Lattice.get_uint32_index = get_uint32_index
+Lattice.get_bool_index = get_bool_index
 Lattice.refcount = _refcount
 Lattice.set_shift = set_shift
 Lattice.set_tilt = set_tilt

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1157,10 +1157,7 @@ class Lattice(list):
         Parameters:
             refpts: element selector
         """
-        if callable(refpts):
-            check = map(refpts, self)
-        else:
-            check = iter(_bool_refs(self, refpts))
+        check = _bool_refs(self, refpts)
         elems = (el.deepcopy() if ok else el for el, ok in zip(self, check))
         return Lattice(elem_generator, elems,
                        iterator=self.attrs_filter, **kwargs)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -632,7 +632,7 @@ class Lattice(list):
     def bunch_spos(self) -> numpy.ndarray:
         """Bunch position around the ring [m]"""
         try:
-            circ = self.beta*clight* \
+            circ = self.beta * clight * \
                 self.harmonic_number/self.rf_frequency
         except AtError:
             circ = self.circumference       

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -26,8 +26,8 @@ from ..constants import clight, e_mass
 from .particle_object import Particle
 from .utils import AtError, AtWarning, Refpts
 # noinspection PyProtectedMember
-from .utils import _uint32_refs, _bool_refs, Uint32Refpts
-from .utils import refpts_iterator, refpts_len, checktype
+from .utils import _uint32_refs, _bool_refs, _refcount, Uint32Refpts
+from .utils import refpts_iterator, checktype
 from .utils import get_s_pos, get_elements, get_cells, get_refpts
 from .utils import get_value_refpts, set_value_refpts
 from .utils import set_shift, set_tilt, get_geometry
@@ -230,7 +230,7 @@ class Lattice(list):
             if isinstance(key, slice):      # Slice
                 rg = range(*key.indices(len(self)))
             else:                           # Array of integers or boolean
-                rg = _uint32_refs(self, key)
+                rg = _uint32_refs(self, key, endpoint=False)
             return Lattice(elem_generator,
                            (super(Lattice, self).__getitem__(i) for i in rg),
                            iterator=self.attrs_filter)
@@ -239,7 +239,7 @@ class Lattice(list):
         try:                                # Integer or slice
             super(Lattice, self).__setitem__(key, values)
         except TypeError:                   # Array of integers or boolean
-            rg = _uint32_refs(self, key)
+            rg = _uint32_refs(self, key, endpoint=False)
             for i, v in zip(*numpy.broadcast_arrays(rg, values)):
                 super(Lattice, self).__setitem__(i, v)
 
@@ -247,7 +247,7 @@ class Lattice(list):
         try:                                # Integer or slice
             super(Lattice, self).__delitem__(key)
         except TypeError:                   # Array of integers or boolean
-            rg = _uint32_refs(self, key)
+            rg = _uint32_refs(self, key, endpoint=False)
             for i in reversed(rg):
                 super(Lattice, self).__delitem__(i)
 
@@ -1350,6 +1350,7 @@ def params_filter(params, elem_filter: Filter, *args) \
 
 Lattice.uint32_refpts = _uint32_refs
 Lattice.bool_refpts = _bool_refs
+Lattice.refcount = _refcount
 Lattice.get_cells = get_cells
 Lattice.get_refpts = get_refpts
 Lattice.set_shift = set_shift
@@ -1357,7 +1358,6 @@ Lattice.set_tilt = set_tilt
 Lattice.get_elements = get_elements
 Lattice.get_s_pos = get_s_pos
 Lattice.select = refpts_iterator
-Lattice.refcount = refpts_len
 Lattice.get_value_refpts = get_value_refpts
 Lattice.set_value_refpts = set_value_refpts
 Lattice.get_geometry = get_geometry

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -319,7 +319,7 @@ def _uint32_refs(ring: Sequence[Element], refpts: Refpts) -> Uint32Refpts:
         checkfun = refpts
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
-    elif numpy.issubdtype(type(refpts), numpy.str_):
+    elif isinstance(refpts, str):
         checkfun = checkname(refpts)
     else:
         return uint32_refpts(refpts, len(ring))
@@ -381,7 +381,7 @@ def _bool_refs(ring: Sequence[Element], refpts: Refpts) -> BoolRefpts:
         checkfun = refpts
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
-    elif numpy.issubdtype(type(refpts), numpy.str_):
+    elif isinstance(refpts, str):
         checkfun = checkname(refpts)
     else:
         return bool_refpts(refpts, len(ring))
@@ -520,7 +520,7 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
     """
     if isinstance(refpts, str):
         refpts = checkattr(refpts, *args)
-    return _bool_refs(ring, refpts, *args)
+    return _bool_refs(ring, refpts)
 
 
 def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
@@ -529,17 +529,8 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
 
     Parameters:
         ring:           Lattice description
-        refpts:         Element selection key. *refpts* may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
         elem_iter (Iterator[Element]):  Iterator over the elements in *ring*
@@ -551,7 +542,7 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
         checkfun = refpts
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
-    elif numpy.issubdtype(type(refpts), numpy.str_):
+    elif isinstance(refpts, str):
         checkfun = checkname(refpts)
     else:
         refs = numpy.ravel(refpts)
@@ -585,7 +576,7 @@ def refpts_count(refpts: RefIndex, n_elements: int) -> int:
     refs = numpy.ravel(refpts)
     if (refpts is None) or (refs.size == 0):
         return 0
-    elif refs.dtype == bool:
+    elif numpy.issubdtype(refs.dtype, numpy.bool_):
         return numpy.count_nonzero(refs)
     elif numpy.issubdtype(refs.dtype, numpy.integer):
         return len(refs)
@@ -598,17 +589,8 @@ def refpts_len(ring: Sequence[Element], refpts: Refpts) -> int:
 
     Parameters:
         ring:           Lattice description
-        refpts:         Element selection key. *refpts* may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
         nrefs (int):  The number of reference points
@@ -619,7 +601,7 @@ def refpts_len(ring: Sequence[Element], refpts: Refpts) -> int:
         checkfun = refpts
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
-    elif numpy.issubdtype(type(refpts), numpy.str_):
+    elif isinstance(refpts, str):
         checkfun = checkname(refpts)
     else:
         return refpts_count(refpts, len(ring))
@@ -635,17 +617,8 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
 
     Parameters:
         ring:           Lattice description
-        refpts:         Element selection key. *refpts* may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
         uint32_refs (Uint32Refs):    :py:obj:`~numpy.uint32` numpy array as
@@ -664,17 +637,8 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, quiet=True) \
 
     Parameters:
         ring:           Lattice description
-        refpts:         Element selection key. *refpts* may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
         elem_list (list):  list of :py:class:`.Element`\ s matching key
@@ -688,17 +652,8 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
     Parameters:
         ring:           Lattice description
-        refpts:         Element selection key. *refpts* may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         attrname:   Attribute name
         index:      index of the value to retrieve if *attrname* is
           an array.
@@ -728,13 +683,8 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
     Parameters:
         ring:       Lattice description
-        refpts:     refpts may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         attrname:   Attribute name
         attrvalues: Attribute values
         index:      index of the value to set if *attrname* is
@@ -783,17 +733,8 @@ def get_s_pos(ring: Sequence[Element], refpts: Optional[Refpts] = None) \
 
     Parameters:
         ring:       Lattice description
-        refpts:     refpts may be:
-
-          #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. an element type, selecting all elements of that type in
-             the lattice, e.g. :pycode:`at.Sextupole`
-          #. a string, selecting all elements whose `FamName` matching it.
-             Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`
-          #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
-             is :py:obj:`True` for selected elements
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
         s_pos:  Array of locations of the elements selected by *refpts*

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -604,8 +604,10 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
     get_cells(ring, attrname, attrvalue) -> BoolRefpts
     Returns a bool array of element indices, selecting ring elements.
 
-    With minor modifications, this function can be replaced by
-    the method :py:meth:`.Lattice.bool_refpts`
+    Deprecated: :pycode:`get_cells(ring, refpts)` is
+    :pycode:`ring.bool_refpts(refpts)` except for :py:obj:`str` arguments:
+    :pycode:`get_cells(ring, attrname [, attrvalue])` is
+    :pycode:`ring.bool_refpts(checkattr(strkey [, attrvalue]))`
 
     Parameters:
         ring (Sequence[Element]):       Lattice description
@@ -770,7 +772,8 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
     r"""Return a :py:obj:`~numpy.uint32` array of element indices selecting
     ring elements.
 
-    This function is equivalent to :py:meth:`.Lattice.uint32_refpts`
+    Deprecated: :pycode:`get_elements(ring, refpts)` is
+    :pycode:`ring.uint32_refpts(refpts)`
 
     Parameters:
         ring:           Lattice description
@@ -792,8 +795,7 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, quiet=True) \
         -> list:
     r"""Returns a list of elements selected by *key*.
 
-    This is equivalent to :pycode:`ring[refpts]`, except that it returns a
-    :py:class:`list` instead of a :py:class:`.Lattice`.
+    Deprecated: :pycode:`get_elements(ring, refpts)` is :pycode:`ring[refpts]`
 
     Parameters:
         ring:           Lattice description

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -48,7 +48,7 @@ __all__ = ['All', 'End', 'AtError', 'AtWarning', 'axis_descr',
            'check_radiation', 'check_6d',
            'set_radiation', 'set_6d',
            'make_copy', 'uint32_refpts', 'bool_refpts',
-           'get_uint32_refpts', 'get_bool_refpts',
+           'get_uint32_index', 'get_bool_index',
            'checkattr', 'checktype', 'checkname',
            'get_elements', 'get_s_pos',
            'refpts_count', 'refpts_iterator',
@@ -351,8 +351,8 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
 
 
 # noinspection PyIncorrectDocstring
-def get_uint32_refpts(ring: Sequence[Element], refpts: Refpts,
-                      endpoint: bool = True) -> Uint32Refpts:
+def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
+                     endpoint: bool = True) -> Uint32Refpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
@@ -368,17 +368,17 @@ def get_uint32_refpts(ring: Sequence[Element], refpts: Refpts,
 
     Examples:
 
-        >>> ring.uint32_refpts(at.Sextupole)
+        >>> get_uint32_index(ring, at.Sextupole)
         array([ 21,  27,  35,  89,  97, 103], dtype=uint32)
 
         numpy array of indices of all :py:class:`.Sextupole`\ s
 
-        >>> ring.uint32_refpts(at.End)
+        >>> get_uint32_index(ring, at.End)
         array([121], dtype=uint32)
 
         numpy array([:pycode:`len(ring)+1`])
 
-        >>> ring.uint32_refpts(at.checkattr('Frequency'))
+        >>> get_uint32_index(ring, at.checkattr('Frequency'))
         array([0], dtype=uint32)
 
         numpy array of indices of all elements having a 'Frequency'
@@ -450,12 +450,10 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
 
 
 # noinspection PyIncorrectDocstring
-def get_bool_refpts(ring: Sequence[Element], refpts: Refpts,
-                    endpoint: bool = True) -> BoolRefpts:
+def get_bool_index(ring: Sequence[Element], refpts: Refpts,
+                   endpoint: bool = True) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
-    r"""bool_refpts(ring: Sequence[Element], refpts: Refpts)
-
-    Returns a bool array of element indices, selecting ring elements.
+    r"""Returns a bool array of element indices, selecting ring elements.
 
     Parameters:
         refpts:         Element selection key.
@@ -469,22 +467,22 @@ def get_bool_refpts(ring: Sequence[Element], refpts: Refpts,
 
     Examples:
 
-        >>> refpts = ring.bool_refpts(at.Quadrupole)
+        >>> refpts = get_bool_index(ring, at.Quadrupole)
 
         Returns a numpy array of booleans where all :py:class:`.Quadrupole`
         are :py:obj:`True`
 
-        >>> refpts = ring.bool_refpts("Q[FD]*")
+        >>> refpts = get_bool_index(ring, "Q[FD]*")
 
         Returns a numpy array of booleans where all elements whose *FamName*
         matches "Q[FD]*" are :py:obj:`True`
 
-        >>> refpts = ring.bool_refpts(at.checkattr('K', 0.0))
+        >>> refpts = get_bool_index(ring, at.checkattr('K', 0.0))
 
         Returns a numpy array of booleans where all elements whose *K*
         attribute is 0.0 are :py:obj:`True`
 
-        >>> refpts = ring.bool_refpts(None)
+        >>> refpts = get_bool_index(ring, None)
 
         Returns a numpy array of *len(ring)+1* :py:obj:`False` values
     """
@@ -825,7 +823,7 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
 
     Parameters:
         ring:       Lattice description
-        refpts:         Element selection key.
+        refpts:     Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Returns:
@@ -842,8 +840,7 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
     s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
     # Prepend position at the start of the first element.
     s_pos = numpy.concatenate(([0.0], s_pos))
-    refpts = get_uint32_refpts(ring, refpts)
-    return s_pos[refpts]
+    return s_pos[get_bool_index(ring, refpts)]
 
 
 def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -48,8 +48,9 @@ __all__ = ['All', 'End', 'AtError', 'AtWarning', 'axis_descr',
            'check_radiation', 'check_6d',
            'set_radiation', 'set_6d',
            'make_copy', 'uint32_refpts', 'bool_refpts',
+           'get_uint32_refpts', 'get_bool_refpts',
            'checkattr', 'checktype', 'checkname',
-           'get_cells', 'get_elements', 'get_refpts', 'get_s_pos',
+           'get_elements', 'get_s_pos',
            'refpts_count', 'refpts_iterator',
            'set_shift', 'set_tilt', 'set_rotation',
            'tilt_elem', 'shift_elem', 'rotate_elem',
@@ -288,7 +289,6 @@ def make_copy(copy: bool) -> Callable:
     return copy_decorator
 
 
-# noinspection PyIncorrectDocstring
 def uint32_refpts(refpts: RefIndex, n_elements: int,
                   endpoint: bool = True,
                   types: str = _typ1) -> Uint32Refpts:
@@ -304,8 +304,10 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
           #. :py:obj:`None`, meaning empty selection,
           #. :py:obj:`.All`, meaning "all possible reference points",
           #. :py:obj:`.End`, selecting the end of the last element.
+        n_elements: Length of the sequence of elements
         endpoint:   if :py:obj:`True`, allow *n_elements* as a
           special index, referring to the end of the last element.
+        types:      Allowed types
 
     Returns:
         uint32_ref (Uint32Refpts):  :py:obj:`~numpy.uint32` numpy array used
@@ -348,9 +350,9 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
         raise _type_error(refpts, types)
 
 
-# Private function accepting a callable for refpts
-def _uint32_refs(ring: Sequence[Element], refpts: Refpts,
-                 endpoint: bool = True) -> Uint32Refpts:
+# noinspection PyIncorrectDocstring
+def get_uint32_refpts(ring: Sequence[Element], refpts: Refpts,
+                      endpoint: bool = True) -> Uint32Refpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
@@ -397,7 +399,6 @@ def _uint32_refs(ring: Sequence[Element], refpts: Refpts,
                           dtype=numpy.uint32)
 
 
-# noinspection PyIncorrectDocstring
 def bool_refpts(refpts: RefIndex, n_elements: int,
                 endpoint: bool = True,
                 types: str = _typ1) -> BoolRefpts:
@@ -416,6 +417,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
         n_elements: Length of the lattice
         endpoint:   if :py:obj:`True`, allow *n_elements* as a
           special index, referring to the end of the last element.
+        types:      Allowed types
 
     Returns:
         bool_refs (BoolRefpts):  A bool numpy array used for indexing
@@ -447,9 +449,9 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
         raise _type_error(refpts, types)
 
 
-# Private function accepting a callable for refpts
-def _bool_refs(ring: Sequence[Element], refpts: Refpts,
-               endpoint: bool = True) -> BoolRefpts:
+# noinspection PyIncorrectDocstring
+def get_bool_refpts(ring: Sequence[Element], refpts: Refpts,
+                    endpoint: bool = True) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""bool_refpts(ring: Sequence[Element], refpts: Refpts)
 
@@ -594,55 +596,6 @@ def checkname(pattern: str) -> ElementFilter:
     return lambda el: fnmatch(el.FamName, pattern)
 
 
-# noinspection PyIncorrectDocstring
-def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
-    # noinspection PyShadowingNames
-    r"""
-    get_cells(ring, filtfunc) -> BoolRefpts
-    get_cells(ring, element_type) -> BoolRefpts
-    get_cells(ring, attrname) -> BoolRefpts
-    get_cells(ring, attrname, attrvalue) -> BoolRefpts
-    Returns a bool array of element indices, selecting ring elements.
-
-    Deprecated: :pycode:`get_cells(ring, refpts)` is
-    :pycode:`ring.bool_refpts(refpts)` except for :py:obj:`str` arguments:
-    :pycode:`get_cells(ring, attrname [, attrvalue])` is
-    :pycode:`ring.bool_refpts(checkattr(strkey [, attrvalue]))`
-
-    Parameters:
-        ring (Sequence[Element]):       Lattice description
-        filtfunc (ElementFilter):       Filter function. Selects
-          :py:class:`.Element`\ s satisfying the filter function
-        element_type (Type[Element]):   Element type
-        attrname (str):                 Attribute name
-        attrvalue (Any):                Attribute value. If absent, select the
-          presence of an *attrname* attribute. If present, select
-          :py:class:`.Element`\ s with :pycode:`attrname == attrvalue`.
-
-    Returns:
-        bool_refs (BoolRefpts):  numpy Array of :py:obj:`bool` with length
-          len(ring)+1
-
-    Examples:
-
-        >>> refpts = get_cells(ring, 'Frequency')
-
-        Returns a numpy array of booleans where all elements having a
-        :pycode:`Frequency` attribute are :py:obj:`True`
-
-        >>> refpts = get_cells(ring, 'K', 0.0)
-
-        Returns a numpy array of booleans where all elements having a
-        :pycode:`K` attribute equal to 0.0 are :py:obj:`True`
-
-    See also:
-        :py:meth:`.Lattice.bool_refpts`, :py:meth:`.Lattice.uint32_refpts`
-    """
-    if isinstance(refpts, str):
-        refpts = checkattr(refpts, *args)
-    return _bool_refs(ring, refpts)
-
-
 def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
         -> Iterator[Element]:
     r"""Return an iterator over selected elements in a lattice
@@ -764,30 +717,6 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
         return refpts_count(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
     return len(list(filter(checkfun, ring)))
-
-
-# noinspection PyUnusedLocal,PyIncorrectDocstring
-def get_refpts(ring: Sequence[Element], refpts: Refpts,
-               quiet=True) -> Uint32Refpts:
-    r"""Return a :py:obj:`~numpy.uint32` array of element indices selecting
-    ring elements.
-
-    Deprecated: :pycode:`get_elements(ring, refpts)` is
-    :pycode:`ring.uint32_refpts(refpts)`
-
-    Parameters:
-        ring:           Lattice description
-        refpts:         Element selection key.
-          See ":ref:`Selecting elements in a lattice <refpts>`"
-
-    Returns:
-        uint32_refs (Uint32Refs):    :py:obj:`~numpy.uint32` numpy array as
-          long as the number of refpts
-
-    See also:
-        :py:meth:`.Lattice.uint32_refpts`, :py:meth:`.Lattice.bool_refpts`
-    """
-    return _uint32_refs(ring, refpts)
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
@@ -913,7 +842,7 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
     s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
     # Prepend position at the start of the first element.
     s_pos = numpy.concatenate(([0.0], s_pos))
-    refpts = _uint32_refs(ring, refpts)
+    refpts = get_uint32_refpts(ring, refpts)
     return s_pos[refpts]
 
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -281,10 +281,11 @@ def uint32_refpts(refpts: RefIndex, n_elements: int) -> Uint32Refpts:
             prev = refs[0]
             for nxt in refs[1:]:
                 if nxt < prev:
-                    raise ValueError('refpts should be given in ascending order')
+                    raise ValueError('refpts should be given in ascending'
+                                     ' order')
                 elif nxt == prev:
-                    raise ValueError('refpts contains duplicates or index(es) out'
-                                     ' of range')
+                    raise ValueError('refpts contains duplicates or index(es)'
+                                     ' out of range')
                 prev = nxt
 
         return refs
@@ -324,7 +325,7 @@ def _uint32_refs(ring: Sequence[Element], refpts: Refpts) -> Uint32Refpts:
     else:
         return uint32_refpts(refpts, len(ring))
 
-    return numpy.fromiter((i for i,el in enumerate(ring) if checkfun(el)),
+    return numpy.fromiter((i for i, el in enumerate(ring) if checkfun(el)),
                           dtype=numpy.uint32)
 
 
@@ -359,6 +360,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int) -> BoolRefpts:
         return brefpts
     else:
         raise _type_error(refpts)
+
 
 # Private function accepting a callable for refpts
 def _bool_refs(ring: Sequence[Element], refpts: Refpts, *args,
@@ -400,6 +402,7 @@ def _bool_refs(ring: Sequence[Element], refpts: Refpts, *args,
 
     return numpy.append(numpy.fromiter(map(checkfun, ring), dtype=bool,
                                        count=len(ring)), False)
+
 
 def checkattr(attrname: str, attrvalue: Optional = None) \
         -> ElementFilter:
@@ -638,7 +641,8 @@ def refpts_len(ring: Sequence[Element], refpts: Refpts) -> int:
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
-def get_refpts(ring: Sequence[Element], refpts: Refpts, quiet=True) -> Uint32Refpts:
+def get_refpts(ring: Sequence[Element], refpts: Refpts,
+               quiet=True) -> Uint32Refpts:
     r"""Return a :py:obj:`~numpy.uint32` array of element indices selecting
     ring elements.
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -51,7 +51,7 @@ __all__ = ['AtError', 'AtWarning', 'axis_descr',
            'set_shift', 'set_tilt', 'set_rotation',
            'tilt_elem', 'shift_elem', 'rotate_elem',
            'get_value_refpts', 'set_value_refpts', 'Refpts',
-           'get_geometry', 'rotate_elem', 'set_rotation']
+           'get_geometry']
 
 _axis_def = dict(
     x=dict(index=0, label="x", unit=" [m]"),
@@ -74,9 +74,13 @@ class AtWarning(UserWarning):
 
 
 def _type_error(refpts):
+    if isinstance(refpts, numpy.ndarray):
+        tp = refpts.dtype.type
+    else:
+        tp = type(refpts)
     return TypeError(
         "Invalid refpts type {0}. Allowed types: "
-        "Type[Element], ElementFilter, str, RefIndex".format(type(refpts)))
+        "Type[Element], ElementFilter, str, int, bool".format(tp))
 
 
 # noinspection PyIncorrectDocstring

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -317,7 +317,7 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
         return numpy.arange(stop, dtype=numpy.uint32)
     elif refpts is RefptsCode.End:
         if not endpoint:
-            raise IndexError('"End" is not allowed if endpoint is False')
+            raise IndexError('"End" index out of range')
         return numpy.array([n_elements], dtype=numpy.uint32)
     elif (refpts is None) or (refs.size == 0):
         return numpy.array([], dtype=numpy.uint32)
@@ -354,31 +354,34 @@ def _uint32_refs(ring: Sequence[Element], refpts: Refpts,
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
-        Parameters:
-            refpts:         Element selection key.
-              See ":ref:`Selecting elements in a lattice <refpts>`"
-            endpoint:   if :py:obj:`True`, allow *len(ring)* as a
-              special index, referring to the end of the last element.
+    Parameters:
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
+        endpoint:   if :py:obj:`True`, allow *len(ring)* as a
+          special index, referring to the end of the last element.
 
-        Returns:
-            uint32_ref (Uint32Refpts): uint32 numpy array used for indexing
-              :py:class:`.Element`\ s in a lattice.
+    Returns:
+        uint32_ref (Uint32Refpts): uint32 numpy array used for indexing
+          :py:class:`.Element`\ s in a lattice.
 
-        Examples:
+    Examples:
 
-            >>> refpts = ring.uint32_refpts(Quadrupole)
+        >>> ring.uint32_refpts(at.Sextupole)
+        array([ 21,  27,  35,  89,  97, 103], dtype=uint32)
 
-            Returns anumpy array of indices of all :py:class:`.Sextupole`\ s
+        numpy array of indices of all :py:class:`.Sextupole`\ s
 
-            >>> refpts = ring.uint32_refpts(All)
+        >>> ring.uint32_refpts(at.End)
+        array([121], dtype=uint32)
 
-            Returns :pycode:`numpy.arange(len(ring)+1, dtype=numpy.uint32)`
+        numpy array([:pycode:`len(ring)+1`])
 
-            >>> refpts = ring.uint32_refpts(checkattr('K', 0.0))
+        >>> ring.uint32_refpts(at.checkattr('Frequency'))
+        array([0], dtype=uint32)
 
-            Returns a numpy array of indices of all elements whose *K*
-            attribute is 0.0
-        """
+        numpy array of indices of all elements having a 'Frequency'
+        attribute
+    """
     if isinstance(refpts, type):
         checkfun = checktype(refpts)
     elif callable(refpts):
@@ -424,7 +427,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
         return numpy.ones(stop, dtype=bool)
     elif refpts is RefptsCode.End:
         if not endpoint:
-            raise IndexError('"End" is not allowed if endpoint is False')
+            raise IndexError('"End" index out of range')
         brefpts = numpy.zeros(stop, dtype=bool)
         brefpts[n_elements] = True
         return brefpts
@@ -448,41 +451,41 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
 def _bool_refs(ring: Sequence[Element], refpts: Refpts,
                endpoint: bool = True) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
-    r"""
-        bool_refpts(ring: Sequence[Element], refpts: Refpts)
-        Returns a bool array of element indices, selecting ring elements.
+    r"""bool_refpts(ring: Sequence[Element], refpts: Refpts)
 
-        Parameters:
-            refpts:         Element selection key.
-              See ":ref:`Selecting elements in a lattice <refpts>`"
-            endpoint:   if :py:obj:`True`, allow *len(ring)* as a
-              special index, referring to the end of the last element.
+    Returns a bool array of element indices, selecting ring elements.
 
-        Returns:
-            bool_refs (BoolRefpts):  A bool numpy array used for indexing
-              :py:class:`.Element`\ s in a lattice.
+    Parameters:
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
+        endpoint:   if :py:obj:`True`, allow *len(ring)* as a
+          special index, referring to the end of the last element.
 
-        Examples:
+    Returns:
+        bool_refs (BoolRefpts):  A bool numpy array used for indexing
+          :py:class:`.Element`\ s in a lattice.
 
-            >>> refpts = ring.bool_refpts(Quadrupole)
+    Examples:
 
-            Returns a numpy array of booleans where all :py:class:`.Quadrupole`
-            are :py:obj:`True`
+        >>> refpts = ring.bool_refpts(at.Quadrupole)
 
-            >>> refpts = ring.bool_refpts("Q[FD]*")
+        Returns a numpy array of booleans where all :py:class:`.Quadrupole`
+        are :py:obj:`True`
 
-            Returns a numpy array of booleans where all elements whose *FamName*
-            matches "Q[FD]*" are :py:obj:`True`
+        >>> refpts = ring.bool_refpts("Q[FD]*")
 
-            >>> refpts = ring.bool_refpts(checkattr('K', 0.0))
+        Returns a numpy array of booleans where all elements whose *FamName*
+        matches "Q[FD]*" are :py:obj:`True`
 
-            Returns a numpy array of booleans where all elements whose *K*
-            attribute is 0.0 are :py:obj:`True`
+        >>> refpts = ring.bool_refpts(at.checkattr('K', 0.0))
 
-            >>> refpts = ring.bool_refpts(None)
+        Returns a numpy array of booleans where all elements whose *K*
+        attribute is 0.0 are :py:obj:`True`
 
-            Returns a numpy array of *len(ring)+1* :py:obj:`False` values
-        """
+        >>> refpts = ring.bool_refpts(None)
+
+        Returns a numpy array of *len(ring)+1* :py:obj:`False` values
+    """
     if isinstance(refpts, type):
         checkfun = checktype(refpts)
     elif callable(refpts):
@@ -505,34 +508,33 @@ def checkattr(attrname: str, attrvalue: Optional = None) \
     # noinspection PyUnresolvedReferences
     r"""Checks the presence or the value of an attribute
 
-        Returns a function to be used as an :py:class:`.Element` filter, which
-        checks the presence or the value of an attribute of the
-        provided :py:class:`.Element`.
-        This function can be used to extract from a ring all elements
-        having a given attribute.
+    Returns a function to be used as an :py:class:`.Element` filter, which
+    checks the presence or the value of an attribute of the
+    provided :py:class:`.Element`.
+    This function can be used to extract from a ring all elements
+    having a given attribute.
 
-        Parameters:
-            attrname: Attribute name
-            attrvalue: Attribute value. If absent, the returned function checks
-              the presence of an *attrname* attribute. If present, the
-              returned function checks if :pycode:`attrname == attrvalue`.
+    Parameters:
+        attrname: Attribute name
+        attrvalue: Attribute value. If absent, the returned function checks
+          the presence of an *attrname* attribute. If present, the
+          returned function checks if :pycode:`attrname == attrvalue`.
 
-        Returns:
-            checkfun (ElementFilter):   Element filter function
+    Returns:
+        checkfun (ElementFilter):   Element filter function
 
-        Examples:
+    Examples:
 
-            >>> cavs = filter(checkattr('Frequency'), ring)
+        >>> cavs = filter(checkattr('Frequency'), ring)
 
-            Returns an iterator over all elements in *ring* that have a
-            :pycode:`Frequency` attribute
+        Returns an iterator over all elements in *ring* that have a
+        :pycode:`Frequency` attribute
 
-            >>> elts = filter(checkattr('K', 0.0), ring)
+        >>> elts = filter(checkattr('K', 0.0), ring)
 
-            Returns an iterator over all elements in ring that have a
-            :pycode:`K` attribute equal to 0.0
-        """
-
+        Returns an iterator over all elements in ring that have a
+        :pycode:`K` attribute equal to 0.0
+    """
     def testf(el):
         try:
             v = getattr(el, attrname)
@@ -571,24 +573,24 @@ def checkname(pattern: str) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     r"""Checks the name of an element
 
-        Returns a function to be used as an :py:class:`.Element` filter,
-        which checks the name of the provided :py:class:`.Element`.
-        This function can be used to extract from a ring all elements
-        having a given name.
+    Returns a function to be used as an :py:class:`.Element` filter,
+    which checks the name of the provided :py:class:`.Element`.
+    This function can be used to extract from a ring all elements
+    having a given name.
 
-        Parameters:
-            pattern: Desired :py:class:`.Element` name. Unix shell-style
-              wildcards are supported (see :py:func:`fnmatch.fnmatch`)
+    Parameters:
+        pattern: Desired :py:class:`.Element` name. Unix shell-style
+          wildcards are supported (see :py:func:`fnmatch.fnmatch`)
 
-        Returns:
-            checkfun (ElementFilter):   Element filter function
+    Returns:
+        checkfun (ElementFilter):   Element filter function
 
-        Examples:
+    Examples:
 
-            >>> qps = filter(checkname('QF*'), ring)
+        >>> qps = filter(checkname('QF*'), ring)
 
-            Returns an iterator over all with name starting with ``QF``.
-        """
+        Returns an iterator over all with name starting with ``QF``.
+    """
     return lambda el: fnmatch(el.FamName, pattern)
 
 
@@ -705,7 +707,7 @@ def refpts_count(refpts: RefIndex, n_elements: int,
         return n_elements+1 if endpoint else n_elements
     elif refpts is RefptsCode.End:
         if not endpoint:
-            raise IndexError('"End" is not allowed if endpoint is False')
+            raise IndexError('"End" index out of range')
         return 1
     elif (refpts is None) or (refs.size == 0):
         return 0
@@ -722,28 +724,31 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns the number of reference points
 
-        Parameters:
-            refpts:         Element selection key.
-              See ":ref:`Selecting elements in a lattice <refpts>`"
-            endpoint:   if :py:obj:`True`, allow *len(ring)* as a
-              special index, referring to the end of the last element.
+    Parameters:
+        refpts:         Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
+        endpoint:   if :py:obj:`True`, allow *len(ring)* as a
+          special index, referring to the end of the last element.
 
-        Returns:
-            nrefs (int):  The number of reference points
+    Returns:
+        nrefs (int):  The number of reference points
 
-        Examples:
+    Examples:
 
-            >>> refpts = ring.refcount(Sextupole)
+        >>> refpts = ring.refcount(at.Sextupole)
+        6
 
-            Returns the number of :py:class:`.Sextupole`\ s in the lattice
+        Returns the number of :py:class:`.Sextupole`\ s in the lattice
 
-            >>> refpts = ring.refcount(All)
+        >>> refpts = ring.refcount(at.All)
+        122
 
-            Returns *len(ring)+1*
+        Returns *len(ring)+1*
 
-            >>> refpts = ring.refcount(All, endpoint=False)
+        >>> refpts = ring.refcount(at.All, endpoint=False)
+        121
 
-            Returns *len(ring)*
+        Returns *len(ring)*
         """
     if isinstance(refpts, type):
         checkfun = checktype(refpts)
@@ -882,8 +887,9 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
     return apply(ring, refpts, attrvalues)
 
 
-def get_s_pos(ring: Sequence[Element], refpts: Optional[Refpts] = None) \
+def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
         -> Sequence[float]:
+    # noinspection PyUnresolvedReferences
     r"""Returns the locations of selected elements
 
     Parameters:
@@ -893,9 +899,14 @@ def get_s_pos(ring: Sequence[Element], refpts: Optional[Refpts] = None) \
 
     Returns:
         s_pos:  Array of locations of the elements selected by *refpts*
-    """
-    if refpts is None:
-        refpts = range(len(ring) + 1)
+
+    Example:
+
+        >>> get_s_pos(ring, at.End)
+        array([26.37428795])
+
+        Position at the end of the last element: length of the lattice
+        """
     # Positions at the end of each element.
     s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
     # Prepend position at the start of the first element.

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -1,31 +1,31 @@
 r"""
 Helper functions for working with AT lattices.
 
-A lattice as understood by pyAT is any sequence of elements.  These functions
+A lattice as understood by pyAT is a sequence of elements.  These functions
 are useful for working with these sequences.
 
 .. _refpts:
 
 **Selecting elements in a lattice:**
 
-The *refpts* argument allows functions to select elements in the lattice. The
-location refers to the entrance of selected elements. *refpts* may be:
+The *refpts* argument allows functions to select locations in the lattice. The
+location is defined as the entrance of the selected element. *refpts* may be:
 
-#. an integer in the range [-len(ring), len(ring)-1]
-   selecting the element according to python indexing rules.
-   As a special case, len(ring) is allowed and refers to the end
+#. an integer in the range *[-len(lattice), len(lattice)-1]*
+   selecting an element according to the python indexing rules.
+   As a special case, *len(lattice)* is allowed and refers to the end
    of the last element,
 #. an ordered list of such integers without duplicates,
-#. a numpy array of booleans of maximum length len(ring)+1,
+#. a numpy array of booleans of maximum length *len(lattice)+1*,
    where selected elements are :py:obj:`True`,
 #. :py:obj:`None`, meaning an empty selection,
 #. :py:obj:`.All`, meaning "all possible reference points": the entrance of all
    elements plus the end of the last element,
-#. :py:obj:`.End`, referring to the end of the last element
-#. an element type, selecting all elements of that type in
+#. :py:obj:`.End`, selecting the end of the last element,
+#. an element type, selecting all the elements of that type in
    the lattice, e.g. :pycode:`at.Sextupole`,
-#. a string, selecting all elements whose `FamName` attribute matches it.
-   Unix shell-style wildcards are accepted, e.g. `'BPM_*1'`,
+#. a string, selecting all the elements whose `FamName` attribute matches it.
+   Unix shell-style wildcards are accepted, e.g. `"Q[FD]*"`,
 #. a callable :pycode:`filtfunc` such that :pycode:`filtfunc(elem)`
    is :py:obj:`True` for selected elements.
 
@@ -299,11 +299,11 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
         refpts:     Element selector. *refpts* may be:
 
           #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. :py:obj:`None`, meaning empty selection
-          #. :py:obj:`.All`, meaning "all possible reference points".
-          #. :py:obj:`.End`, referring to the end of the last element
+             (0 indicating the first element),
+          #. a sequence of booleans marking the selected elements,
+          #. :py:obj:`None`, meaning empty selection,
+          #. :py:obj:`.All`, meaning "all possible reference points",
+          #. :py:obj:`.End`, selecting the end of the last element.
         endpoint:   if :py:obj:`True`, allow *n_elements* as a
           special index, referring to the end of the last element.
 
@@ -337,11 +337,10 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
             prev = refs[0]
             for nxt in refs[1:]:
                 if nxt < prev:
-                    raise ValueError('refpts should be given in ascending'
+                    raise IndexError('Index out of range or not in ascending'
                                      ' order')
                 elif nxt == prev:
-                    raise ValueError('refpts contains duplicates or index(es)'
-                                     ' out of range')
+                    raise IndexError('Duplicated index')
                 prev = nxt
 
         return refs
@@ -406,11 +405,11 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
         refpts:     Element selector. *refpts* may be:
 
           #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. :py:obj:`None`, meaning empty selection
-          #. :py:obj:`.All`, meaning "all possible reference points".
-          #. :py:obj:`.End`, referring to the end of the last element
+             (0 indicating the first element),
+          #. a sequence of booleans marking the selected elements,
+          #. :py:obj:`None`, meaning empty selection,
+          #. :py:obj:`.All`, meaning "all possible reference points",
+          #. :py:obj:`.End`, selecting the end of the last element.
         n_elements: Length of the lattice
         endpoint:   if :py:obj:`True`, allow *n_elements* as a
           special index, referring to the end of the last element.
@@ -689,11 +688,11 @@ def refpts_count(refpts: RefIndex, n_elements: int,
         refpts:     refpts may be:
 
           #. an integer or a sequence of integers
-             (0 indicating the first element)
-          #. a sequence of booleans marking the selected elements
-          #. :py:obj:`None`, meaning empty selection
-          #. :py:obj:`.All`, meaning "all possible reference points"
-          #. :py:obj:`.End`, referring to the end of the last element
+             (0 indicating the first element),
+          #. a sequence of booleans marking the selected elements,
+          #. :py:obj:`None`, meaning empty selection,
+          #. :py:obj:`.All`, meaning "all possible reference points",
+          #. :py:obj:`.End`, selecting the end of the last element.
         n_elements: Lattice length
         endpoint:   if :py:obj:`True`, allow *n_elements* as a
           special index, referring to the end of the last element.

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -7,7 +7,7 @@ from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts
 from at.lattice import check_radiation, AtError, AtWarning
 from at.lattice import QuantumDiffusion, Collective
-from at.lattice import checktype, set_value_refpts, get_cells, refpts_len
+from at.lattice import checktype, set_value_refpts, get_cells
 from at.constants import clight, Cgamma
 from at.tracking import lattice_pass
 
@@ -69,7 +69,8 @@ def get_energy_loss(ring: Lattice,
     def tracking(ring):
         """Losses from tracking
         """
-        ringtmp = ring.disable_6d(RFCavity, QuantumDiffusion, Collective, copy=True)
+        ringtmp = ring.disable_6d(RFCavity, QuantumDiffusion, Collective,
+                                  copy=True)
         o6 = numpy.squeeze(lattice_pass(ringtmp, numpy.zeros(6),
                            refpts=len(ringtmp)))
         if numpy.isnan(o6[0]):
@@ -96,7 +97,7 @@ def get_energy_loss(ring: Lattice,
 def get_timelag_fromU0(ring: Lattice,
                        method: Optional[ELossMethod] = ELossMethod.TRACKING,
                        cavpts: Optional[Refpts] = None,
-                       divider: Optional[float] = 4) -> Tuple[float, float]:
+                       divider: Optional[int] = 4) -> Tuple[float, float]:
     """
     Get the TimeLag attribute of RF cavities based on frequency,
     voltage and energy loss per turn, so that the synchronous phase is zero.
@@ -167,7 +168,7 @@ def get_timelag_fromU0(ring: Lattice,
         vrf = numpy.sum(rfv)
         timelag = clight/(2*numpy.pi*frf)*numpy.arcsin(u0/vrf)
         ts = timelag - tml
-        timelag *= numpy.ones(refpts_len(ring, cavpts))
+        timelag *= numpy.ones(ring.refcount(cavpts))
     return timelag, ts
 
 

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -131,7 +131,7 @@ def get_timelag_fromU0(ring: Lattice,
             return eq1
 
     if cavpts is None:
-        cavpts = ring.get_cells(checktype(RFCavity))
+        cavpts = ring.get_bool_refpts(RFCavity)
     u0 = ring.get_energy_loss(method=method) / ring.periodicity
     freq = numpy.array([cav.Frequency for cav in ring.select(cavpts)])
     rfv = numpy.array([cav.Voltage for cav in ring.select(cavpts)])
@@ -200,7 +200,7 @@ def set_cavity_phase(ring: Lattice,
         warn(FutureWarning('You should use "cavpts" instead of "refpts"'))
         cavpts = refpts
     elif cavpts is None:
-        cavpts = get_cells(ring, checktype(RFCavity))
+        cavpts = ring.get_bool_refpts(RFCavity)
     timelag, _ = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)
 

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -7,7 +7,7 @@ from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts
 from at.lattice import check_radiation, AtError, AtWarning
 from at.lattice import QuantumDiffusion, Collective
-from at.lattice import checktype, set_value_refpts, get_cells
+from at.lattice import get_bool_index, set_value_refpts
 from at.constants import clight, Cgamma
 from at.tracking import lattice_pass
 
@@ -131,8 +131,8 @@ def get_timelag_fromU0(ring: Lattice,
             return eq1
 
     if cavpts is None:
-        cavpts = ring.get_bool_refpts(RFCavity)
-    u0 = ring.get_energy_loss(method=method) / ring.periodicity
+        cavpts = get_bool_index(ring, RFCavity)
+    u0 = get_energy_loss(ring, method=method) / ring.periodicity
     freq = numpy.array([cav.Frequency for cav in ring.select(cavpts)])
     rfv = numpy.array([cav.Voltage for cav in ring.select(cavpts)])
     tl0 = numpy.array([cav.TimeLag for cav in ring.select(cavpts)])
@@ -200,7 +200,7 @@ def set_cavity_phase(ring: Lattice,
         warn(FutureWarning('You should use "cavpts" instead of "refpts"'))
         cavpts = refpts
     elif cavpts is None:
-        cavpts = ring.get_bool_refpts(RFCavity)
+        cavpts = get_bool_index(ring, RFCavity)
     timelag, _ = get_timelag_fromU0(ring, method=method, cavpts=cavpts)
     set_value_refpts(ring, cavpts, 'TimeLag', timelag, copy=copy)
 

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -4,8 +4,8 @@ transfer matrix related functions
 A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 import numpy
-from ..lattice import Lattice, Element, get_refpts, DConstant, Refpts
-from ..lattice.elements import Bend, M66
+from ..lattice import Lattice, Element, get_uint32_index, DConstant, Refpts
+from ..lattice.elements import Dipole, M66
 from ..tracking import lattice_pass, element_pass
 from .orbit import Orbit, find_orbit4, find_orbit6
 from .amat import jmat, symplectify
@@ -81,7 +81,7 @@ def find_m44(ring: Lattice, dp: float = None, refpts: Refpts = None,
     # Add the deltas to multiple copies of the closed orbit
     in_mat = orbit.reshape(6, 1) + dmat
 
-    refs = ring.uint32_refpts(refpts)
+    refs = get_uint32_index(ring, refpts)
     out_mat = numpy.rollaxis(
         numpy.squeeze(lattice_pass(ring, in_mat, refpts=refs,
                                    keep_lattice=keep_lattice), axis=3), -1
@@ -153,7 +153,7 @@ def find_m66(ring: Lattice, refpts: Refpts = None,
 
     in_mat = orbit.reshape(6, 1) + dmat
 
-    refs = ring.uint32_refpts(refpts)
+    refs = get_uint32_index(ring, refpts)
     out_mat = numpy.rollaxis(
         numpy.squeeze(lattice_pass(ring, in_mat, refpts=refs,
                                    keep_lattice=keep_lattice), axis=3), -1
@@ -217,9 +217,9 @@ def gen_m66_elem(ring: Lattice,
         m66:        6x6 transfer matrix
     """
 
-    dip_inds = get_refpts(ring, Bend)
-    theta = numpy.array([ring[ind].BendingAngle for ind in dip_inds])
-    lendp = numpy.array([ring[ind].Length for ind in dip_inds])
+    dipoles = ring[Dipole]
+    theta = numpy.array([elem.BendingAngle for elem in dipoles])
+    lendp = numpy.array([elem.Length for elem in dipoles])
     s_pos = ring.get_s_pos()
     s = numpy.diff(numpy.array([s_pos[0], s_pos[-1]]))[0]
     i2 = numpy.sum(numpy.abs(theta * theta / lendp))

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,7 +4,7 @@ Closed orbit related functions
 import numpy
 from at.constants import clight
 from at.lattice import AtError, AtWarning, check_6d, DConstant
-from at.lattice import Lattice, get_s_pos, uint32_refpts, Refpts
+from at.lattice import Lattice, get_s_pos, Refpts
 from at.tracking import lattice_pass
 from . import ELossMethod, get_timelag_fromU0
 import warnings
@@ -154,9 +154,11 @@ def find_orbit4(ring: Lattice, dp: float = None, refpts: Refpts = None, *,
     2. Have any time dependence (localized impedance, fast kickers etc)
 
     Parameters:
-        ring:           Lattice description (``is_6d`` must be :py:obj:`False`)
+        ring:           Lattice description (:py:meth:`~.Lattice.is_6d` must be
+          :py:obj:`False`)
         dp:             Momentum deviation. Defaults to 0
-        refpts:         Observation points
+        refpts:         Observation points.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         dct:            Path lengthening. If specified, *dp* is ignored and
           the off-momentum is deduced from the path lengthening.
         df:             Deviation from the nominal RF frequency. If specified,
@@ -201,12 +203,13 @@ def find_orbit4(ring: Lattice, dp: float = None, refpts: Refpts = None, *,
             orbit = _orbit_dp(ring, dp, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
-    all_points = numpy.empty((0, 6), dtype=float) if len(
-        uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
-                     keep_lattice=keep_lattice), axis=(1, 3)).T
+    if ring.refcount(refpts) == 0:
+        all_points = numpy.empty((0, 6), dtype=float)
+    else:
+        all_points = lattice_pass(ring, orbit.copy(order='K'), refpts=refpts,
+                                  keep_lattice=keep_lattice)
+        all_points = numpy.squeeze(all_points, axis=(1, 3)).T
     return orbit, all_points
 
 
@@ -244,9 +247,11 @@ def find_sync_orbit(ring: Lattice, dct: float = None, refpts: Refpts = None, *,
     2. Have any time dependence (localized impedance, fast kickers etc)
 
     Parameters:
-        ring:           Lattice description (``is_6d`` must be :py:obj:`False`)
+        ring:           Lattice description (:py:meth:`~.Lattice.is_6d` must be
+          :py:obj:`False`)
         dct:            Path lengthening.
-        refpts:         Observation points
+        refpts:         Observation points.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         dp:             Momentum deviation. Defaults to :py:obj:`None`
         df:             Deviation from the nominal RF frequency. If specified,
           *dct* is ignored and the off-momentum is deduced from the frequency
@@ -290,12 +295,13 @@ def find_sync_orbit(ring: Lattice, dct: float = None, refpts: Refpts = None, *,
             orbit = _orbit_dct(ring, dct,  keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
-    all_points = numpy.empty((0, 6), dtype=float) if len(
-        uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
-                     keep_lattice=keep_lattice), axis=(1, 3)).T
+    if ring.refcount(refpts) == 0:
+        all_points = numpy.empty((0, 6), dtype=float)
+    else:
+        all_points = lattice_pass(ring, orbit.copy(order='K'), refpts=refpts,
+                                  keep_lattice=keep_lattice)
+        all_points = numpy.squeeze(all_points, axis=(1, 3)).T
     return orbit, all_points
 
 
@@ -403,7 +409,8 @@ def find_orbit6(ring: Lattice, refpts: Refpts = None, *,
 
     Parameters:
         ring:           Lattice description
-        refpts:         Observation points
+        refpts:         Observation points.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         orbit:          Avoids looking for initial the closed orbit if it is
           already known ((6,) array). :py:func:`find_sync_orbit` propagates it
           to the specified *refpts*.
@@ -442,28 +449,32 @@ def find_orbit6(ring: Lattice, refpts: Refpts = None, *,
         orbit = _orbit6(ring, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
-    all_points = numpy.empty((0, 6), dtype=float) if len(
-        uint32refs) == 0 else numpy.squeeze(
-        lattice_pass(ring, orbit.copy(order='K'), refpts=uint32refs,
-                     keep_lattice=keep_lattice), axis=(1, 3)).T
+    if ring.refcount(refpts) == 0:
+        all_points = numpy.empty((0, 6), dtype=float)
+    else:
+        all_points = lattice_pass(ring, orbit.copy(order='K'), refpts=refpts,
+                                  keep_lattice=keep_lattice)
+        all_points = numpy.squeeze(all_points, axis=(1, 3)).T
     return orbit, all_points
 
 
-def find_orbit(ring, refpts=None, **kwargs):
+def find_orbit(ring, refpts: Refpts = None, **kwargs):
     r"""Gets the closed orbit in the general case
 
     Depending on the lattice, :py:func:`find_orbit` will:
 
-    * use :py:func:`find_orbit6` if ``ring.is_6d`` is :py:obj:`True`,
-    * use :py:func:`find_sync_orbit` if ``ring.is_6d`` is :py:obj:`False` and
+    * use :py:func:`find_orbit6` if :py:meth:`~.Lattice.is_6d` is
+      :py:obj:`True`,
+    * use :py:func:`find_sync_orbit` if :py:meth:`~.Lattice.is_6d` is
+      :py:obj:`False` and
       *dct* or *df* is specified,
     * use :py:func:`find_orbit4` otherwise.
 
     Parameters:
         ring:           Lattice description
-        refpts:         Observation points
+        refpts:         Observation points.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Keyword Args:
         orbit (Orbit):          Avoids looking for initial the closed

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -154,7 +154,7 @@ def find_orbit4(ring: Lattice, dp: float = None, refpts: Refpts = None, *,
     2. Have any time dependence (localized impedance, fast kickers etc)
 
     Parameters:
-        ring:           Lattice description (:py:meth:`~.Lattice.is_6d` must be
+        ring:           Lattice description (:py:attr:`~.Lattice.is_6d` must be
           :py:obj:`False`)
         dp:             Momentum deviation. Defaults to 0
         refpts:         Observation points.
@@ -247,7 +247,7 @@ def find_sync_orbit(ring: Lattice, dct: float = None, refpts: Refpts = None, *,
     2. Have any time dependence (localized impedance, fast kickers etc)
 
     Parameters:
-        ring:           Lattice description (:py:meth:`~.Lattice.is_6d` must be
+        ring:           Lattice description (:py:attr:`~.Lattice.is_6d` must be
           :py:obj:`False`)
         dct:            Path lengthening.
         refpts:         Observation points.
@@ -464,9 +464,9 @@ def find_orbit(ring, refpts: Refpts = None, **kwargs):
 
     Depending on the lattice, :py:func:`find_orbit` will:
 
-    * use :py:func:`find_orbit6` if :py:meth:`~.Lattice.is_6d` is
+    * use :py:func:`find_orbit6` if :py:attr:`~.Lattice.is_6d` is
       :py:obj:`True`,
-    * use :py:func:`find_sync_orbit` if :py:meth:`~.Lattice.is_6d` is
+    * use :py:func:`find_sync_orbit` if :py:attr:`~.Lattice.is_6d` is
       :py:obj:`False` and
       *dct* or *df* is specified,
     * use :py:func:`find_orbit4` otherwise.

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -201,7 +201,7 @@ def find_orbit4(ring: Lattice, dp: float = None, refpts: Refpts = None, *,
             orbit = _orbit_dp(ring, dp, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = uint32_refpts(refpts, len(ring))
+    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
     all_points = numpy.empty((0, 6), dtype=float) if len(
         uint32refs) == 0 else numpy.squeeze(
@@ -290,7 +290,7 @@ def find_sync_orbit(ring: Lattice, dct: float = None, refpts: Refpts = None, *,
             orbit = _orbit_dct(ring, dct,  keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = uint32_refpts(refpts, len(ring))
+    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
     all_points = numpy.empty((0, 6), dtype=float) if len(
         uint32refs) == 0 else numpy.squeeze(
@@ -442,7 +442,7 @@ def find_orbit6(ring: Lattice, refpts: Refpts = None, *,
         orbit = _orbit6(ring, keep_lattice=keep_lattice, **kwargs)
         keep_lattice = True
 
-    uint32refs = uint32_refpts(refpts, len(ring))
+    uint32refs = ring.uint32_refpts(refpts)
     # bug in numpy < 1.13
     all_points = numpy.empty((0, 6), dtype=float) if len(
         uint32refs) == 0 else numpy.squeeze(

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -4,7 +4,7 @@ Simple parallelisation of atpass() using multiprocessing.
 from functools import partial
 import multiprocessing
 # noinspection PyProtectedMember
-from ..lattice.utils import get_uint32_refpts
+from ..lattice.utils import get_uint32_index
 from ..lattice import AtWarning, Element, DConstant, random
 from ..lattice import Refpts, End
 from warnings import warn
@@ -165,7 +165,7 @@ def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
 
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refpts = get_uint32_refpts(lattice, refpts)
+    refpts = get_uint32_index(lattice, refpts)
     bunch_currents = getattr(lattice, 'bunch_currents', np.zeros(1))
     bunch_spos = getattr(lattice, 'bunch_spos', np.zeros(1))
     kwargs.update(bunch_currents=bunch_currents, bunch_spos=bunch_spos)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -89,11 +89,8 @@ def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
           the end of the element. For the best efficiency, *r_in*
           should be given as F_CONTIGUOUS numpy array.
         nturns:                 number of turns to be tracked
-        refpts:                 numpy array of indices of elements where
-          output is desired:
-
-          * len(line) means end of the last element (default)
-          * 0 means entrance of the first element
+        refpts:                 Selects the location of coordinates output.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         pool_size:              number of processes. If None,
           ``min(npart,nproc)`` is used
         start_method:           python multiprocessing start method.

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -4,7 +4,7 @@ Simple parallelisation of atpass() using multiprocessing.
 from functools import partial
 import multiprocessing
 # noinspection PyProtectedMember
-from ..lattice.utils import _uint32_refs
+from ..lattice.utils import get_uint32_refpts
 from ..lattice import AtWarning, Element, DConstant, random
 from ..lattice import Refpts, End
 from warnings import warn
@@ -165,7 +165,7 @@ def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
 
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refpts = _uint32_refs(lattice, refpts)
+    refpts = get_uint32_refpts(lattice, refpts)
     bunch_currents = getattr(lattice, 'bunch_currents', np.zeros(1))
     bunch_spos = getattr(lattice, 'bunch_spos', np.zeros(1))
     kwargs.update(bunch_currents=bunch_currents, bunch_spos=bunch_spos)

--- a/pyat/at/tracking/patpass.py
+++ b/pyat/at/tracking/patpass.py
@@ -3,8 +3,10 @@ Simple parallelisation of atpass() using multiprocessing.
 """
 from functools import partial
 import multiprocessing
-from ..lattice import AtWarning, Element, uint32_refpts, DConstant, random
-from ..lattice import Refpts
+# noinspection PyProtectedMember
+from ..lattice.utils import _uint32_refs
+from ..lattice import AtWarning, Element, DConstant, random
+from ..lattice import Refpts, End
 from warnings import warn
 from .atpass import reset_rng, atpass as _atpass
 from .track import fortran_align
@@ -68,7 +70,7 @@ def _pass(ring, r_in, pool_size, start_method, **kwargs):
 
 @fortran_align
 def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
-            refpts: Refpts = None, pool_size: int = None,
+            refpts: Refpts = End, pool_size: int = None,
             start_method: str = None, **kwargs):
     """
     Simple parallel implementation of :py:func:`.lattice_pass`.
@@ -166,9 +168,7 @@ def patpass(lattice: Iterable[Element], r_in, nturns: int = 1,
 
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    if refpts is None:
-        refpts = len(lattice)
-    refpts = uint32_refpts(refpts, len(lattice))
+    refpts = _uint32_refs(lattice, refpts)
     bunch_currents = getattr(lattice, 'bunch_currents', np.zeros(1))
     bunch_spos = getattr(lattice, 'bunch_spos', np.zeros(1))
     kwargs.update(bunch_currents=bunch_currents, bunch_spos=bunch_spos)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -66,11 +66,8 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
           the end of the element. For the best efficiency, *r_in*
           should be given as F_CONTIGUOUS numpy array.
         nturns:                 number of turns to be tracked
-        refpts:                 numpy array of indices of elements where
-          output is desired:
-
-          * len(line) means end of the last element (default)
-          * 0 means entrance of the first element
+        refpts:                 Selects the location of coordinates output.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
 
     Keyword arguments:
         keep_lattice (bool):    Use elements persisted from a previous

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -3,7 +3,7 @@ import functools
 from warnings import warn
 from .atpass import atpass as _atpass, elempass as _elempass
 from ..lattice import Element, Particle, Refpts, End
-from ..lattice import elements, refpts_iterator, get_uint32_refpts
+from ..lattice import elements, refpts_iterator, get_uint32_index
 from typing import List, Iterable
 
 
@@ -136,7 +136,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refs = get_uint32_refpts(lattice, refpts)
+    refs = get_uint32_index(lattice, refpts)
     # define properties if lattice is not a Lattice object
     nbunch = getattr(lattice, 'nbunch', 1)
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -2,7 +2,9 @@ import numpy
 import functools
 from warnings import warn
 from .atpass import atpass as _atpass, elempass as _elempass
-from ..lattice import Element, Particle, Refpts, uint32_refpts
+# noinspection PyProtectedMember
+from ..lattice.utils import _uint32_refs
+from ..lattice import Element, Particle, Refpts, End
 from ..lattice import elements, get_elements
 from typing import List, Iterable
 
@@ -51,7 +53,7 @@ def fortran_align(func):
 
 @fortran_align
 def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
-                 refpts: Refpts = None, **kwargs):
+                 refpts: Refpts = End, **kwargs):
     """
     :py:func:`lattice_pass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's
@@ -128,7 +130,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
          keywords to ensure the continuity of the turn number.
        * For multiparticle tracking with large number of turn the size of
          *r_out* may increase excessively. To avoid memory issues
-         :pycode:`lattice_pass(lattice, r_in, refpts=[])` can be used.
+         :pycode:`lattice_pass(lattice, r_in, refpts=None)` can be used.
          An empty list is returned and the tracking results of the last turn
          are stored in *r_in*.
        * To model buckets with different RF voltage :pycode:`unfold_beam=False`
@@ -139,9 +141,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    if refpts is None:
-        refpts = len(lattice)
-    refs = uint32_refpts(refpts, len(lattice))
+    refs = _uint32_refs(lattice, refpts)
     # define properties if lattice is not a Lattice object
     nbunch = getattr(lattice, 'nbunch', 1)
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -2,10 +2,8 @@ import numpy
 import functools
 from warnings import warn
 from .atpass import atpass as _atpass, elempass as _elempass
-# noinspection PyProtectedMember
-from ..lattice.utils import _uint32_refs
 from ..lattice import Element, Particle, Refpts, End
-from ..lattice import elements, get_elements
+from ..lattice import elements, refpts_iterator, get_uint32_refpts
 from typing import List, Iterable
 
 
@@ -16,7 +14,7 @@ DIMENSION_ERROR = 'Input to lattice_pass() must be a 6xN array.'
 
 
 def _set_beam_monitors(ring: List[Element], nbunch: int, nturns: int):
-    monitors = get_elements(ring, elements.BeamMoments)
+    monitors = list(refpts_iterator(ring, elements.BeamMoments))
     for m in monitors:
         m.set_buffers(nturns, nbunch)
     return len(monitors) == 0
@@ -138,7 +136,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refs = _uint32_refs(lattice, refpts)
+    refs = get_uint32_refpts(lattice, refpts)
     # define properties if lattice is not a Lattice object
     nbunch = getattr(lattice, 'nbunch', 1)
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -15,8 +15,9 @@ import pytest
 ))
 def test_uint32_refpts_converts_numerical_inputs_correctly(ref_in, expected):
     numpy.testing.assert_equal(uint32_refpts(ref_in, 5), expected)
-    ref_in2 = numpy.asarray(ref_in).astype(numpy.float64)
-    numpy.testing.assert_equal(uint32_refpts(ref_in2, 5), expected)
+    # float indexes are deprecated
+    # ref_in2 = numpy.asarray(ref_in).astype(numpy.float64)
+    # numpy.testing.assert_equal(uint32_refpts(ref_in2, 5), expected)
     ref_in2 = numpy.asarray(ref_in).astype(numpy.int64)
     numpy.testing.assert_equal(uint32_refpts(ref_in2, 5), expected)
 

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -126,7 +126,7 @@ def test_get_elements(hmba_lattice):
 
 
 def test_get_s_pos_returns_zero_for_empty_lattice():
-    numpy.testing.assert_equal(get_s_pos([], None), numpy.array((0,)))
+    numpy.testing.assert_equal(get_s_pos([]), numpy.array((0,)))
 
 
 def test_get_s_pos_returns_length_for_lattice_with_one_element():
@@ -134,12 +134,10 @@ def test_get_s_pos_returns_length_for_lattice_with_one_element():
     assert get_s_pos([e], [1]) == numpy.array([0.1])
 
 
-def test_get_s_pos_returns_all_pts_for_lat_with_2_elements_and_refpts_None():
+def test_get_s_pos_returns_all_pts_for_lat_with_2_elements():
     e = elements.LongElement('e', 0.1)
     f = elements.LongElement('e', 2.1)
-    print(get_s_pos([e, f], None))
-    numpy.testing.assert_equal(get_s_pos([e, f], None),
-                               numpy.array([0, 0.1, 2.2]))
+    numpy.testing.assert_equal(get_s_pos([e, f]), numpy.array([0, 0.1, 2.2]))
 
 
 def test_get_s_pos_returns_all_pts_for_lat_with_2_elements_using_int_refpts():

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -1,6 +1,4 @@
-import sys
 import numpy
-from io import BytesIO, StringIO
 from at.lattice import elements, uint32_refpts, bool_refpts, checkattr
 from at.lattice import checktype, get_cells, refpts_iterator, get_elements
 from at.lattice import get_s_pos, tilt_elem, shift_elem, set_tilt, set_shift
@@ -123,22 +121,7 @@ def test_get_elements(hmba_lattice):
     assert get_elements(hmba_lattice, elements.RFCavity) == [hmba_lattice[0]]
     # test invalid key raises TypeError
     with pytest.raises(TypeError):
-        get_elements(hmba_lattice, None)
-    # test quiet suppresses print statement correctly
-    if sys.version_info < (3, 0):
-        capturedOutput = BytesIO()
-    else:
-        capturedOutput = StringIO()
-    sys.stdout = capturedOutput
-    get_elements(hmba_lattice, 'BPM_06', quiet=True)
-    sys.stdout = sys.__stdout__
-    assert capturedOutput.getvalue() == ''
-    sys.stdout = capturedOutput
-    get_elements(hmba_lattice, 'BPM_06', quiet=False)
-    sys.stdout = sys.__stdout__
-    assert capturedOutput.getvalue() == ("String 'BPM_06' matched 1 family: "
-                                         "BPM_06\nall corresponding elements "
-                                         "have been returned.\n")
+        get_elements(hmba_lattice, 1.0)
 
 
 def test_get_s_pos_returns_zero_for_empty_lattice():

--- a/pyat/test/test_lattice_utils.py
+++ b/pyat/test/test_lattice_utils.py
@@ -43,8 +43,8 @@ def test_uint32_refpts_converts_other_input_types_correctly(ref_in, expected):
 # indexing misordered
 @pytest.mark.parametrize('ref_in', ([0, 1, 2, 3], [2, 1], [0, 0], [-1, 0],
                                     [0, -2], [3, 0], [1, 3], [-1, 3], [3, -2]))
-def test_uint32_refpts_throws_ValueError_correctly(ref_in):
-    with pytest.raises(ValueError):
+def test_uint32_refpts_throws_IndexError_correctly(ref_in):
+    with pytest.raises(IndexError):
         uint32_refpts(ref_in, 2)
 
 

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -241,9 +241,9 @@ def test_linopt_no_refpts(dba_lattice):
     assert len(physics.linopt(dba_lattice, DP, get_chrom=True)) == 4
 
 
-@pytest.mark.parametrize('refpts', ([145], [1, 2, 3, 145]))
+@pytest.mark.parametrize('refpts', ([121], [1, 2, 3, 121]))
 def test_linopt_line(hmba_lattice, refpts):
-    refpts.append(len(hmba_lattice))
+#    refpts.append(len(hmba_lattice))
     l0, q, qp, ld = at.linopt(hmba_lattice, refpts=refpts)
     lt0, qt, qpt, ltd = at.linopt(hmba_lattice, refpts=refpts, twiss_in=l0)
     assert_close(ld['beta'], ltd['beta'], rtol=1e-12)


### PR DESCRIPTION
This is major upgrade concerning the definition of the common "refpts" argument.

Up to now, the "refpts" value is restricted to two forms : _integer_ form and _boolean_ form. Three utility functions: `get_cells`, `get_refpts` and `get_elements` can convert other forms like element FamNames, element types or filter functions to the two basic forms.

The refpts argument can be processed by 4 main functions:
* `uint32_refpts`: sanity check and conversion to the _integer_ form
* `bool_refpts`: sanity check and conversion to the _bool_ form
* `refpts_count`: count of the selected lattice elements
* `refpts_iterator`: iterate through the selected lattice elements

Here we will upgrade these 4 functions to accept any form accepted until now by `get_cells`, `get_refpts`... So now, the refpts argument may one of:

1. an integer in the range _[-len(lattice), len(lattice)-1]_ selecting an element according to the python
indexing rules. As a special case, _len(lattice)_ is allowed and refers to the end of the last element,
2. an ordered list of such integers without duplicates,
3. a numpy array of booleans of maximum length _len(lattice)+1_, where selected elements are `True`,
4. `None`, meaning an empty selection,
5. `All`, new keyword meaning "all possible reference points": the entrance of all
elements plus the end of the last element,
6. `End`, new keyword selecting the end of the last element,
7. an element type, selecting all the elements of that type in
the lattice, e.g. `at.Sextupole`,
8. a string, selecting all the elements whose `FamName` attribute matches it.
Unix shell-style wildcards are accepted, e.g. `"Q[FD]*"`,
9. a callable `filtfunc` such that `filtfunc(elem)` is `True` for selected elements

This opens new possibilities without breaking anything.
