### PR TITLE
Axis definitions

### DIFF
--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -6,6 +6,7 @@ These functions are useful for building ad manipulating these sequences.
 """
 import sys
 import numpy as np
+from .axisdef import *
 from .options import DConstant, random
 from .particle_object import Particle
 from .elements import *

--- a/pyat/at/lattice/axisdef.py
+++ b/pyat/at/lattice/axisdef.py
@@ -1,9 +1,11 @@
 """Helper functions for axis and plane descriptions"""
 from __future__ import annotations
 from typing import Optional, Union
+# For sys.version_info.minor < 9:
+from typing import Tuple
 
 AxisCode = Union[str, int, slice, None, type(Ellipsis)]
-AxisDef = Union[AxisCode, tuple[AxisCode, AxisCode]]
+AxisDef = Union[AxisCode, Tuple[AxisCode, AxisCode]]
 
 _axis_def = dict(
     x=dict(index=0, label="x", unit=" [m]"),
@@ -36,11 +38,6 @@ _plane_def['x'] = _plane_def['h']
 _plane_def['y'] = _plane_def['v']
 _plane_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _plane_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
-
-_no_def = {
-    None: dict(index=slice(None), label="", unit="", code=":"),
-    Ellipsis: dict(index=Ellipsis, label="", unit="", code="...")
-}
 
 
 def _descr(dd: dict, arg: AxisDef, key: Optional[str] = None):
@@ -164,34 +161,3 @@ def plane_(plane: AxisDef, key: Optional[str] = None):
 
     """
     return _descr(_plane_def, plane, key=key)
-
-
-def optics_(fieldname: str, axis: AxisDef, key: Optional[str] = None):
-    r"""Return axis/plane descriptions
-
-    In optics structured arrays, some fields use "axis" indexing (0:6), like
-    *closed_orbit* or *M*, and some use "plane" indexing (0:3), like *beta* or
-    *tune*. This function selects the indexing corresonding to the given
-    *fieldname*
-
-    Args:
-        fieldname:      Name of the optics field
-        axis:           axis or tuple of axis (see :py:func:`axis_` and
-          :py:func:`axis_`)
-        key:            key in the coordinate descriptor dictionary.  (see
-          :py:func:`axis_` and :py:func:`axis_`)
-
-    Returns:
-        descr :         value or tuple[values]
-    """
-    if callable(fieldname):
-        return _descr(_no_def, axis, key=key)
-    elif fieldname in {'M', 'closed_orbit', 'dispersion', 'A', 'R'}:
-        return _descr(_axis_def, axis, key=key)
-    else:
-        return _descr(_plane_def, axis, key=key)
-
-
-def nop_(axis: AxisDef, key: Optional[str] = None):
-    """Handle a :py:obj:`None` index as slice(None)"""
-    return _descr(_no_def, axis, key=key)

--- a/pyat/at/lattice/axisdef.py
+++ b/pyat/at/lattice/axisdef.py
@@ -27,17 +27,16 @@ _axis_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _axis_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
 _plane_def = dict(
-    h=dict(index=0, label="h", unit=" [m]"),
-    v=dict(index=1, label="v", unit=" [m]"),
-    l=dict(index=2, label="l", unit="")
+    h=dict(index=0, label="x", unit=" [m]"),
+    v=dict(index=1, label="y", unit=" [m]"),
+    l=dict(index=2, label="z", unit="")
 )
 for xk, xv in [it for it in _plane_def.items()]:
     xv['code'] = xk
     _plane_def[xv['index']] = xv
     _plane_def[xk.upper()] = xv
-_plane_def['x'] = _plane_def['h']
-_plane_def['y'] = _plane_def['v']
-_plane_def['z'] = _plane_def['l']
+_plane_def['h'] = _plane_def['x']
+_plane_def['v'] = _plane_def['y']
 _plane_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _plane_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
@@ -124,11 +123,11 @@ def plane_(plane: AxisDef, key: Optional[str] = None):
         plane:          plane code or tuple[plane code] selecting planes.
           planes for the 3 planes are:
 
-          0, 'h', 'H', 'x' for horizontal plane,
+          0, 'x', 'X', 'h' for horizontal plane,
 
-          1, 'v', 'V', 'y' for vertical plane,
+          1, 'y', 'Y', 'v' for vertical plane,
 
-          2, 'l', 'L', 'z' for the longitudinal plane
+          2, 'z', 'Z'   for the longitudinal plane
 
           :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all planes
         key:            key in the plane descriptor dictionary,

--- a/pyat/at/lattice/axisdef.py
+++ b/pyat/at/lattice/axisdef.py
@@ -19,17 +19,16 @@ for xk, xv in [it for it in _axis_def.items()]:
     xv['code'] = xk
     _axis_def[xv['index']] = xv
     _axis_def[xk.upper()] = xv
-_axis_def['xp'] = _axis_def['px']
-_axis_def['yp'] = _axis_def['py']
 _axis_def['delta'] = _axis_def['dp']
 _axis_def['s'] = _axis_def['ct']
+_axis_def['S'] = _axis_def['ct']
 _axis_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _axis_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
 _plane_def = dict(
-    h=dict(index=0, label="x", unit=" [m]"),
-    v=dict(index=1, label="y", unit=" [m]"),
-    l=dict(index=2, label="z", unit="")
+    x=dict(index=0, label="x", unit=" [m]"),
+    y=dict(index=1, label="y", unit=" [m]"),
+    z=dict(index=2, label="z", unit="")
 )
 for xk, xv in [it for it in _plane_def.items()]:
     xv['code'] = xk
@@ -37,6 +36,8 @@ for xk, xv in [it for it in _plane_def.items()]:
     _plane_def[xk.upper()] = xv
 _plane_def['h'] = _plane_def['x']
 _plane_def['v'] = _plane_def['y']
+_plane_def['H'] = _plane_def['x']
+_plane_def['V'] = _plane_def['y']
 _plane_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _plane_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
@@ -64,15 +65,15 @@ def axis_(axis: AxisDef, key: Optional[str] = None):
 
           0, 'x', 'X'
 
-          1, 'px', PX', 'xp'
+          1, 'px', PX'
 
-          2, 'z', 'Z'
+          2, 'y', 'Y'
 
-          3, 'py', 'PY', 'yp'
+          3, 'py', 'PY'
 
           4, 'dp', 'DP', 'delta'
 
-          5, 'ct', 'CT', 's'
+          5, 'ct', 'CT', 's', 'S'
 
           :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all axes
 
@@ -120,12 +121,12 @@ def plane_(plane: AxisDef, key: Optional[str] = None):
     r"""Return plane descriptions
 
     Parameters:
-        plane:          plane code or tuple[plane code] selecting planes.
-          planes for the 3 planes are:
+        plane:          plane code or tuple of plane codes selecting planes.
+          codes for the 3 planes are:
 
-          0, 'x', 'X', 'h' for horizontal plane,
+          0, 'x', 'X', 'h', 'H' for horizontal plane,
 
-          1, 'y', 'Y', 'v' for vertical plane,
+          1, 'y', 'Y', 'v', 'V' for vertical plane,
 
           2, 'z', 'Z'   for the longitudinal plane
 

--- a/pyat/at/lattice/axisdef.py
+++ b/pyat/at/lattice/axisdef.py
@@ -1,0 +1,197 @@
+"""Helper functions for axis and plane descriptions"""
+from __future__ import annotations
+from typing import Optional, Union
+
+AxisCode = Union[str, int, slice, None, type(Ellipsis)]
+AxisDef = Union[AxisCode, tuple[AxisCode, AxisCode]]
+
+_axis_def = dict(
+    x=dict(index=0, label="x", unit=" [m]"),
+    px=dict(index=1, label=r"$p_x$", unit=" [rad]"),
+    y=dict(index=2, label="y", unit=" [m]"),
+    py=dict(index=3, label=r"$p_y$", unit=" [rad]"),
+    dp=dict(index=4, label=r"$\delta$", unit=""),
+    ct=dict(index=5, label=r"$\beta c \tau$", unit=" [m]"),
+)
+for xk, xv in [it for it in _axis_def.items()]:
+    xv['code'] = xk
+    _axis_def[xv['index']] = xv
+    _axis_def[xk.upper()] = xv
+_axis_def['xp'] = _axis_def['px']
+_axis_def['yp'] = _axis_def['py']
+_axis_def['delta'] = _axis_def['dp']
+_axis_def[None] = dict(index=slice(None), label="", unit="", code=":")
+_axis_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
+
+_plane_def = dict(
+    h=dict(index=0, label="h", unit=" [m]"),
+    v=dict(index=1, label="v", unit=" [m]"),
+    l=dict(index=2, label="l", unit="")
+)
+for xk, xv in [it for it in _plane_def.items()]:
+    xv['code'] = xk
+    _plane_def[xv['index']] = xv
+    _plane_def[xk.upper()] = xv
+_plane_def['x'] = _plane_def['h']
+_plane_def['y'] = _plane_def['v']
+_plane_def[None] = dict(index=slice(None), label="", unit="", code=":")
+_plane_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
+
+_no_def = {
+    None: dict(index=slice(None), label="", unit="", code=":"),
+    Ellipsis: dict(index=Ellipsis, label="", unit="", code="...")
+}
+
+
+def _descr(dd: dict, arg: AxisDef, key: Optional[str] = None):
+    if isinstance(arg, tuple):
+        return tuple(_descr(dd, a, key=key) for a in arg)
+    else:
+        try:
+            descr = dd[arg]
+        except (TypeError, KeyError):
+            descr = dict(index=arg, code=arg, label="", unit="")
+        if key is None:
+            return descr
+        else:
+            return descr[key]
+
+
+def axis_(axis: AxisDef, key: Optional[str] = None):
+    r"""Return axis descriptions
+
+    Parameters:
+        axis:           axis code or tuple of axis codes selecting axes in the
+          standard AT coordinate system. codes for the 6 axes are:
+
+          0, 'x', 'X'
+
+          1, 'px', PX', 'xp'
+
+          2, 'z', 'Z'
+
+          3, 'py', 'PY', 'yp'
+
+          4, 'dp', 'delta'
+
+          5, 'ct'
+
+          :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all axes
+
+        key:            key in the coordinate descriptor dictionary,
+          selecting the desired information. One of :
+
+          'index'
+            index in the standard AT coordinate vector
+          'code'
+            string representation
+          'label'
+            label for plot annotation
+          'unit'
+            coordinate unit
+          :py:obj:`None`
+            entire description dictionary
+
+    Returns:
+        descr : value of tuple[values]
+
+    Examples:
+
+        >>> axis_(('x','dp'), key='index')
+        (0, 4)
+
+        returns the indices in the standard coordinate vector
+
+        >>> dplabel = axis_('dp', key='label')
+        >>> print(dplabel)
+        $\delta$
+
+        returns the coordinate label for plot annotation
+
+        >>> axis_((0,'dp'))
+        ({'plane': 0, 'label': 'x', 'unit': ' [m]', 'code': 'x'},
+         {'plane': 4, 'label': '$\\delta$', 'unit': '', 'code': 'dp'})
+
+        returns the entire description directories
+
+    """
+    return _descr(_axis_def, axis, key=key)
+
+
+def plane_(plane: AxisDef, key: Optional[str] = None):
+    r"""Return plane descriptions
+
+    Parameters:
+        plane:          plane code or tuple[plane code] selecting planes.
+          planes for the 3 planes are:
+
+          0, 'h', 'H', 'x' for horizontal plane,
+
+          1, 'v', 'V', 'y' for vertical plane,
+
+          2, 'l', 'L' for the longitudinal plane
+
+          :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all planes
+        key:            key in the plane descriptor dictionary,
+          selecting the desired information. One of :
+
+          'plane'
+            plane in the optics data
+          'code'
+            string representation
+          'label'
+            label for plot annotation
+          'unit'
+            coordinate unit
+          :py:obj:`None`
+            entire description dictionary
+
+    Returns:
+        descr : value or tuple[values]
+
+    Examples:
+
+        >>> plane_('v', key='index')
+        1
+
+        returns the indices in the standard coordinate vector
+
+        >>> plane_(('x','y'))
+        ({'plane': 0, 'label': 'h', 'unit': ' [m]', 'code': 'h'},
+         {'plane': 1, 'label': 'v', 'unit': ' [m]', 'code': 'v'})
+
+        returns the entire description directories
+
+    """
+    return _descr(_plane_def, plane, key=key)
+
+
+def optics_(fieldname: str, axis: AxisDef, key: Optional[str] = None):
+    r"""Return axis/plane descriptions
+
+    In optics structured arrays, some fields use "axis" indexing (0:6), like
+    *closed_orbit* or *M*, and some use "plane" indexing (0:3), like *beta* or
+    *tune*. This function selects the indexing corresonding to the given
+    *fieldname*
+
+    Args:
+        fieldname:      Name of the optics field
+        axis:           axis or tuple of axis (see :py:func:`axis_` and
+          :py:func:`axis_`)
+        key:            key in the coordinate descriptor dictionary.  (see
+          :py:func:`axis_` and :py:func:`axis_`)
+
+    Returns:
+        descr :         value or tuple[values]
+    """
+    if callable(fieldname):
+        return _descr(_no_def, axis, key=key)
+    elif fieldname in {'M', 'closed_orbit', 'dispersion', 'A', 'R'}:
+        return _descr(_axis_def, axis, key=key)
+    else:
+        return _descr(_plane_def, axis, key=key)
+
+
+def nop_(axis: AxisDef, key: Optional[str] = None):
+    """Handle a :py:obj:`None` index as slice(None)"""
+    return _descr(_no_def, axis, key=key)

--- a/pyat/at/lattice/axisdef.py
+++ b/pyat/at/lattice/axisdef.py
@@ -22,6 +22,7 @@ for xk, xv in [it for it in _axis_def.items()]:
 _axis_def['xp'] = _axis_def['px']
 _axis_def['yp'] = _axis_def['py']
 _axis_def['delta'] = _axis_def['dp']
+_axis_def['s'] = _axis_def['ct']
 _axis_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _axis_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
@@ -36,6 +37,7 @@ for xk, xv in [it for it in _plane_def.items()]:
     _plane_def[xk.upper()] = xv
 _plane_def['x'] = _plane_def['h']
 _plane_def['y'] = _plane_def['v']
+_plane_def['z'] = _plane_def['l']
 _plane_def[None] = dict(index=slice(None), label="", unit="", code=":")
 _plane_def[Ellipsis] = dict(index=Ellipsis, label="", unit="", code="...")
 
@@ -69,9 +71,9 @@ def axis_(axis: AxisDef, key: Optional[str] = None):
 
           3, 'py', 'PY', 'yp'
 
-          4, 'dp', 'delta'
+          4, 'dp', 'DP', 'delta'
 
-          5, 'ct'
+          5, 'ct', 'CT', 's'
 
           :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all axes
 
@@ -126,7 +128,7 @@ def plane_(plane: AxisDef, key: Optional[str] = None):
 
           1, 'v', 'V', 'y' for vertical plane,
 
-          2, 'l', 'L' for the longitudinal plane
+          2, 'l', 'L', 'z' for the longitudinal plane
 
           :py:obj:`None`, slice(None) and :py:obj:`Ellipsis` selects all planes
         key:            key in the plane descriptor dictionary,


### PR DESCRIPTION
Many functions require the user to specify a coordinate axis (x, p<sub>x</sub>, y, p<sub>x</sub>, &delta;, c&tau;)  or a plane (horizontal, vertical or longitudinal).
A new module `axisdef.py` introduces helper functions to make the specification of coordinate axes or plane selection easier.

These functions supersede the `axis_descr` function of the `utils.py` module.