### PR TITLE
Relaxed passmethod coherence tests when loading files

### DIFF
--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -215,8 +215,8 @@ def element_from_dict(elem_dict: dict, index: Optional[int] = None,
     def sanitise_class(index, cls, elem_dict):
         """Checks that the Class and PassMethod of the element are a valid
             combination. Some Classes and PassMethods are incompatible and
-            would raise errors during calculation if left, so we raise an error
-            here with a more helpful message.
+            would raise errors during calculation, so we send a
+            warning here.
 
         Args:
             index:          element index

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -66,6 +66,8 @@ _PASS_MAP = {'BendLinearPass': elt.Dipole,
              'BndMPoleSymplectic4RadPass': elt.Dipole,
              'BndMPoleSymplectic4Pass': elt.Dipole,
              'QuadLinearPass': elt.Quadrupole,
+             'StrMPoleSymplectic4Pass': elt.Multipole,
+             'StrMPoleSymplectic4RadPass': elt.Multipole,
              'CorrectorPass': elt.Corrector,
              'CavityPass': elt.RFCavity, 'RFCavityPass': elt.RFCavity,
              'ThinMPolePass': elt.ThinMultipole,
@@ -230,7 +232,7 @@ def element_from_dict(elem_dict: dict, index: Optional[int] = None,
             msg = ''.join(('Error in element', location,
                            'PassMethod {0} '.format(pass_method),
                            message.format(*args), '\n{0}'.format(elem_dict)))
-            return AttributeError(msg)
+            return AtWarning(msg)
 
         class_name = cls.__name__
         pass_method = elem_dict.get('PassMethod')
@@ -240,18 +242,12 @@ def element_from_dict(elem_dict: dict, index: Optional[int] = None,
             file_name = pass_method + _ext_suffix
             file_path = os.path.join(integrators.__path__[0], file_name)
             if not os.path.isfile(os.path.realpath(file_path)):
-                raise err("does not have a {0} file.".format(file_name))
+                warn(err(" is missing {0}.".format(file_name)))
             elif (pass_method == 'IdentityPass') and (length != 0.0):
-                raise err("is not compatible with length {0}.", length)
+                warn(err("is not compatible with length {0}.", length))
             elif pass_to_class is not None:
                 if not issubclass(cls, pass_to_class):
-                    raise err("is not compatible with Class {0}.", class_name)
-            elif issubclass(cls, (elt.Marker, elt.Monitor, RingParam)):
-                if pass_method != 'IdentityPass':
-                    raise err("is not compatible with Class {0}.", class_name)
-            elif cls == elt.Drift:
-                if pass_method != 'DriftPass':
-                    raise err("is not compatible with Class {0}.", class_name)
+                    warn(err("is not compatible with Class {0}.", class_name))
 
     cls = find_class(elem_dict, quiet=quiet)
     if check:

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -231,15 +231,12 @@ def test_find_Element(elem_kwargs):
          'FamName': 'fam'},
         {'Class': 'Marker', 'PassMethod': 'StrMPoleSymplectic4Pass',
          'FamName': 'fam'},
-        {'Class': 'Monitor', 'PassMethod': 'StrMPoleSymplectic4Pass',
-         'FamName': 'fam'},
-        {'Class': 'RingParam', 'PassMethod': 'StrMPoleSymplectic4Pass',
-         'Energy': 3E9, 'FamName': 'fam'},
         {'Class': 'Drift', 'PassMethod': 'StrMPoleSymplectic4Pass',
          'Length': 1.0, 'FamName': 'fam'},
-        {'Class': 'Drift', 'PassMethod': 'InvalidPass'}))
+        {'Class': 'Drift', 'PassMethod': 'InvalidPass',
+         'Length': 1.0, 'FamName': 'fam'}))
 def test_sanitise_class_error(elem_kwargs):
-    with pytest.raises(AttributeError):
+    with pytest.warns(AtWarning):
         element_from_dict(elem_kwargs)
 
 


### PR DESCRIPTION
When loading .mat files, a series of tests check the coherence between the element class and the pass method, and by default raise an exception. This created several problems in the past (like [here](https://github.com/atcollab/at/pull/574#issuecomment-1549455798)). The changes here are:
1. the number of tests is reduced to a minimum, to avoid problems when new pass methods are implemented:
   - `IdentityPass` with a non-null length,
   - missing C integrator,
   - a few remaining class checks.
2. More important: a **warning** is emitted instead of an **error**. So the lattice is created and the user has the possibility of correcting the doubtful elements if needed. Up to now, the only workaround was to create a new .mat file.

As before, the `quiet=True` keyword shortcuts the tests (no more warnings emitted).