### PR TITLE
Fix circular imports

### DIFF
--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -5,6 +5,7 @@ A :py:class:`.Lattice` in pyAT is a sequence of :py:class:`.Element` objects.
 These functions are useful for building ad manipulating these sequences.
 """
 import sys
+import numpy as np
 from .options import DConstant, random
 from .particle_object import Particle
 from .elements import *
@@ -18,3 +19,6 @@ from .deprecated import *
 # noinspection PyUnresolvedReferences
 from .. import constants
 sys.modules['at.lattice.constants'] = sys.modules['at.constants']
+
+# Type definitions
+Orbit = np.ndarray

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -9,9 +9,9 @@ from .orbit import *
 from .matrix import *
 from .revolution import *
 from .linear import *
-from .ring_parameters import *
 from .diffmatrix import find_mpole_raddiff_matrix
 from .radiation import *
+from .ring_parameters import *
 from .harmonic_analysis import *
 from .nonlinear import *
 from .fastring import *

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -3,7 +3,7 @@ Closed orbit related functions
 """
 import numpy
 from at.constants import clight
-from at.lattice import AtError, AtWarning, check_6d, DConstant
+from at.lattice import AtError, AtWarning, check_6d, DConstant, Orbit
 from at.lattice import Lattice, get_s_pos, Refpts
 from at.lattice import set_cavity
 from at.tracking import lattice_pass
@@ -11,8 +11,7 @@ from . import ELossMethod, get_timelag_fromU0
 import warnings
 import functools
 
-Orbit = numpy.ndarray
-
+# For backward compatibility, Orbit is redefined from .lattice
 __all__ = ['Orbit', 'find_orbit4', 'find_sync_orbit', 'find_orbit6',
            'find_orbit', 'get_revolution_frequency', 'frequency_control']
            

--- a/pyat/at/physics/ring_parameters.py
+++ b/pyat/at/physics/ring_parameters.py
@@ -2,7 +2,8 @@ from math import pi, sqrt, asin, cos
 import numpy
 from numpy import nan
 from typing import Optional
-from ..lattice import Lattice
+from . import get_radiation_integrals, ohmi_envelope, get_energy_loss
+from ..lattice import Lattice, Orbit
 from ..constants import clight, Cgamma, Cq
 
 __all__ = ['RingParameters', 'radiation_parameters', 'envelope_parameters']
@@ -112,7 +113,7 @@ def radiation_parameters(ring: Lattice, dp: Optional[float] = None,
     _, ringdata, twiss = ring.get_optics(refpts=range(len(ring) + 1), dp=dp,
                                          get_chrom=True, **kwargs)
     rp.chromaticities = ringdata.chromaticity * ring.periodicity
-    integs = ring.get_radiation_integrals(dp=dp, twiss=twiss)
+    integs = get_radiation_integrals(ring, dp=dp, twiss=twiss)
     rp.i1, rp.i2, rp.i3, rp.i4, rp.i5 = numpy.array(integs) * ring.periodicity
     circumference = ring.circumference
     voltage = ring.rf_voltage
@@ -155,14 +156,19 @@ def radiation_parameters(ring: Lattice, dp: Optional[float] = None,
 
 # noinspection PyPep8Naming
 def envelope_parameters(ring: Lattice,
-                        params: Optional[RingParameters] = None)\
-        -> RingParameters:
+                        params: Optional[RingParameters] = None,
+                        orbit: Orbit = None,
+                        keep_lattice: bool = False) -> RingParameters:
     r"""Compute ring parameters from ohmi_envelope
 
     Parameters:
-        ring:       Lattice description.
-        params:     :py:class:`.RingParameters` object to be updated.
+        ring:           Lattice description.
+        params:         :py:class:`.RingParameters` object to be updated.
           Default: create a new one
+        orbit:          Avoids looking for the closed orbit if it is
+          already known ((6,) array)
+        keep_lattice:   Assume no lattice change since the
+          previous tracking.
 
     Returns:
         params:             :py:class:`.RingParameters` object.
@@ -183,10 +189,11 @@ def envelope_parameters(ring: Lattice,
     ==================  ========================================
     """
     rp = RingParameters() if params is None else params
-    emit0, beamdata, emit = ring.ohmi_envelope()
+    emit0, beamdata, emit = ohmi_envelope(ring, orbit=orbit,
+                                          keep_lattice=keep_lattice)
     voltage = ring.rf_voltage
     rp.E0 = ring.energy
-    rp.U0 = ring.energy_loss
+    rp.U0 = get_energy_loss(ring)
     rev_freq = ring.revolution_frequency
     rp.Tau = 1.0 / rev_freq / beamdata.damping_rates / ring.periodicity
     alpha = 1.0 / rp.Tau

--- a/pyat/at/physics/ring_parameters.py
+++ b/pyat/at/physics/ring_parameters.py
@@ -2,7 +2,8 @@ from math import pi, sqrt, asin, cos
 import numpy
 from numpy import nan
 from typing import Optional
-from . import get_radiation_integrals, ohmi_envelope, get_energy_loss
+from .radiation import get_radiation_integrals, ohmi_envelope
+from .energy_loss import get_energy_loss
 from ..lattice import Lattice, Orbit
 from ..constants import clight, Cgamma, Cq
 

--- a/pyat/at/tracking/particles.py
+++ b/pyat/at/tracking/particles.py
@@ -4,8 +4,7 @@ Functions relating to particle generation
 import numpy as np
 from numpy.linalg import cholesky, LinAlgError
 from warnings import warn
-from ..physics import Orbit, ohmi_envelope
-from ..lattice import AtError, AtWarning, Lattice, random
+from ..lattice import AtError, AtWarning, Lattice, Orbit, random
 
 __all__ = ['beam', 'sigma_matrix']
 
@@ -143,7 +142,7 @@ def sigma_matrix(ring: Lattice = None, **kwargs):
         orbit = el0.closed_orbit
         Rm = r_expand(el0['R'], r56)
         if ring.is_6d:
-            _, beam0, _ = ohmi_envelope(ring, orbit=orbit)
+            _, beam0, _ = ring.ohmi_envelope(orbit=orbit)
             sigmat = sigma_from_rmat(Rm, beam0.mode_emittances, em56)
         else:
             sigmat = sigma_from_rmat(Rm, None, em56)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -2,7 +2,7 @@ import numpy
 import functools
 from warnings import warn
 from .atpass import atpass as _atpass, elempass as _elempass
-from ..lattice import Element, Particle, Refpts, End
+from ..lattice import Lattice, Element, Particle, Refpts, End
 from ..lattice import elements, refpts_iterator, get_uint32_index
 from typing import List, Iterable
 
@@ -241,3 +241,6 @@ def elempass(*args, **kwargs):
     """
     warn(UserWarning("The public interface for tracking is 'element_pass'"))
     return _elempass(*args, **kwargs)
+
+
+Lattice.lattice_pass = lattice_pass


### PR DESCRIPTION
This corrects some circular import problems which appeared while developing. The modifications are:

- the `Orbit` type is declared earlier (in `lattice` rather than `physics`), but is still defined in `physics` for compatibility,
- some imports in `lattice/__init__.py` and  `physics/__init__.py` are reordered,
- some function calls are replaced by calls to `Lattice` methods to avoid imports.