### PR TITLE
Fixes bug producing infrequent NaN from calcnaff

### DIFF
--- a/atmat/atphysics/nafflib/calcnaff.m
+++ b/atmat/atphysics/nafflib/calcnaff.m
@@ -4,7 +4,7 @@ function [frequency,amplitude,phase] = calcnaff(Y, Yp, varargin)
 %
 %  INPUTS
 %  1. Y  - position vector
-%  2. Yp -
+%  2. Yp - angle vector
 %  3. WindowType  - Window type - 0 {Default} no windowing
 %                                 1 Window of Hann
 %                                 2 etc
@@ -33,7 +33,7 @@ function [frequency,amplitude,phase] = calcnaff(Y, Yp, varargin)
 %  above 1024 = pow2(10)
 %
 %  Examples
-%  NT = 9996; % divided by 6
+%  NT = 9996; % divisible by 6
 %  simple quasiperiodic (even period) motion 
 %  y =2+0.1*cos(pi*(0:NT-1))+0.00125*cos(pi/3*(0:NT-1));
 %  yp=2+0.1*sin(pi*(0:NT-1))+0.00125*sin(pi/3*(0:NT-1));
@@ -57,7 +57,7 @@ if whann, WindowType=1; end
 if any(isnan(Y(1,:)))
     fprintf('Warning Y contains NaNs\n');
     frequency =NaN; amplitude = NaN;  phase = NaN;
-elseif any(isnan(Y(1,:)))
+elseif any(isnan(Yp(1,:)))
     fprintf('Warning Yp contains NaNs\n');
     frequency =NaN; amplitude = NaN;  phase = NaN;
 elseif (mean(Y) == Y(1) && mean(Yp) == Yp(1))

--- a/atmat/atphysics/nafflib/calcnaff.m
+++ b/atmat/atphysics/nafflib/calcnaff.m
@@ -43,11 +43,6 @@ function [frequency,amplitude,phase] = calcnaff(Y, Yp, varargin)
 
 % Written by Laurent S. Nadolski
 % April 6th, 2007
-% Modification September 2009: 
-%  test if constant data or nan data
-
-% BUG in nafflib: returns nan even if valid data. Number of try
-nitermax = 10;
 
 % Flag factory
 [wraw1,args]=getflag(varargin,'Raw'); %#ok<ASGLU>
@@ -57,7 +52,6 @@ nitermax = 10;
 [DisplayFlag,args]=getflag(args,'Display');
 [WindowType,nfreq,DebugFlag]=getargs(args,0,10,double(dbg));
 if whann, WindowType=1; end
-
 
 % Test wether nan or constant data
 if any(isnan(Y(1,:)))
@@ -71,15 +65,6 @@ elseif (mean(Y) == Y(1) && mean(Yp) == Yp(1))
     frequency = 0; amplitude = 0;  phase = 0;
 else % Frequency map analysis
     [frequency,amplitude,phase] = nafflib(Y, Yp, WindowType,nfreq,DebugFlag);
-    %It seems there is a bug in nafflib, something returns nan even for valid data 
-    niter = 0;
-    while any(isnan(frequency)) && (niter < nitermax)
-        pause(2);
-        fprintf('Warning Nan returned by NAFF (x%d)\n', niter);
-        niter = niter +1;
-        [frequency,amplitude,phase] = nafflib(Y, Yp, WindowType,nfreq,1); % add debugging
-    end
-        
     if DisplayFlag
         fprintf('*** Naff run on %s\n', datestr(clock))
         for k = 1:length(frequency)

--- a/atmat/atphysics/nafflib/nafflib.c
+++ b/atmat/atphysics/nafflib/nafflib.c
@@ -47,8 +47,10 @@ double *amplitude_out, double *phase_out, int win, int nfreq, int debug)
     double *d_in, *d_out;
     t_complexe *c_in;
     
-    /* ndata is truncated to be a multiple of 6 if is not yet) */
-    ndata = 6*(int )(ndata/6.0);
+    /* ndata is truncated to be a multiple of 6 if is not yet)
+     * ndata-1 to make sure valid data is read when 
+     * writing ydata/ypdata to g_NAFVariable.ZTABS */
+    ndata = 6*(int )((ndata-1)/6.0);
     
     g_NAFVariable.DTOUR=2*M_PI; /* size of a "cadran" */
     g_NAFVariable.XH=1;         /* step */
@@ -80,7 +82,7 @@ double *amplitude_out, double *phase_out, int win, int nfreq, int debug)
     naf_initnaf();
     
  /*Transform initial data to complex data since algorithm is optimized for cx data*/
-    for (i=0;i<ndata;i++) {
+    for (i=0;i<=ndata;i++) {
         g_NAFVariable.ZTABS[i].reel = ydata[i];
         g_NAFVariable.ZTABS[i].imag = ypdata[i];
     }


### PR DESCRIPTION
Dear all,

This pull request concerns MATLAB.
As noted in #40 calcnaff sometimes produces NaN values even though the input is valid and a second run does result in valid frequencies. 
The problem is that the interface between MATLAB and the NAFF algorithm did no write to the last element of the
complex input to NAFF.
This pull request fixes that.

In my tests this also fixed the fluctuating results from run to run (e.g. phase) seen in #40 as well.

Fixes #40 