### PR TITLE
do not split elements with IdTablePass method

### DIFF
--- a/atmat/atplot/xplot.m
+++ b/atmat/atplot/xplot.m
@@ -74,7 +74,8 @@ end
 if nargout>0, varargout={curve}; end
 
     function newelems=splitelem(elem)
-        if isfield(elem,'Length') && elem.Length > 0
+        if isfield(elem,'Length') && elem.Length > 0 ...
+                && ~strcmp(elem.PassMethod, 'IdTablePass')
             nslices=ceil(elem.Length/elmlength);
             if ~KeepAxis
                 newelems=atdivelem(elem,ones(1,nslices)./nslices);


### PR DESCRIPTION
This pull request temporarily fixes the atplot bug reported in issue #561 where atplot shows a wrong value of the tune due to the split of an element with pass method IdTablePass.

A pass method check has been added inside the local splitelem function.

Best regards,
o