### PR TITLE
Fix atBunchLength

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/BunchLength.m
+++ b/atmat/atphysics/LongitudinalDynamics/BunchLength.m
@@ -15,7 +15,7 @@ function BL = BunchLength (Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta,circ)
 % sigmadelta is the energy spread
 % circ is the ring circumference
 % 
-%   see also: atBunchLength
+%   see also: atBunchLength, blgrowth
 
 blg = abs(blgrowth(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta));
 phi=pi - asin(U0./Vrf);
@@ -24,26 +24,4 @@ zcBL = sigdelta.*(circ * alpha)./(2 * pi .* nus );
 BL = zcBL .* blg;
 end
 
-function blg = blgrowth(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta)
-% bunch lengthening factor due to the potential well effect
-
-% Ib is the bunch current [A] (it may be a vector for multiple values)
-% Zn is the longitudinal broadband impedance [Ohms]
-% Vrf is the RF voltage [V] (it may be a vector for multiple values)
-% U0 is the energy loss around the ring [eV]
-% h is the harmonic number
-% alpha is the momentum compaction factor
-% sigmadelta is the energy spread
-
-phi=pi - asin(U0./Vrf);
-nus= sqrt(-(Vrf/E0).*(h * alpha)/(2*pi) .* cos(phi));
-
-Delta = -(2*pi*Ib*Zn)./(Vrf*h.*cos(phi).*(alpha*sigdelta./nus).^3);
-Q=Delta/(4*sqrt(pi));
-
-
-
-blg = (2/3)^(1/3)./(9*Q + sqrt(3)*sqrt(-4+27*Q.^2)).^(1/3)...
-    + (9*Q + sqrt(3)*sqrt(-4+27*Q.^2)).^(1/3)./(2^(1/3)*3^(2/3));
-end
 

--- a/atmat/atphysics/LongitudinalDynamics/atBunchLength.m
+++ b/atmat/atphysics/LongitudinalDynamics/atBunchLength.m
@@ -6,7 +6,8 @@ function BL = atBunchLength (ring,Ib,Zn)
 %
 % Ib is the bunch current [A] (it may be a vector for multiple values)
 % Zn is the longitudinal broadband impedance [Ohms]
-% ring is the at ring without radiation
+% ring is the at lattice (4D or 6D)
+%
 % BL is the bunch length in metres 
 %
 %   see also: BunchLength, blgrowth

--- a/atmat/atphysics/LongitudinalDynamics/atBunchLength.m
+++ b/atmat/atphysics/LongitudinalDynamics/atBunchLength.m
@@ -9,14 +9,25 @@ function BL = atBunchLength (ring,Ib,Zn)
 % ring is the at ring without radiation
 % BL is the bunch length in metres 
 %
-%   see also: BunchLength
+%   see also: BunchLength, blgrowth
 
-rp=ringpara(ring);
-[E0,~,Vrf,h,U0]=atenergy(ring);
-alpha=rp.alphac;
-sigdelta=rp.sigma_E;
+is6d=check_6d(ring);
 circ=findspos(ring,length(ring)+1);
 
-BL = BunchLength(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta,circ);
-
+if ~is6d
+    [E0,~,Vrf,h,U0]=atenergy(ring);
+    rp=ringpara(ring);
+    alpha=rp.alphac;
+    sigdelta=rp.sigma_E;
+    BL = BunchLength(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta,circ);
+else
+    [~,ringdata]=atx(ring,1);
+    [~,~,Vrf,h]=atenergy(ring);
+    alpha = ringdata.alpha;
+    E0 = ringdata.energy;
+    U0 = ringdata.eloss;
+    sigdelta = ringdata.espread;
+    bl0 = ringdata.blength;
+    BL = bl0 * blgrowth(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta);
+end
 end

--- a/atmat/atphysics/LongitudinalDynamics/blgrowth.m
+++ b/atmat/atphysics/LongitudinalDynamics/blgrowth.m
@@ -1,0 +1,27 @@
+function blg = blgrowth(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta)
+%  blg = blgrowth(Ib,Zn,Vrf,U0,E0,h,alpha,sigdelta)
+%
+% bunch lengthening factor due to the potential well effect
+%
+% Ib is the bunch current [A] (it may be a vector for multiple values)
+% Zn is the longitudinal broadband impedance [Ohms]
+% Vrf is the RF voltage [V] (it may be a vector for multiple values)
+% U0 is the energy loss around the ring [eV]
+% h is the harmonic number
+% alpha is the momentum compaction factor
+% sigmadelta is the energy spread
+%
+%   see also: atBunchLength, BunchLength
+%
+
+phi=pi - asin(U0./Vrf);
+nus= sqrt(-(Vrf/E0).*(h * alpha)/(2*pi) .* cos(phi));
+
+Delta = -(2*pi*Ib*Zn)./(Vrf*h.*cos(phi).*(alpha*sigdelta./nus).^3);
+Q=Delta/(4*sqrt(pi));
+
+
+
+blg = (2/3)^(1/3)./(9*Q + sqrt(3)*sqrt(-4+27*Q.^2)).^(1/3)...
+    + (9*Q + sqrt(3)*sqrt(-4+27*Q.^2)).^(1/3)./(2^(1/3)*3^(2/3));
+end


### PR DESCRIPTION
atBunchLength now checks if the ring is 4D or 6D. If it is 4D, the needed parameters are computed with ringpara, if it is 6D they are computed with atx.
The function blgrowth has been separated from BunchLength, so it can be used by both BunchLength and atBunchLength. 