### PR TITLE
Acceptance shift zero + docs

### DIFF
--- a/pyat/at/acceptance/acceptance.py
+++ b/pyat/at/acceptance/acceptance.py
@@ -23,7 +23,7 @@ def get_acceptance(
         use_mp: Optional[bool] = False,
         verbose: Optional[bool] = True,
         divider: Optional[int] = 2,
-        shift_zero: Optional[float] = 1.0e-9,
+        shift_zero: Optional[float] = 1.0e-6,
         start_method: Optional[str] = None,
 ):
     # noinspection PyUnresolvedReferences
@@ -61,7 +61,7 @@ def get_acceptance(
         verbose:        Print out some information
         divider:        Value of the divider used in
           :py:attr:`.GridMode.RECURSIVE` boundary search
-        shift_zero:
+        shift_zero: Epsilon offset applied on all 6 coordinates
         start_method:   Python multiprocessing start method. The default
           ``None`` uses the python default that is considered safe.
           Available parameters: ``'fork'``, ``'spawn'``, ``'forkserver'``.
@@ -163,7 +163,7 @@ def get_1d_acceptance(
         use_mp: Optional[bool] = False,
         verbose: Optional[bool] = False,
         divider: Optional[int] = 2,
-        shift_zero: Optional[float] = 1.0e-9,
+        shift_zero: Optional[float] = 1.0e-6,
         start_method: Optional[str] = None,
 
 ):
@@ -197,7 +197,7 @@ def get_1d_acceptance(
         verbose:        Print out some information
         divider:        Value of the divider used in
           :py:attr:`.GridMode.RECURSIVE` boundary search
-        shift_zero:
+        shift_zero: Epsilon offset applied on all 6 coordinates
         start_method:   Python multiprocessing start method. The default
           ``None`` uses the python default that is considered safe.
           Available parameters: ``'fork'``, ``'spawn'``, ``'forkserver'``.
@@ -270,7 +270,7 @@ def get_horizontal_acceptance(ring: Lattice,
         verbose:        Print out some information
         divider:        Value of the divider used in
           :py:attr:`.GridMode.RECURSIVE` boundary search
-        shift_zero:
+        shift_zero: Epsilon offset applied on all 6 coordinates
         start_method:   Python multiprocessing start method. The default
           ``None`` uses the python default that is considered safe.
           Available parameters: ``'fork'``, ``'spawn'``, ``'forkserver'``.
@@ -328,7 +328,7 @@ def get_vertical_acceptance(ring: Lattice,
         verbose:        Print out some information
         divider:        Value of the divider used in
           :py:attr:`.GridMode.RECURSIVE` boundary search
-        shift_zero:
+        shift_zero: Epsilon offset applied on all 6 coordinates
         start_method:   Python multiprocessing start method. The default
           ``None`` uses the python default that is considered safe.
           Available parameters: ``'fork'``, ``'spawn'``, ``'forkserver'``.
@@ -386,7 +386,7 @@ def get_momentum_acceptance(ring: Lattice,
         verbose:        Print out some information
         divider:        Value of the divider used in
           :py:attr:`.GridMode.RECURSIVE` boundary search
-        shift_zero:
+        shift_zero: Epsilon offset applied on all 6 coordinates
         start_method:   Python multiprocessing start method. The default
           ``None`` uses the python default that is considered safe.
           Available parameters: ``'fork'``, ``'spawn'``, ``'forkserver'``.

--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -88,7 +88,7 @@ def set_ring_orbit(ring, dp, obspt, orbit):
 
 
 def grid_configuration(planes, npoints, amplitudes, grid_mode, bounds=None,
-                       shift_zero=1.0e-9):
+                       shift_zero=1.0e-6):
     """
     Return a grid configuration based on user input parameters, the ordering
     is as follows: CARTESIAN: (x,y), RADIAL/RECURSIVE (r, theta).
@@ -156,9 +156,7 @@ def get_parts(config, offset):
         g = get_part_grid_radial(bnd, np, amp)
     parts = numpy.zeros((6, numpy.prod(np)))
     parts[pind, :] = [g[i] for i in range(len(pind))]
-    if len(pind) == 2:
-        parts[pind[0]][parts[pind[1]] == 0.0] += config.shift_zero
-        parts[pind[1]][parts[pind[0]] == 0.0] += config.shift_zero
+    offset += config.shift_zero
     parts = (parts.T+offset).T
     return parts, grid(g, offset[pind])
 

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -530,13 +530,13 @@ class Lattice(list):
         """Returns a deep copy of the lattice"""
         return copy.deepcopy(self)
         
-    def slice_elements(self, refpts, slices: Optional[int] = 1) \
+    def slice_elements(self, refpts: Refpts, slices: Optional[int] = 1) \
             -> "Lattice":
         """Create a new lattice by slicing the elements at refpts
+        Parameters:
+            refpts: element selector
 
         Keyword arguments:
-            size=None:      Length of a slice. Default: computed from the
-              range and number of points: ``size = (s_max-s_min)/slices``.
             slices=1:       Number of slices in the specified range. Ignored if
               size is specified. Default: no slicing
 


### PR DESCRIPTION
This PR fixes a couple small issues:
-acceptance shift_zero now applied to all coordinates with a larger default and documentation completed: this prevents to build artificial wings on the DA when on one coordinate is non zero
-The documentation of lattice_object.slice_elements is corrected.

