### PR TITLE
Energy loss relative tolerance

### DIFF
--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -97,7 +97,8 @@ def get_energy_loss(ring: Lattice,
 def get_timelag_fromU0(ring: Lattice,
                        method: Optional[ELossMethod] = ELossMethod.TRACKING,
                        cavpts: Optional[Refpts] = None,
-                       divider: Optional[int] = 4) -> Tuple[float, float]:
+                       divider: Optional[int] = 4,
+                       ts_tol: Optional[float] = 1.0e-9) -> Tuple[float, float]:
     """
     Get the TimeLag attribute of RF cavities based on frequency,
     voltage and energy loss per turn, so that the synchronous phase is zero.
@@ -111,6 +112,8 @@ def get_timelag_fromU0(ring: Lattice,
           See :py:class:`ELossMethod`.
         cavpts:             Cavity location. If None, use all cavities.
           This allows to ignore harmonic cavities.
+        divider: number of segments to search for ts
+        phis_tol: relative tolerance for ts calculation
     Returns:
         timelag (float):    Timelag
         ts (float):         Time difference with the present value
@@ -152,7 +155,7 @@ def get_timelag_fromU0(ring: Lattice,
             r.append(least_squares(eq, bounds[1]*fact+tt0,
                                    args=args, bounds=bounds+tt0))
         res = numpy.array([ri.fun[0] for ri in r])
-        ok = res < 1.0e-9
+        ok = res < ts_tol
         vals = numpy.array([abs(ri.x[0]).round(decimals=6) for ri in r])
         if not numpy.any(ok):
             raise AtError('No solution found for Phis, please check '

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -123,12 +123,12 @@ def get_timelag_fromU0(ring: Lattice,
 
     def eq(x, freq, rfv, tl0, u0):
         omf = 2*numpy.pi*freq/clight
-        eq1 = numpy.sum(-rfv*numpy.sin(omf*(x-tl0)))-u0
+        eq1 = (numpy.sum(-rfv*numpy.sin(omf*(x-tl0)))-u0)/u0
         eq2 = numpy.sum(-omf*rfv*numpy.cos(omf*(x-tl0)))
         if eq2 > 0:
             return numpy.sqrt(eq1**2+eq2**2)
         else:
-            return eq1
+            return abs(eq1)
 
     if cavpts is None:
         cavpts = get_bool_index(ring, RFCavity)
@@ -151,8 +151,8 @@ def get_timelag_fromU0(ring: Lattice,
                                    args=args, bounds=bounds+tt0))
             r.append(least_squares(eq, bounds[1]*fact+tt0,
                                    args=args, bounds=bounds+tt0))
-        res = numpy.array([abs(ri.fun[0]) for ri in r])
-        ok = res < 1.0e-6
+        res = numpy.array([ri.fun[0] for ri in r])
+        ok = res < 1.0e-9
         vals = numpy.array([abs(ri.x[0]).round(decimals=6) for ri in r])
         if not numpy.any(ok):
             raise AtError('No solution found for Phis, please check '

--- a/pyat/at/physics/ring_parameters.py
+++ b/pyat/at/physics/ring_parameters.py
@@ -3,7 +3,7 @@ import numpy
 from numpy import nan
 from typing import Optional
 from .radiation import get_radiation_integrals, ohmi_envelope
-from .energy_loss import get_energy_loss
+from .energy_loss import get_energy_loss, get_timelag_fromU0
 from ..lattice import Lattice, Orbit
 from ..constants import clight, Cgamma, Cq
 
@@ -200,7 +200,7 @@ def envelope_parameters(ring: Lattice,
     alpha = 1.0 / rp.Tau
     rp.J = 4.0 * alpha / numpy.sum(alpha)
     rp.tunes6, _ = numpy.modf(ring.periodicity * beamdata.tunes)
-    rp.phi_s = pi - asin(rp.U0 / voltage)
+    rp.phi_s = pi - numpy.arcsin(rp.U0 / voltage)
     rp.voltage = voltage
     rp.f_s = rp.tunes6[2] * rev_freq
     rp.emittances = beamdata.mode_emittances


### PR DESCRIPTION
The function `get_timelag_fromU0` for lattice with very large U0 and multiple RF harmonics.
The reason is that for multiple harmonic a least square fit is use to compute the synchronous phase, the quantity to minimize is the difference between U0 and the accelerating voltage.
However using the absolute difference, the tolerance was becoming too tight for very large U0. This value is now normalized to U0. In addition, the tolerance was reduced to 1.0e-9 and set as an optional argument.

A small modification to envelope_parameters() is also propose to prevent attribute errors when voltage<U0. The function now simply returns a NaN.