### PR TITLE
Improve the import order

### DIFF
--- a/pyat/at/acceptance/acceptance.py
+++ b/pyat/at/acceptance/acceptance.py
@@ -5,8 +5,7 @@ from .boundary import GridMode
 from .boundary import boundary_search
 from typing import Optional, Sequence
 import multiprocessing
-from ..lattice import Lattice, Refpts
-from ..physics import frequency_control
+from ..lattice import Lattice, Refpts, frequency_control
 
 
 __all__ = ['get_acceptance', 'get_1d_acceptance', 'get_horizontal_acceptance',

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -2,17 +2,18 @@
 Accelerator physics functions
 """
 # noinspection PyUnresolvedReferences
-from ..lattice import DConstant     # For backward compatibility
+# Avalailable here for backward compatibility
+from ..lattice import DConstant, Orbit, frequency_control
 from .amat import *
 from .energy_loss import *
+from .revolution import *
+from .harmonic_analysis import *
 from .orbit import *
 from .matrix import *
-from .revolution import *
 from .linear import *
 from .diffmatrix import find_mpole_raddiff_matrix
 from .radiation import *
 from .ring_parameters import *
-from .harmonic_analysis import *
 from .nonlinear import *
 from .fastring import *
 from .frequency_maps import fmap_parallel_track

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -8,10 +8,10 @@ import warnings
 from scipy.linalg import solve
 from ..constants import clight
 from ..lattice import DConstant, Refpts, get_bool_index, get_uint32_index
-from ..lattice import AtWarning, Lattice, check_6d, get_s_pos
+from ..lattice import AtWarning, Lattice, Orbit, check_6d, get_s_pos
+from ..lattice import frequency_control
 from ..tracking import lattice_pass
-from .orbit import Orbit, find_orbit4, find_orbit6
-from .orbit import frequency_control
+from .orbit import find_orbit4, find_orbit6
 from .matrix import find_m44, find_m66
 from .amat import a_matrix, jmat, jmatswap
 from .harmonic_analysis import get_tunes_harmonic

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -1,9 +1,10 @@
 """
 Coupled or non-coupled 4x4 linear motion
 """
+from __future__ import annotations
 import numpy
 from math import sqrt, pi, sin, cos, atan2
-from typing import Callable
+from collections.abc import Callable
 import warnings
 from scipy.linalg import solve
 from ..constants import clight

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -4,10 +4,11 @@ transfer matrix related functions
 A collection of functions to compute 4x4 and 6x6 transfer matrices
 """
 import numpy
-from ..lattice import Lattice, Element, get_uint32_index, DConstant, Refpts
+from ..lattice import Lattice, Element, DConstant, Refpts, Orbit
+from ..lattice import frequency_control, get_uint32_index
 from ..lattice.elements import Dipole, M66
 from ..tracking import lattice_pass, element_pass
-from .orbit import Orbit, find_orbit4, find_orbit6, frequency_control
+from .orbit import find_orbit4, find_orbit6
 from .amat import jmat, symplectify
 
 __all__ = ['find_m44', 'find_m66', 'find_elem_m66', 'gen_m66_elem']

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -4,52 +4,15 @@ Closed orbit related functions
 import numpy
 from at.constants import clight
 from at.lattice import AtError, AtWarning, check_6d, DConstant, Orbit
-from at.lattice import Lattice, get_s_pos, Refpts
-from at.lattice import set_cavity
+from at.lattice import Lattice, get_s_pos, Refpts, frequency_control
 from at.tracking import lattice_pass
 from . import ELossMethod, get_timelag_fromU0
 import warnings
-import functools
 
 # For backward compatibility, Orbit is redefined from .lattice
 __all__ = ['Orbit', 'find_orbit4', 'find_sync_orbit', 'find_orbit6',
-           'find_orbit', 'get_revolution_frequency', 'frequency_control']
-           
-           
-def frequency_control(func):
-    r""" Function to be used as decorator for :pycode:`func(ring, *args, **kwargs)`
+           'find_orbit', 'get_revolution_frequency']
 
-    If :pycode:`ring.is_6d` is :py:obj:`True` **and** *dp*, *dct* or *df*
-    is specified in *kwargs*, make a copy of *ring* with a modified
-    RF frequency, remove *dp*, *dct* or *df* from *kwargs* and call
-    *func* with the modified *ring*.
-
-    If :pycode:`ring.is_6d` is :py:obj:`False` **or** no *dp*, *dct* or
-    *df* is specified in *kwargs*, *func* is called unchanged.
-
-    Examples:
-
-        .. code-block:: python
-
-            @frequency_control
-            def func(ring, *args, dp=None, dct=None, **kwargs):
-                pass
-    """
-    @functools.wraps(func)
-    def wrapper(ring, *args, **kwargs):
-        if ring.is_6d:
-            momargs = {}
-            for key in ['dp', 'dct', 'df']:
-                v = kwargs.pop(key, None)
-                if v is not None:
-                    momargs[key] = v
-            if len(momargs) > 0:
-                frequency = ring.get_revolution_frequency(**momargs) \
-                    * ring.harmonic_number
-                ring = set_cavity(ring, Frequency=frequency, copy=True)
-        return func(ring, *args, **kwargs)
-    return wrapper
-           
            
 def get_revolution_frequency(ring: Lattice,
                              dp: float = None,

--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -6,42 +6,10 @@ from at.constants import clight
 from at.lattice import AtError, AtWarning, check_6d, DConstant, Orbit
 from at.lattice import Lattice, get_s_pos, Refpts, frequency_control
 from at.tracking import lattice_pass
-from . import ELossMethod, get_timelag_fromU0
+from .energy_loss import ELossMethod, get_timelag_fromU0
 import warnings
 
-# For backward compatibility, Orbit is redefined from .lattice
-__all__ = ['Orbit', 'find_orbit4', 'find_sync_orbit', 'find_orbit6',
-           'find_orbit', 'get_revolution_frequency']
-
-           
-def get_revolution_frequency(ring: Lattice,
-                             dp: float = None,
-                             dct: float = None,
-                             df: float = None) -> float:
-    """Compute the revolution frequency of the full ring [Hz]
-
-    Parameters:
-        ring:       Lattice description
-        dp:         Momentum deviation. Defaults to :py:obj:`None`
-        dct:        Path lengthening. Defaults to :py:obj:`None`
-        df:         Deviation of RF frequency. Defaults to :py:obj:`None`
-
-    Returns:
-        frev:       Revolution frequency [Hz]
-    """
-    lcell = ring.cell_length
-    cell_frev = ring.beta * clight / lcell
-    if dct is not None:
-        cell_frev *= lcell / (lcell + dct)
-    elif dp is not None:
-        # Find the path lengthening for dp
-        rnorad = ring.disable_6d(copy=True) if ring.is_6d else ring
-        orbit = lattice_pass(rnorad, rnorad.find_orbit4(dp=dp)[0])
-        dct = numpy.squeeze(orbit)[5]
-        cell_frev *= lcell / (lcell + dct)
-    elif df is not None:
-        cell_frev += df / ring.cell_harmnumber
-    return cell_frev / ring.periodicity
+__all__ = ['find_orbit4', 'find_sync_orbit', 'find_orbit6', 'find_orbit']
 
 
 @check_6d(False)
@@ -400,7 +368,6 @@ def _orbit6(ring: Lattice, cavpts=None, guess=None, keep_lattice=False,
 # noinspection PyIncorrectDocstring
 @frequency_control
 def find_orbit6(ring: Lattice, refpts: Refpts = None, *,
-                dp: float = None, dct: float = None, df: float = None,
                 orbit: Orbit = None, keep_lattice: bool = False, **kwargs):
     r"""Gets the closed orbit in the full 6-D phase space
 
@@ -443,13 +410,7 @@ def find_orbit6(ring: Lattice, refpts: Refpts = None, *,
 
     Parameters:
         ring:           Lattice description
-        dp:             Momentum deviation. Defaults to 0
         refpts:         Observation points
-        dct:            Path lengthening. If specified, *dp* is ignored and
-          the off-momentum is deduced from the path lengthening.
-        df:             Deviation from the nominal RF frequency. If specified,
-          *dp* is ignored and the off-momentum is deduced from the frequency
-          deviation.
         orbit:          Avoids looking for initial the closed orbit if it is
           already known ((6,) array). :py:func:`find_sync_orbit` propagates it
           to the specified *refpts*.
@@ -554,4 +515,3 @@ Lattice.find_orbit4 = find_orbit4
 Lattice.find_sync_orbit = find_sync_orbit
 Lattice.find_orbit6 = find_orbit6
 Lattice.find_orbit = find_orbit
-Lattice.get_revolution_frequency = get_revolution_frequency


### PR DESCRIPTION
The main point is to have the `frequency_control` decorator available for use in the lattice package.

- `frequency_control` has been moved to the `lattice/cavity_access.py` module, without any code change. Now it can be used everywhere in the `lattice` package. It's also still available in the `physics` package for compatibility,
- `get_revolution_frequency` is back in the `revolution.py` module, without any code change,
- all other changes are displacements of import statements to linearise the import order. So no real code change !


