### PR TITLE
improve help of non-linear module

### DIFF
--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -261,6 +261,9 @@ def get_tunes_harmonic(cents, method: str = 'laskar',
                                           num_harmonics=num_harmonics,
                                           method=method,
                                           hann=hann)
-        tunes[i] = get_max_spectrum(freq, amp, fmin, fmax)
+        try:                                 
+            tunes[i] = get_max_spectrum(freq, amp, fmin, fmax)
+        except ValueError:
+            tunes[i] = np.nan
 
     return tunes

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -269,7 +269,7 @@ def test_nl_detuning_chromaticity(hmba_lattice):
     nlqpharm, _, _ = at.nonlinear.chromaticity(hmba_lattice,
                                                method='laskar', npoints=11)
     q0, q1, _, _, _, _ = at.nonlinear.detuning(hmba_lattice,
-                                               npoints=11, window=1)
+                                               npoints=11)
     assert_close(nlqplin, [[0.38156741, 0.17908231, 1.18656034, -16.47368694],
                            [0.85437409, 0.1224062, 2.01744075, -3.06407764]],
                  atol=1e-12, rtol=1e-5)


### PR DESCRIPTION
The PR was initially meant to improve the help of the non-linear module. 
In addition it fixes a nasty behavior of `get_tune_harmonics` that was crashing with an obscure `ValueError` when the tracking was failing.
If the tracking fails a nan is returned in this proposal (I hope this does not crash with #556).

More generally, my feeling is that the module 'nonlinear.py' would profit a lot from a good clean-up. 
Since this is closely linked to `harmonic_analysis`, that also needs some re-writing as mentioned in #556 , I would like to suggest to plan a complete re-write in a separate PR and keep this one as a temporary fix.