### PR TITLE
zero length elements in lifetime calculation

### DIFF
--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -150,8 +150,9 @@ def get_lifetime(ring, emity, bunch_curr, emitx=None, sigs=None, sigp=None,
 
     mask = [ring[r].Length > 0.0 for r in refpts]
     if not numpy.all(mask):
-        warnings.warn(AtWarning('zero-length elements removed '
-                                'from lifetime calculation'))
+        zerolength_warning = ('zero-length elements removed '
+                              'from lifetime calculation')
+        warnings.warn(AtWarning(zerolength_warning))
     refpts = refpts[mask]
 
     if momap is None:

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -150,8 +150,8 @@ def get_lifetime(ring, emity, bunch_curr, emitx=None, sigs=None, sigp=None,
 
     mask = [ring[r].Length > 0.0 for r in refpts]
     if not numpy.all(mask):
-        warnings.warn(AtWarning('zero-lentgh element removed '
-                                'from lifetime calcualtion'))
+        warnings.warn(AtWarning('zero-length elements removed '
+                                'from lifetime calculation'))
     refpts = refpts[mask]
 
     if momap is None:


### PR DESCRIPTION
This PR is a bugfix in response to issue #575. The following corrective action are impleted:
-if zero-length elements are provided, they are automatically remove with a warning
-if the user provides the momentum aperture the zero-lenght elements are also remove from the momentum aperture such that refpts and momap always remain consistent
-the momentum aperture and refpts used for the lifetime calculation (with elements removed) are returned by the function