### PR TITLE
Restore the standard behaviour of reversed(Lattice)

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -173,7 +173,7 @@ class Lattice(list):
             ``params_filter(params, ringparam_filter, *args)``
                 runs through ``ringparam_filter(params, *args)``, looks for
                 energy and periodicity if not yet defined.
-"""
+        """
         if iterator is None:
             arg1, = args or [[]]  # accept 0 or 1 argument
             if isinstance(arg1, Lattice):
@@ -271,9 +271,6 @@ class Lattice(list):
     def __mul__(self, n):
         return self.repeat(n)
 
-    def __reversed__(self):
-        return (el.swap_faces(copy=True) for el in self[::-1])
-
     def _addition_filter(self, elems: Iterable[Element], copy_elements=False):
         cavities = []
         length = 0.0
@@ -309,14 +306,12 @@ class Lattice(list):
     def insert(self, idx: SupportsIndex, elem: Element, copy_elements=False):
         r"""This method allow to insert an AT element in the lattice.
 
-            Parameters:
-                idx (SupportsIndex): index at which the lement is inserted
-                elem (Element): AT element to be inserted in the lattice
-
-            Keyword Arguments:
-                copy_elements(bool): Default :py:obj:`True`.
-                                     If :py:obj:`True` a deep copy of elem
-                                     is used.
+        Parameters:
+            idx (SupportsIndex): index at which the lement is inserted
+            elem (Element): AT element to be inserted in the lattice
+            copy_elements(bool): Default :py:obj:`True`.
+                                 If :py:obj:`True` a deep copy of elem
+                                 is used.
         """
         # noinspection PyUnusedLocal
         # scan the new element to update it
@@ -326,20 +321,18 @@ class Lattice(list):
 
     def extend(self, elems: Iterable[Element], copy_elements=False):
         r"""This method adds all the elements of `elems` to the end of the
-            lattice. The behavior is the same as for a :py:obj:`list`
+        lattice. The behavior is the same as for a :py:obj:`list`
 
-            Equivalents syntaxes:
-            >>> ring.extend(elems)
-            >>> ring += elems
+        Equivalents syntaxes:
+        >>> ring.extend(elems)
+        >>> ring += elems
 
-            Parameters:
-                elem (Iterable[Element]): Sequence of AT elements to be
-                                          appended to the lattice
-
-            Keyword Arguments:
-                copy_elements(bool): Default :py:obj:`True`.
-                                     If :py:obj:`True` deep copies of each
-                                     element of elems are used
+        Parameters:
+            elems (Iterable[Element]): Sequence of AT elements to be
+                                      appended to the lattice
+            copy_elements(bool): Default :py:obj:`True`.
+                                 If :py:obj:`True` deep copies of each
+                                 element of elems are used
         """
         if hasattr(self, '_energy'):
             # When unpickling a Lattice, extend is called before the lattice
@@ -359,8 +352,6 @@ class Lattice(list):
 
             Parameters:
                 elem (Element): AT element to be appended to the lattice
-
-            Keyword Arguments:
                 copy_elements(bool): Default :py:obj:`True`.
                                      If :py:obj:`True` a deep copy of elem
                                      is used
@@ -369,24 +360,22 @@ class Lattice(list):
 
     def repeat(self, n: int, copy_elements=True):
         r"""This method allows to repeat the lattice `n` times.
-            If `n` does not divide `ring.periodicity`, the new ring
-            periodicity is set to 1, otherwise  it is et to
-            `ring.periodicity /= n`.
+        If `n` does not divide `ring.periodicity`, the new ring
+        periodicity is set to 1, otherwise  it is et to
+        `ring.periodicity /= n`.
 
-            Equivalents syntaxes:
-            >>> newring = ring.repeat(n)
-            >>> newring = ring * n
+        Equivalents syntaxes:
+        >>> newring = ring.repeat(n)
+        >>> newring = ring * n
 
-            Parameters:
-                n (int): number of repetition
+        Parameters:
+            n (int): number of repetition
+            copy_elements(bool): Default :py:obj:`True`.
+                        If :py:obj:`True` deepcopies of the
+                        lattice are used for the repetition
 
-            Keyword Arguments:
-                copy_elements(bool): Default :py:obj:`True`.
-                            If :py:obj:`True` deepcopies of the
-                            lattice are used for the repetition
-
-            Returns:
-                newring (Lattice): the new repeated lattice
+        Returns:
+            newring (Lattice): the new repeated lattice
         """
         def copy_fun(elem, copy):
             if copy:
@@ -427,8 +416,6 @@ class Lattice(list):
             lattices: :py:obj:`Iterables[Element]` to be concatenanted
                       to the Lattice, several lattices are allowed
                       (see example)
-
-        Keyword Arguments:
             copy_elements(bool): Default :py:obj:`False`. If :py:obj:`True`
                         deepcopies of the elements of lattices are used
             copy(bool): Default :py:obj:`False`. If :py:obj:`True`
@@ -452,11 +439,7 @@ class Lattice(list):
         r"""Reverse the order of the lattice and swapt the faces
         of elements. Alignment errors are not swapped
 
-
-        Usage:
-        >>> newring = ring.reverse(copy=True)
-
-        Keyword Arguments:
+        Parameters:
             copy(bool): Default :py:obj:`False`. If :py:obj:`True`
                            the lattice is modified in place.
                            Oterwise a new Lattice object is returned
@@ -465,15 +448,17 @@ class Lattice(list):
             lattice(Lattice): reversed Lattice, if `copy==True` the
                               new lattice object is returned
                               otherwise None
+        Example:
+            >>> newring = ring.reverse(copy=True)
         """
+        elems = (el.swap_faces(copy=True) for el in reversed(self))
         if copy:
-            elems = (el.swap_faces(copy=copy) for el in self[::-1])
             return Lattice(elem_generator, elems, iterator=self.attrs_filter)
         else:
-            reversed_list = list(reversed(self))
+            reversed_list = list(elems)
             self[:] = reversed_list
 
-    def develop(self) -> "Lattice":
+    def develop(self) -> Lattice:
         """Develop a periodical lattice by repeating its elements
         *self.periodicity* times
 
@@ -503,7 +488,7 @@ class Lattice(list):
         res.update((k, v) for k, v in vrs.items() if not k.startswith('_'))
         return res
 
-    def rotate(self, n: int) -> "Lattice":
+    def rotate(self, n: int) -> Lattice:
         """Return a new lattice rotated left by n elements"""
         if len(self) == 0:
             return self.copy()
@@ -522,22 +507,20 @@ class Lattice(list):
         for (key, value) in attrs.items():
             setattr(self, key, value)
 
-    def copy(self) -> "Lattice":
+    def copy(self) -> Lattice:
         """Returns a shallow copy of the lattice"""
         return copy.copy(self)
 
-    def deepcopy(self) -> "Lattice":
+    def deepcopy(self) -> Lattice:
         """Returns a deep copy of the lattice"""
         return copy.deepcopy(self)
         
-    def slice_elements(self, refpts: Refpts, slices: Optional[int] = 1) \
-            -> "Lattice":
+    def slice_elements(self, refpts: Refpts, slices: int = 1) -> Lattice:
         """Create a new lattice by slicing the elements at refpts
-        Parameters:
-            refpts: element selector
 
-        Keyword arguments:
-            slices=1:       Number of slices in the specified range. Ignored if
+        Parameters:
+            refpts:     Element selector
+            slices:     Number of slices in the specified range. Ignored if
               size is specified. Default: no slicing
 
         Returns:
@@ -546,7 +529,7 @@ class Lattice(list):
         def slice_generator(_):
             check = get_bool_index(self, refpts)
             for el, ok in zip(self, check):
-                if ok and (slices>1):
+                if ok and (slices > 1):
                     frac = numpy.ones(slices) / slices
                     for elem in el.divide(frac):
                         yield elem
@@ -556,7 +539,7 @@ class Lattice(list):
         return Lattice(slice_generator, iterator=self.attrs_filter)        
 
     def slice(self, size: Optional[float] = None, slices: Optional[int] = 1) \
-            -> "Lattice":
+            -> Lattice:
         """Create a new lattice by slicing the range of interest into small
         elements
 
@@ -1043,7 +1026,7 @@ class Lattice(list):
             lattice_modify()
 
     # noinspection PyShadowingNames,PyIncorrectDocstring
-    def enable_6d(self, *args, **kwargs) -> Optional["Lattice"]:
+    def enable_6d(self, *args, **kwargs) -> Optional[Lattice]:
         # noinspection PyUnresolvedReferences
         r"""
         enable_6d(elem_class[, elem_class]..., copy=False)
@@ -1142,7 +1125,7 @@ class Lattice(list):
         return self._set_6d(True, *args, **kwargs)
 
     # noinspection PyShadowingNames,PyIncorrectDocstring
-    def disable_6d(self, *args, **kwargs) -> Optional["Lattice"]:
+    def disable_6d(self, *args, **kwargs) -> Optional[Lattice]:
         # noinspection PyUnresolvedReferences
         r"""
         disable_6d(elem_class[, elem_class]... , copy=False)
@@ -1298,7 +1281,7 @@ class Lattice(list):
         return Lattice(sbreak_iterator, iter_mk,
                        iterator=self.attrs_filter, **kwargs)
 
-    def reduce(self, **kwargs) -> "Lattice":
+    def reduce(self, **kwargs) -> Lattice:
         """Removes all elements with an ``IdentityPass`` PassMethod and merges
         compatible consecutive elements.
 
@@ -1335,7 +1318,7 @@ class Lattice(list):
         return Lattice(reduce_filter, self.select(kp | keep),
                        iterator=self.attrs_filter, **kwargs)
 
-    def replace(self, refpts: Refpts, **kwargs) -> "Lattice":
+    def replace(self, refpts: Refpts, **kwargs) -> Lattice:
         """Return a shallow copy of the lattice replacing the selected
         elements by a deep copy
 
@@ -1348,7 +1331,7 @@ class Lattice(list):
                        iterator=self.attrs_filter, **kwargs)
 
     # Obsolete methods kept for compatibility
-    def radiation_on(self, *args, **kwargs) -> Optional["Lattice"]:
+    def radiation_on(self, *args, **kwargs) -> Optional[Lattice]:
         """Obsolete. Turn longitudinal motion on
 
         The function name is misleading, since the function deals with
@@ -1364,7 +1347,7 @@ class Lattice(list):
             zip(('cavity_pass', 'dipole_pass', 'quadrupole_pass'), args))
         return self._set_6d(True, **kwargs)
 
-    def radiation_off(self, *args, **kwargs) -> Optional["Lattice"]:
+    def radiation_off(self, *args, **kwargs) -> Optional[Lattice]:
         """Obsolete. Turn longitudinal motion off
 
         The function name is misleading, since the function deals with


### PR DESCRIPTION
This PR restores the standard behaviour of the `reversed()` iterator for `Lattice` objects: the behaviour introduced in #573 could be confusing, since it was iterating on copies of the elements instead of element themselves.

As a consequence, the only way to build reversed lattices by swapping entrance and exit faces is to use the `Lattice.reversed()` method.