### PR TITLE
Lattice operators

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -322,28 +322,33 @@ class Element(object):
         # Bx default, the element is indivisible
         return [self]
 
-    def swap_faces(self):
+    def swap_faces(self, copy=False):
         """Swap the faces of an element, alignment errors are ignored"""
         def swapattr(element, attro, attri):
             val = getattr(element, attri)
             delattr(element, attri)
             return attro, val
+        if copy: 
+            el = self.copy()
+        else:
+            el = self
         # Remove and swap entrance and exit attributes
-        fin = dict(swapattr(self, kout, kin)
-                   for kin, kout in zip(self._entrance_fields,
-                                        self._exit_fields)
-                   if kin in vars(self)
-                   and kin not in self._no_swap)
-        fout = dict(swapattr(self, kin, kout)
-                    for kin, kout in zip(self._entrance_fields,
-                                         self._exit_fields)
-                    if kout in vars(self)
-                    and kout not in self._no_swap)
+        fin = dict(swapattr(el, kout, kin)
+                   for kin, kout in zip(el._entrance_fields,
+                                        el._exit_fields)
+                   if kin in vars(el)
+                   and kin not in el._no_swap)
+        fout = dict(swapattr(el, kin, kout)
+                    for kin, kout in zip(el._entrance_fields,
+                                         el._exit_fields)
+                    if kout in vars(el)
+                    and kout not in el._no_swap)
         # Apply swapped entrance and exit attributes
         for key, value in fin.items():
-            setattr(self, key, value)
+            setattr(el, key, value)
         for key, value in fout.items():
-            setattr(self, key, value)
+            setattr(el, key, value)
+        return el if copy else None
 
     def update(self, *args, **kwargs):
         """

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -253,6 +253,7 @@ class Element(object):
 
     _entrance_fields = ['T1', 'R1']
     _exit_fields = ['T2', 'R2']
+    _no_swap = _entrance_fields + _exit_fields
 
     def __init__(self, family_name: str, **kwargs):
         """
@@ -320,6 +321,28 @@ class Element(object):
         """
         # Bx default, the element is indivisible
         return [self]
+
+    def swap_faces(self):
+        def swapattr(element, attro, attri):
+            val = getattr(element, attri)
+            delattr(element, attri)
+            return attro, val
+        # Remove and swap entrance and exit attributes
+        fin = dict(swapattr(self, kout, kin)
+                   for kin, kout in zip(self._entrance_fields,
+                                        self._exit_fields)
+                   if kin in vars(self)
+                   and kin not in self._no_swap)
+        fout = dict(swapattr(self, kin, kout)
+                    for kin, kout in zip(self._entrance_fields,
+                                         self._exit_fields)
+                    if kout in vars(self)
+                    and kout not in self._no_swap)
+        # Apply swapped entrance and exit attributes
+        for key, value in fin.items():
+            setattr(self, key, value)
+        for key, value in fout.items():
+            setattr(self, key, value)
 
     def update(self, *args, **kwargs):
         """
@@ -694,7 +717,7 @@ class Dipole(Radiative, Multipole):
 
     _entrance_fields = Multipole._entrance_fields + ['EntranceAngle',
                                                      'FringeInt1',
-                                                     'FringeBendEntrance'
+                                                     'FringeBendEntrance',
                                                      'FringeQuadEntrance']
     _exit_fields = Multipole._exit_fields + ['ExitAngle',
                                              'FringeInt2',

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -323,6 +323,7 @@ class Element(object):
         return [self]
 
     def swap_faces(self):
+        """Swap the faces of an element, alignment errors are ignored"""
         def swapattr(element, attro, attri):
             val = getattr(element, attri)
             delattr(element, attri)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1258,7 +1258,8 @@ class Lattice(list):
             return radiate
 
 
-def merge_lattices(*lattices: Tuple[Union[Lattice, List], ...], copy=False):
+def merge_lattices(*lattices: Tuple[Union[Lattice, List], ...],
+                   copy=False) -> Lattice:
     """Merge several lattices together
 
     Equivalents syntaxes:

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -261,10 +261,10 @@ class Lattice(list):
 
     def __add__(self, elems):
         """Add elems, an iterable of AT elements, to the lattice"""
-        return merge_lattices(self, elems, copy=True)
+        return merge_lattices(self, elems)
 
     def __iadd__(self, elems):
-        return merge_lattices(self, elems)
+        return merge_lattices(self, elems, inplace=True)
 
     def __mul__(self, n):
         return self.repeat(n)
@@ -1256,8 +1256,8 @@ class Lattice(list):
             return radiate
 
 
-def merge_lattices(*lattices: Tuple[Iterable[Element], ...],
-                   copy=False) -> Lattice:
+def merge_lattices(lattice0: Lattice, *lattices: Tuple[Iterable[Element], ...],
+                   copy=False, inplace=False) -> Lattice:
     """Merge several lattices together
 
     Equivalents syntaxes:
@@ -1265,20 +1265,29 @@ def merge_lattices(*lattices: Tuple[Iterable[Element], ...],
     >>>newring = ring1 + ring2
 
     Parameters:
-        lattices:  lattices to be merged
+        lattice0:  initial lattice
+        lattices:  lattices to be merged to lattice0
 
     Keyword Arguments:
         copy(bool): Default :py:obj:`False`. If :py:obj:`True`
-                            deepcopies are used to produce the
-                            merged newring
+                            deepcopies of the elements of lattices
+        inplace(bool): Default :py:obj:`False`. If :py:obj:`True`
+                       the lattice `lattice0 is modified in place.
+                       Otherwise a new Lattice object is created.
 
     Returns:
         newring(Lattice): merged Lattice
     """
-    newring = Lattice(lattices[0])
-    for lat in lattices[1:]:
-        newring.extend(lat, copy=copy)
-    return newring
+    if not isinstance(lattice0, Lattice):
+        raise AtError('Input argument lattice0 is not a Lattice object')
+
+    if inplace:
+        lattice = lattice0
+    else:
+        lattice = Lattice(lattice0)
+    for lat in numpy.atleast_2d(lattices):
+        lattice.extend(lat, copy=copy)
+    return lattice
 
 
 def lattice_filter(params, lattice):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -272,7 +272,7 @@ class Lattice(list):
         return self.repeat(n)
 
     def __reversed__(self):
-        return self.reverse(copy=True)
+        return (el.swap_faces(copy=True) for el in self[::-1])
 
     def _addition_filter(self, elems: Iterable[Element], copy_elements=False):
         cavities = []
@@ -453,9 +453,8 @@ class Lattice(list):
         of elements. Alignment errors are not swapped
 
 
-        Equivalents syntaxes:
+        Usage:
         >>> newring = ring.reverse(copy=True)
-        >>> newring = reversed(ring)
 
         Keyword Arguments:
             copy(bool): Default :py:obj:`False`. If :py:obj:`True`

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -309,10 +309,10 @@ class Lattice(list):
     def extend(self, elems: Iterable[Element]):
         r"""This method adds all the elements of `elems` to the end of the
             lattice. The behavior is the same as for a :py:obj:`list`
-            
-            Equivalents syntaxes:        
+
+            Equivalents syntaxes:
             >>>ring.extend(elems)
-            >>>ring += elems          
+            >>>ring += elems
         """
         if hasattr(self, '_energy'):
             # When unpickling a Lattice, extend is called before the lattice
@@ -321,36 +321,37 @@ class Lattice(list):
         super().extend(elems)
 
     def append(self, elem: Element):
-        r"""This method overwrites the inherited method :py:meth:`list.append()`,
-            it behavior is changed, it accepts only AT lattice elements 
-            :py:obj:`Element` as input argument.  
+        r"""This method overwrites the inherited method
+            :py:meth:`list.append()`,
+            it behavior is changed, it accepts only AT lattice elements
+            :py:obj:`Element` as input argument.
 
-            Equivalents syntaxes:        
+            Equivalents syntaxes:
             >>>ring.append(elem)
-            >>>ring += [elem]                     
+            >>>ring += [elem]
         """
         self.extend([elem])
-        
+
     def repeat(self, n: int, copy=True):
-        r"""This method allows to repeat the lattice `n` times. 
-            If `n` does not divide `ring.periodicity`, the new ring 
+        r"""This method allows to repeat the lattice `n` times.
+            If `n` does not divide `ring.periodicity`, the new ring
             periodicity is set to 1, otherwise  it is et to
             `ring.periodicity /= n`.
-            
+
             Parameters:
                 n (int): number of repetition
-            
+
             Keyword Arguments:
                 copy(bool): Default :py:obj:`True`. If :py:obj:`True`
                             deepcopies of the lattice are used for the
                             repetition
-                
+
             Returns:
                 newring (Lattice): the new repeated lattice
 
-            Equivalents syntaxes:        
+            Equivalents syntaxes:
             >>>newring = ring.repeat(n)
-            >>>newring = ring * n                     
+            >>>newring = ring * n
         """
         """Repeats n times the lattice"""
         periodicity = self.periodicity
@@ -365,10 +366,10 @@ class Lattice(list):
         elems = []
         for i in range(n):
             if copy:
-                elems += self.deepcopy() 
+                elems += self.deepcopy()
             else:
-                elems += self            
-        return Lattice(elem_generator, elems, 
+                elems += self
+        return Lattice(elem_generator, elems,
                        iterator=self.attrs_filter, periodicity=periodicity)
 
     @property
@@ -678,7 +679,7 @@ class Lattice(list):
             circ = self.beta * clight * \
                 self.harmonic_number/self.rf_frequency
         except AtError:
-            circ = self.circumference       
+            circ = self.circumference
         bs = circ/len(self._fillpattern)
         allpos = bs*numpy.arange(len(self._fillpattern))
         return allpos[self._fillpattern > 0]
@@ -1255,33 +1256,33 @@ class Lattice(list):
             # noinspection PyAttributeOutsideInit
             self._radiation = radiate
             return radiate
-            
-            
+
+
 def merge_lattices(*lattices: Tuple[Lattice, ...], copy=False):
     """Merge several lattices together
-    
-    Equivalents syntaxes:  
-    >>>newring = merge_lattices(ring1, ring2)           
-    >>>newring = ring1 + ring2 
+
+    Equivalents syntaxes:
+    >>>newring = merge_lattices(ring1, ring2)
+    >>>newring = ring1 + ring2
 
     Parameters:
         lattices:  lattices to be merged
-        
+
     Keyword Arguments:
         copy(bool): Default :py:obj:`False`. If :py:obj:`True`
-                            deepcopies are used to produce the merged
-                            newring
+                            deepcopies are used to produce the
+                            merged newring
 
     Returns:
         newring(Lattice): merged Lattice
-    """    
+    """
     newring = []
-    for l in lattices:
+    for lat in lattices:
         if copy:
-            newring += l.deepcopy()
+            newring += lat.deepcopy()
         else:
-            newring += l
-    return newring 
+            newring += lat
+    return newring
 
 
 def lattice_filter(params, lattice):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -302,6 +302,16 @@ class Lattice(list):
         self._radiation |= params.pop('_radiation')
 
     def insert(self, idx: SupportsIndex, elem: Element, copy=False):
+        r"""This method allow to insert an AT element in the lattice.
+
+            Parameters:
+                idx (SupportsIndex): index at which the lement is inserted
+                elem (Element): AT element to be inserted in the lattice
+
+            Keyword Arguments:
+                copy(bool): Default :py:obj:`True`. If :py:obj:`True`
+                            a deep copy of elem is used
+        """
         # noinspection PyUnusedLocal
         # scan the new element to update it
         elist = list(self._addition_filter([elem], copy=copy))
@@ -314,6 +324,14 @@ class Lattice(list):
             Equivalents syntaxes:
             >>>ring.extend(elems)
             >>>ring += elems
+
+            Parameters:
+                elem (Iterable[Element]): Sequence of AT elements to be
+                                          appended to the lattice
+
+            Keyword Arguments:
+                copy(bool): Default :py:obj:`True`. If :py:obj:`True`
+                            deep copies of each element of elems are used
         """
         if hasattr(self, '_energy'):
             # When unpickling a Lattice, extend is called before the lattice
@@ -330,6 +348,13 @@ class Lattice(list):
             Equivalents syntaxes:
             >>>ring.append(elem)
             >>>ring += [elem]
+
+            Parameters:
+                elem (Element): AT element to be appended to the lattice
+
+            Keyword Arguments:
+                copy(bool): Default :py:obj:`True`. If :py:obj:`True`
+                            a deep copy of elem is used
         """
         self.extend([elem], copy=copy)
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -316,7 +316,8 @@ class Lattice(list):
         """
         # noinspection PyUnusedLocal
         # scan the new element to update it
-        elist = list(self._addition_filter([elem], copy_elements=copy_elements))
+        elist = list(self._addition_filter([elem],
+                     copy_elements=copy_elements))
         super().insert(idx, elem)
 
     def extend(self, elems: Iterable[Element], copy_elements=False):
@@ -384,11 +385,11 @@ class Lattice(list):
                 newring (Lattice): the new repeated lattice
         """
         def copy_fun(elem, copy):
-             if copy:
-                 return elem.deepcopy()
-             else:
-                 return elem
-        
+            if copy:
+                return elem.deepcopy()
+            else:
+                return elem
+
         periodicity = self.periodicity
         if n != 0 and periodicity > 1:
             nbp = periodicity / n

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -468,7 +468,7 @@ class Lattice(list):
                               otherwise None
         """
         if copy:
-            lattice = Lattice(self)
+            lattice = Lattice(self).deepcopy()
         else:
             lattice = self
         lattice[:] = lattice[::-1]

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -272,7 +272,8 @@ class Lattice(list):
         return self.repeat(n)
 
     def __reversed__(self):
-        return self.reverse(copy=True)
+        for elem in self[::-1]:
+            yield elem.swap_faces(copy=True)
 
     def _addition_filter(self, elems: Iterable[Element], copy_elements=False):
         cavities = []
@@ -468,13 +469,14 @@ class Lattice(list):
                               otherwise None
         """
         if copy:
-            lattice = Lattice(self).deepcopy()
+            elems = (el.swap_faces(copy=copy) for el in self)
+            return Lattice(elem_generator, elems, iterator=self.attrs_filter,
+                           periodicity=self.periodicity)            
         else:
-            lattice = self
-        lattice[:] = lattice[::-1]
-        for e in lattice:
-            e.swap_faces()
-        return lattice if copy else None
+            reversed_list = self[::-1]
+            for el in reversed_list:
+                e.swap_faces()
+            self[:] = reversed_list
 
     def develop(self) -> "Lattice":
         """Develop a periodical lattice by repeating its elements

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -261,7 +261,7 @@ class Lattice(list):
 
     def __add__(self, elems):
         """Add elems, an iterable of AT elements, to the lattice"""
-        return self.concatenate(elems)
+        return self.concatenate(elems, copy=True)
 
     def __iadd__(self, elems):
         self.concatenate(elems, copy=False)
@@ -398,17 +398,28 @@ class Lattice(list):
                 warn(AtWarning('Non-integer number of cells: {}/{}. Periodi'
                                'city set to 1'.format(self.periodicity, n)))
                 periodicity = 1
+        try:
+            cell_h = self._cell_harmnumber
+        except AttributeError:
+            hdict = {}
+        else:
+            hdict = dict(_cell_harmnumber=n*cell_h)
         elems = (copy_fun(el, copy_elements) for _ in range(n) for el in self)
         return Lattice(elem_generator, elems, iterator=self.attrs_filter,
-                       periodicity=periodicity)
+                       periodicity=periodicity, **hdict)
 
     def concatenate(self, *lattices: Tuple[Iterable[Element], ...],
-                    copy_elements=False, copy=True):
+                    copy_elements=False, copy=False):
         """Concatenate several `Iterable[Element]` with the lattice
 
         Equivalents syntaxes:
-        >>> newring = ring.concatenate(r1, r2, r3)
+        >>> newring = ring.concatenate(r1, r2, r3, copy=True)
         >>> newring = ring + r1 + r2 + r3
+
+        >>> ring.concatenate(r1, copy=False)
+        >>> ring += r1
+
+
 
         Parameters:
             lattices: :py:obj:`Iterables[Element]` to be concatenanted
@@ -417,7 +428,7 @@ class Lattice(list):
         Keyword Arguments:
             copy_elements(bool): Default :py:obj:`False`. If :py:obj:`True`
                         deepcopies of the elements of lattices are used
-            copy(bool): Default :py:obj:`True`. If :py:obj:`True`
+            copy(bool): Default :py:obj:`False`. If :py:obj:`True`
                            the lattice is modified in place.
                            Oterwise a new Lattice object is returned
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -271,6 +271,9 @@ class Lattice(list):
     def __mul__(self, n):
         return self.repeat(n)
 
+    def __reversed__(self):
+        return self.reverse(copy=True)
+
     def _addition_filter(self, elems: Iterable[Element], copy_elements=False):
         cavities = []
         length = 0.0
@@ -420,8 +423,6 @@ class Lattice(list):
         >>> ring.concatenate(r1, copy=False)
         >>> ring += r1
 
-
-
         Parameters:
             lattices: :py:obj:`Iterables[Element]` to be concatenanted
                       to the Lattice
@@ -434,8 +435,9 @@ class Lattice(list):
                            Oterwise a new Lattice object is returned
 
         Returns:
-            newring(Lattice): concatenated Lattice, if `copy==True` the
-                              input lattice is returned
+            lattice(Lattice): concatenated Lattice, if `copy==True` the
+                              new lattice object is returned
+                              otherwise None
         """
         if copy:
             lattice = Lattice(self)
@@ -443,6 +445,32 @@ class Lattice(list):
             lattice = self
         for lat in numpy.atleast_2d(lattices):
             lattice.extend(lat, copy_elements=copy_elements)
+        return lattice if copy else None
+
+    def reverse(self, copy=False):
+        """Concatenate several `Iterable[Element]` with the lattice
+
+        Equivalents syntaxes:
+        >>> newring = ring.reverse(copy=True)
+        >>> newring = reversed(ring)
+
+        Keyword Arguments:
+            copy(bool): Default :py:obj:`False`. If :py:obj:`True`
+                           the lattice is modified in place.
+                           Oterwise a new Lattice object is returned
+
+        Returns:
+            lattice(Lattice): reversed Lattice, if `copy==True` the
+                              new lattice object is returned
+                              otherwise None
+        """
+        if copy:
+            lattice = Lattice(self)
+        else:
+            lattice = self
+        lattice[:] = lattice[::-1]
+        for e in lattice:
+            e.swap_faces()
         return lattice if copy else None
 
     def develop(self) -> "Lattice":

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -15,8 +15,7 @@ import sys
 import copy
 import numpy
 import math
-import itertools
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 if sys.version_info.minor < 9:
     from typing import Callable, Iterable, Generator
     SupportsIndex = int

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1258,7 +1258,7 @@ class Lattice(list):
             return radiate
 
 
-def merge_lattices(*lattices: Tuple[Lattice, ...], copy=False):
+def merge_lattices(*lattices: Tuple[Union[Lattice, List], ...], copy=False):
     """Merge several lattices together
 
     Equivalents syntaxes:
@@ -1279,10 +1279,10 @@ def merge_lattices(*lattices: Tuple[Lattice, ...], copy=False):
     newring = []
     for lat in lattices:
         if copy:
-            newring += lat.deepcopy()
+            newring += copy.deepcopy(lat)
         else:
             newring += lat
-    return newring
+    return Lattice(newring)
 
 
 def lattice_filter(params, lattice):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -63,7 +63,7 @@ _DEFAULT_PASS = {
 }
 
 __all__ = ['Lattice', 'type_filter', 'params_filter', 'lattice_filter',
-           'elem_generator', 'no_filter']
+           'elem_generator', 'no_filter', 'merge_lattices']
 
 # Don't warn on floating-pont errors
 numpy.seterr(divide='ignore', invalid='ignore')
@@ -369,6 +369,26 @@ class Lattice(list):
             elems.extend(self, copy=copy)
         return Lattice(elem_generator, elems,
                        iterator=self.attrs_filter, periodicity=periodicity)
+
+    def concatenate(self, *lattices: Tuple[Iterable[Element], ...],
+                    copy=False):
+        """Concatenate several `Iterable[Element]` with the lattice
+
+        Equivalents syntaxes:
+        >>>newring = ring.concatenate(r1, r2, r3)
+        >>>newring = ring + r1 + r2 + r3
+
+        Parameters:
+            lattices:  lattices to be merged to the ring
+
+        Keyword Arguments:
+            copy(bool): Default :py:obj:`False`. If :py:obj:`True`
+                        deepcopies of the elements of lattices
+
+        Returns:
+            newring(Lattice): concatenated Lattice
+        """
+        return merge_lattices(self, *lattices, copy=copy)
 
     @property
     def attrs(self) -> Dict:

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -272,8 +272,7 @@ class Lattice(list):
         return self.repeat(n)
 
     def __reversed__(self):
-        for elem in self[::-1]:
-            yield elem.swap_faces(copy=True)
+        return self.reverse(copy=True)
 
     def _addition_filter(self, elems: Iterable[Element], copy_elements=False):
         cavities = []

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -362,7 +362,7 @@ class Lattice(list):
                 warn(AtWarning('Non-integer number of cells: {}/{}. Periodi'
                                'city set to 1'.format(self.periodicity, n)))
                 periodicity = 1
-        elems = itertools.repeat(self, n-1)
+        elems = itertools.repeat(self, max(n-1, 0))
         lattice = self.concatenate(*elems, copy=copy)
         return Lattice(lattice, periodicity=periodicity)
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1258,7 +1258,7 @@ class Lattice(list):
             return radiate
 
 
-def merge_lattices(*lattices: Tuple[Union[Lattice, List], ...],
+def merge_lattices(*lattices: Tuple[Iterable[Element], ...],
                    copy=False) -> Lattice:
     """Merge several lattices together
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -412,7 +412,7 @@ class Lattice(list):
         return Lattice(elem_generator, elems, iterator=self.attrs_filter,
                        periodicity=periodicity, **hdict)
 
-    def concatenate(self, *lattices: Tuple[Iterable[Element], ...],
+    def concatenate(self, *lattices: Iterable[Element],
                     copy_elements=False, copy=False):
         """Concatenate several `Iterable[Element]` with the lattice
 
@@ -425,7 +425,8 @@ class Lattice(list):
 
         Parameters:
             lattices: :py:obj:`Iterables[Element]` to be concatenanted
-                      to the Lattice
+                      to the Lattice, several lattices are allowed
+                      (see example)
 
         Keyword Arguments:
             copy_elements(bool): Default :py:obj:`False`. If :py:obj:`True`
@@ -443,7 +444,7 @@ class Lattice(list):
             lattice = Lattice(self)
         else:
             lattice = self
-        for lat in numpy.atleast_2d(lattices):
+        for lat in lattices:
             lattice.extend(lat, copy_elements=copy_elements)
         return lattice if copy else None
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -448,7 +448,9 @@ class Lattice(list):
         return lattice if copy else None
 
     def reverse(self, copy=False):
-        """Concatenate several `Iterable[Element]` with the lattice
+        r"""Reverse the order of the lattice and swapt the faces
+        of elements. Alignment errors are not swapped
+
 
         Equivalents syntaxes:
         >>> newring = ring.reverse(copy=True)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -339,6 +339,10 @@ class Lattice(list):
             periodicity is set to 1, otherwise  it is et to
             `ring.periodicity /= n`.
 
+            Equivalents syntaxes:
+            >>>newring = ring.repeat(n)
+            >>>newring = ring * n
+
             Parameters:
                 n (int): number of repetition
 
@@ -349,12 +353,7 @@ class Lattice(list):
 
             Returns:
                 newring (Lattice): the new repeated lattice
-
-            Equivalents syntaxes:
-            >>>newring = ring.repeat(n)
-            >>>newring = ring * n
         """
-        """Repeats n times the lattice"""
         periodicity = self.periodicity
         if n != 0 and periodicity > 1:
             nbp = periodicity / n

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -470,9 +470,7 @@ class Lattice(list):
             elems = (el.swap_faces(copy=copy) for el in self[::-1])
             return Lattice(elem_generator, elems, iterator=self.attrs_filter)
         else:
-            reversed_list = self[::-1]
-            for el in reversed_list:
-                el.swap_faces()
+            reversed_list = list(reversed(self))
             self[:] = reversed_list
 
     def develop(self) -> "Lattice":

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -468,7 +468,7 @@ class Lattice(list):
                               otherwise None
         """
         if copy:
-            elems = (el.swap_faces(copy=copy) for el in self)
+            elems = (el.swap_faces(copy=copy) for el in self[::-1])
             return Lattice(elem_generator, elems, iterator=self.attrs_filter,
                            periodicity=self.periodicity)            
         else:

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -469,8 +469,7 @@ class Lattice(list):
         """
         if copy:
             elems = (el.swap_faces(copy=copy) for el in self[::-1])
-            return Lattice(elem_generator, elems, iterator=self.attrs_filter,
-                           periodicity=self.periodicity)            
+            return Lattice(elem_generator, elems, iterator=self.attrs_filter)
         else:
             reversed_list = self[::-1]
             for el in reversed_list:

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -475,7 +475,7 @@ class Lattice(list):
         else:
             reversed_list = self[::-1]
             for el in reversed_list:
-                e.swap_faces()
+                el.swap_faces()
             self[:] = reversed_list
 
     def develop(self) -> "Lattice":

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -348,4 +348,4 @@ def test_exit_entrance():
     q = elements.Quadrupole('quad', 0.4, k=1)
     for kin, kout in zip(q._entrance_fields, q._exit_fields):
         assert_equal(kin.replace('Entrance', ''). replace('1', ''),
-                     kin.replace('Entrance', '').replace('1', ''))
+                     kout.replace('Exit', '').replace('2', ''))

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -2,6 +2,7 @@ import pytest
 import numpy
 from at import element_pass, lattice_pass
 from at import elements
+from numpy.testing import assert_equal
 
 
 def test_data_checks():
@@ -341,3 +342,10 @@ def test_wiggler(rin):
     expected[5] = 0.000000181809691064259
     element_pass(c, rin)
     numpy.testing.assert_allclose(rin, expected, atol=1e-12)
+
+
+def test_exit_entrance():
+    q = elements.Quadrupole('quad', 0.4, k=1)
+    for kin, kout in zip(q._entrance_fields, q._exit_fields):
+        assert_equal(kin.replace('Entrance', ''). replace('1', ''),
+                     kin.replace('Entrance', '').replace('1', ''))

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -1,5 +1,5 @@
 import numpy
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pytest
 from at import elements
 from at.lattice import Lattice, AtWarning, AtError
@@ -185,3 +185,25 @@ def test_develop(ring):
     rp2 = newring.radiation_parameters()
     assert_allclose(rp1.fulltunes, rp2.fulltunes)
     assert_allclose(rp1.U0, rp2.U0)
+
+@pytest.mark.parametrize('ring',
+                         [pytest.lazy_fixture('hmba_lattice')])
+def test_operators(ring):
+    newring1 = ring + ring
+    newring2 = ring.concatenate(ring, copy=True)
+    assert_equal(len(newring1), len(ring)*2)
+    assert_equal(len(newring2), len(ring) * 2)
+    newring1 += ring
+    newring2.concatenate(ring, copy=False)
+    assert_equal(len(newring1), len(ring)*3)
+    assert_equal(len(newring2), len(ring)*3)
+    newring1 = ring * 2
+    newring2 = ring.repeat(2)
+    assert_equal(len(newring1), len(ring)*2)
+    assert_equal(len(newring2), len(ring) * 2)
+    assert_equal(newring1.harmonic_number, ring.harmonic_number)
+    newring1 = ring.reverse(copy=True)
+    newring2 = reversed(ring)
+    assert_equal(newring1[-1].FamName, ring[0].FamName)
+    assert_equal(newring2[-1].FamName, ring[0].FamName)
+

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -203,7 +203,5 @@ def test_operators(ring):
     assert_equal(len(newring2), len(ring) * 2)
     assert_equal(newring1.harmonic_number, ring.harmonic_number)
     newring1 = ring.reverse(copy=True)
-    newring2 = reversed(ring)
     assert_equal(newring1[-1].FamName, ring[0].FamName)
-    assert_equal(newring2[-1].FamName, ring[0].FamName)
 


### PR DESCRIPTION
This PR proposes to introduce function as alternatives to the operators `+`, `+=`, `*`. This allows users to use their favorite syntax (function or operator) but also to document these functionalities in the sphinx webpage.

The default behavior remains unchanged except for the operator `*` that is now using deep copies of the elements of the original ring for the repetition. 
All functions are provided with an optional argument `copy` that allow to use deep copies of the elements to be appended, inserted or concatenated.

This issue was discussed in #565 and reported in #572. There might be other options to achieve this, please advise.