### PR TITLE
Fix bug in memory allocation of wake method

### DIFF
--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -260,10 +260,9 @@ void compute_kicks(int nslice,int nturns,int nelem,
 };
 
 
-double *wakefunc_long_resonator(double ds, double freqres, double qfactor, double rshunt, double beta) {
+double *wakefunc_long_resonator(double ds, double freqres, double qfactor, double rshunt, double beta, double *wake) {
 
     double omega, alpha, omegabar;
-    double *wake = malloc(2*sizeof(double));
     wake[0] = 0.0;
     wake[1] = 0.0;
     double dt;
@@ -296,7 +295,6 @@ double *wakefunc_long_resonator(double ds, double freqres, double qfactor, doubl
         wake[0] = 0.0;
         wake[1] = 0.0;
     }            
-    return wake;
 }
 
 
@@ -310,7 +308,7 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
     double ds,wi;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
-    double *wake = malloc(2*sizeof(double));
+    double *wake = atMalloc(2*sizeof(double));
     double vba, vbp;
     double *vbr = vbunch;
     double *vbi = vbunch+nbunch;
@@ -339,7 +337,7 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
                 ds = turnhistoryZ[i]-turnhistoryZ[ii];
                 if(turnhistoryW[ii]>0.0 && ds>=0){
                     wi = turnhistoryW[ii];
-                    wake = wakefunc_long_resonator(ds,freq,qfactor,rshunt,beta);       
+                    wakefunc_long_resonator(ds,freq,qfactor,rshunt,beta,wake);       
                     kz[i-nslice*nbunch*(nturns-1)] += normfact*wi*wake[0];
                     vbeamk[0] += normfact*wi*wake[0]*energy/nbunch;
                     vbeamk[1] -= normfact*wi*wake[1]*energy/nbunch;
@@ -366,7 +364,7 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
         vbr[i] = sqrt(vr*vr+vi*vi); 
         vbi[i] = atan2(vi,vr);
     }
-    free(wake);
+    atFree(wake);
 };
 
 

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -31,7 +31,7 @@ int binarySearch(double *array,double value,int upper,int lower,int nStep){
 };
 
 
-double getTableWake(double *waketable,double *waketableT,double distance,int index){
+static double getTableWake(double *waketable,double *waketableT,double distance,int index){
     double w = waketable[index] + (distance-waketableT[index])*(waketable[index+1]-waketable[index])/
           (waketableT[index+1]-waketableT[index]);
     if(atIsNaN(w)){
@@ -42,7 +42,7 @@ double getTableWake(double *waketable,double *waketableT,double distance,int ind
 };
 
 
-void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
+static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
     double *xtmp,*xtmp0;
     double *ytmp,*ytmp0;
     double *ztmp,*ztmp0;
@@ -82,7 +82,7 @@ void rotate_table_history(long nturns,long nslice,double *turnhistory,double cir
 };
 
 
-void getbounds(double *r_in, int nbunch, int num_particles, double *smin,
+static void getbounds(double *r_in, int nbunch, int num_particles, double *smin,
                double *smax, double *z_cuts){
     double *rtmp;
     int i, ib;
@@ -123,17 +123,17 @@ void getbounds(double *r_in, int nbunch, int num_particles, double *smin,
 }
 
 
-void slice_bunch(double *r_in,int num_particles,int nslice,int nturns,
+static void slice_bunch(double *r_in,int num_particles,int nslice,int nturns,
                  int nbunch,double *bunch_spos,double *bunch_currents,
                  double *turnhistory,int *pslice,double *z_cuts){
     
     int i,ii,ib;
     double *rtmp;
     
-    double *smin = malloc(nbunch*sizeof(double));
-    double *smax = malloc(nbunch*sizeof(double));
-    double *hz = malloc(nbunch*sizeof(double));
-    double *np_bunch = malloc(nbunch*sizeof(double));
+    double *smin = atMalloc(nbunch*sizeof(double));
+    double *smax = atMalloc(nbunch*sizeof(double));
+    double *hz = atMalloc(nbunch*sizeof(double));
+    double *np_bunch = atMalloc(nbunch*sizeof(double));
     getbounds(r_in,nbunch,num_particles,smin,smax,z_cuts);     
     
     for(i=0;i<nbunch;i++){
@@ -199,13 +199,13 @@ void slice_bunch(double *r_in,int num_particles,int nslice,int nturns,
         ypos[i] =  (weight[i]>0.0) ? ypos[i]/weight[i] : 0.0;
         weight[i] *= bunch_currents[ib]/np_bunch[ib];
     } 
-    free(np_bunch);
-    free(smin);
-    free(smax);
-    free(hz);
+    atFree(np_bunch);
+    atFree(smin);
+    atFree(smax);
+    atFree(hz);
 };
 
-void compute_kicks(int nslice,int nturns,int nelem,
+static void compute_kicks(int nslice,int nturns,int nelem,
                    double *turnhistory,double *waketableT,double *waketableDX,
                    double *waketableDY,double *waketableQX,double *waketableQY,
                    double *waketableZ,double *normfact, double *kx,double *ky,
@@ -260,7 +260,7 @@ void compute_kicks(int nslice,int nturns,int nelem,
 };
 
 
-double *wakefunc_long_resonator(double ds, double freqres, double qfactor, double rshunt, double beta, double *wake) {
+static double *wakefunc_long_resonator(double ds, double freqres, double qfactor, double rshunt, double beta, double *wake) {
 
     double omega, alpha, omegabar;
     wake[0] = 0.0;
@@ -298,7 +298,7 @@ double *wakefunc_long_resonator(double ds, double freqres, double qfactor, doubl
 }
 
 
-void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory,double normfact,
+static void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory,double normfact,
                            double *kz,double freq, double qfactor, double rshunt,
                            double beta, double *vbeamk, double energy, double *vbunch) {
 
@@ -387,7 +387,7 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
 };
 
 
-void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *turnhistory,
+static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *turnhistory,
                           double normfact, double *kz,double freq, double qfactor,
                           double rshunt, double *vbeam, double circumference,
                           double energy, double beta, double *vbeamk, double *vbunch){  
@@ -470,7 +470,7 @@ void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *turnhistor
 };
 
 
-void update_vgen(double *vbeam,double *vcav,double *vgen,double voltgain,double phasegain){
+static void update_vgen(double *vbeam,double *vcav,double *vgen,double voltgain,double phasegain){
     double vbeamr = vbeam[0]*cos(vbeam[1]);
     double vbeami = vbeam[0]*sin(vbeam[1]);
     double vcavr = vcav[0]*cos(vcav[1]);

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -308,7 +308,7 @@ static void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turn
     double ds,wi,wii;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
-    double *wake = atMalloc(2*sizeof(double));
+    double wake[2];
     double vba, vbp;
     double *vbr = vbunch;
     double *vbi = vbunch+nbunch;
@@ -383,7 +383,6 @@ static void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turn
     vbp = atan2(vbeamk[1],vbeamk[0]);
     vbeamk[0] = vba;
     vbeamk[1] = vbp;
-    atFree(wake);
 };
 
 

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -304,15 +304,16 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
 
     int rank=0;
     int size=1;
-    int i,ii,ib;
-    double ds,wi;
+    int i,ii,ib,loopstart,loopend;
+    double ds,wi,wii;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
     double *wake = atMalloc(2*sizeof(double));
     double vba, vbp;
     double *vbr = vbunch;
     double *vbi = vbunch+nbunch;
-
+    double totalW = 0;
+    
     for (i=0;i<nslice*nbunch;i++) {
         ib = (int)(i/nslice);
         kz[i]=0.0;
@@ -332,21 +333,44 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
     #endif
     for(i=nslice*nbunch*(nturns-1);i<nslice*nbunch*nturns;i++){  
         ib = (int)((i-nslice*nbunch*(nturns-1))/nslice);
+        wi = turnhistoryW[i];
+        totalW += wi;
+        
         if(turnhistoryW[i]>0.0 && rank==(i+size)%size){
             for (ii=0;ii<nslice*nbunch*nturns;ii++){
                 ds = turnhistoryZ[i]-turnhistoryZ[ii];
                 if(turnhistoryW[ii]>0.0 && ds>=0){
-                    wi = turnhistoryW[ii];
+                    wii = turnhistoryW[ii];
                     wakefunc_long_resonator(ds,freq,qfactor,rshunt,beta,wake);       
-                    kz[i-nslice*nbunch*(nturns-1)] += normfact*wi*wake[0];
-                    vbeamk[0] += normfact*wi*wake[0]*energy/nbunch/nslice;
-                    vbeamk[1] -= normfact*wi*wake[1]*energy/nbunch/nslice;
-                    vbr[ib] += normfact*wi*wake[0]*energy/nslice;
-                    vbi[ib] -= normfact*wi*wake[1]*energy/nslice;
+                    kz[i-nslice*nbunch*(nturns-1)] += normfact*wii*wake[0];
+                    
+                    vbeamk[0] += normfact*wii*wake[0]*energy*wi;
+                    vbeamk[1] -= normfact*wii*wake[1]*energy*wi;
+                    vbr[ib] += normfact*wii*wake[0]*energy*wi;
+                    vbi[ib] -= normfact*wii*wake[1]*energy*wi;
                 }            
             }
         }
     }
+    
+    vbeamk[0] /= totalW;
+    vbeamk[1] /= totalW;
+    
+    for(i=0;i<nbunch;i++){
+        totalW = 0.0;
+        loopstart = nslice*nbunch*(nturns-1) + i*nslice;
+        loopend = loopstart + nslice;
+        for(ii=loopstart;ii<loopend;ii++){
+            totalW += turnhistoryW[ii];
+        }
+        
+        double vr = vbr[i]/totalW;
+        double vi = vbi[i]/totalW;
+        vbr[i] = sqrt(vr*vr+vi*vi); 
+        vbi[i] = atan2(vi,vr);
+    }
+
+
     #ifdef MPI
     MPI_Allreduce(MPI_IN_PLACE,kz,nslice*nbunch,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
     MPI_Allreduce(MPI_IN_PLACE,vbeamk,2,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
@@ -354,16 +378,11 @@ void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turnhistory
     MPI_Allreduce(MPI_IN_PLACE,vbi,nbunch,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
     MPI_Barrier(MPI_COMM_WORLD);
     #endif
+
     vba = sqrt(vbeamk[0]*vbeamk[0]+vbeamk[1]*vbeamk[1]);   
     vbp = atan2(vbeamk[1],vbeamk[0]);
     vbeamk[0] = vba;
     vbeamk[1] = vbp;
-    for(i=0;i<nbunch;i++){
-        double vr = vbr[i];
-        double vi = vbi[i];
-        vbr[i] = sqrt(vr*vr+vi*vi); 
-        vbi[i] = atan2(vi,vr);
-    }
     atFree(wake);
 };
 

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -376,7 +376,7 @@ void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *turnhistor
     int i,ib,it,is;
     double wi;
     double selfkick;
-    double sliceperturn = nslice*nbunch;
+    int sliceperturn = nslice*nbunch;
     double dt =0.0;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -629,12 +629,10 @@ class Lattice(list):
         """Indices of filled bunches"""
         return numpy.flatnonzero(self._fillpattern)
 
-    @property
-    def beam_current(self):
+    def get_beam_current(self):
         return self._beam_current
 
-    @beam_current.setter
-    def beam_current(self, value, clear_history=True):
+    def set_beam_current(self, value, clear_history=True):
         self._beam_current = value
         if clear_history:
             self.set_wake_turnhistory()
@@ -652,7 +650,7 @@ class Lattice(list):
             circ = self.beta * clight * \
                 self.harmonic_number/self.rf_frequency
         except AtError:
-            circ = self.circumference       
+            circ = self.circumference
         bs = circ/len(self._fillpattern)
         allpos = bs*numpy.arange(len(self._fillpattern))
         return allpos[self._fillpattern > 0]
@@ -1376,3 +1374,5 @@ Lattice.select = refpts_iterator
 Lattice.get_value_refpts = get_value_refpts
 Lattice.set_value_refpts = set_value_refpts
 Lattice.get_geometry = get_geometry
+Lattice.beam_current = property(Lattice.get_beam_current,
+                                Lattice.set_beam_current)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -637,6 +637,8 @@ class Lattice(list):
         if clear_history:
             self.set_wake_turnhistory()
 
+    beam_current = property(get_beam_current, set_beam_current)
+
     @property
     def bunch_currents(self) -> numpy.ndarray:
         """Bunch currents [A]"""
@@ -1374,5 +1376,3 @@ Lattice.select = refpts_iterator
 Lattice.get_value_refpts = get_value_refpts
 Lattice.set_value_refpts = set_value_refpts
 Lattice.get_geometry = get_geometry
-Lattice.beam_current = property(Lattice.get_beam_current,
-                                Lattice.set_beam_current)


### PR DESCRIPTION
double memory allocation of wake (2 numbers) led to runaway memory. Surprised it wasn't spotted before. Bug is now fixed by using pointer instead of extra allocation