### PR TITLE
regex option

### DIFF
--- a/pyat/at/lattice/deprecated.py
+++ b/pyat/at/lattice/deprecated.py
@@ -8,7 +8,8 @@ __all__ = ['get_cells', 'get_refpts']
 
 
 # noinspection PyIncorrectDocstring
-def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
+def get_cells(ring: Sequence[Element], refpts: Refpts, *args,
+              regex=False) -> BoolRefpts:
     # noinspection PyShadowingNames
     r"""
     get_cells(ring, filtfunc) -> BoolRefpts
@@ -31,6 +32,8 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
         attrvalue (Any):                Attribute value. If absent, select the
           presence of an *attrname* attribute. If present, select
           :py:class:`.Element`\ s with :pycode:`attrname == attrvalue`.
+        regex: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         bool_refs (BoolRefpts):  numpy Array of :py:obj:`bool` with length
@@ -53,12 +56,12 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args) -> BoolRefpts:
     """
     if isinstance(refpts, str):
         refpts = checkattr(refpts, *args)
-    return get_bool_index(ring, refpts)
+    return get_bool_index(ring, refpts, regex=regex)
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
 def get_refpts(ring: Sequence[Element], refpts: Refpts,
-               quiet=True) -> Uint32Refpts:
+               regex=False) -> Uint32Refpts:
     r"""Return a :py:obj:`~numpy.uint32` array of element indices selecting
     ring elements.
 
@@ -69,6 +72,8 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
+        regex: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         uint32_refs (Uint32Refs):    :py:obj:`~numpy.uint32` numpy array as
@@ -77,7 +82,7 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
     See also:
         :py:meth:`.Lattice.uint32_refpts`, :py:meth:`.Lattice.bool_refpts`
     """
-    return get_uint32_index(ring, refpts)
+    return get_uint32_index(ring, refpts, regex=regex)
 
 
 Lattice.uint32_refpts = get_uint32_index

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -30,6 +30,7 @@ class _Dst(object):
     OrbMaxIter = 20          # Max. number of iterations for orbit
     omp_num_threads = int(os.environ.get('OMP_NUM_THREADS', '0'))
     patpass_poolsize = multiprocessing.cpu_count()
+    use_regex = False
     _rank = _MPI_rk         # MPI rank
 
     def __setattr__(self, name, value):

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -96,13 +96,12 @@ Methods:
 Examples:
     >>> at.random.common.random()
     0.8699988509120198
-    
+
     Generates a random number in [0, 1) which is identical in all threads
 
     >>> at.random.thread.normal(size=5)
     array([-0.02326275, -0.89806482, -1.69086929, -0.74399398,  0.70156743])
-    
+
     Generates an array of Gaussian random values which is specific to
     each thread
-    
 """

--- a/pyat/at/lattice/options.py
+++ b/pyat/at/lattice/options.py
@@ -30,7 +30,6 @@ class _Dst(object):
     OrbMaxIter = 20          # Max. number of iterations for orbit
     omp_num_threads = int(os.environ.get('OMP_NUM_THREADS', '0'))
     patpass_poolsize = multiprocessing.cpu_count()
-    use_regex = False
     _rank = _MPI_rk         # MPI rank
 
     def __setattr__(self, name, value):

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -838,7 +838,7 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
     return apply(ring, refpts, attrvalues, regex)
 
 
-def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
+def get_s_pos(ring: Sequence[Element], refpts: Refpts = All, regex=False) \
         -> Sequence[float]:
     # noinspection PyUnresolvedReferences
     r"""Returns the locations of selected elements
@@ -847,6 +847,8 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
         ring:       Lattice description
         refpts:     Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
+        regex: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         s_pos:  Array of locations of the elements selected by *refpts*
@@ -862,7 +864,7 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \
     s_pos = numpy.cumsum([getattr(el, 'Length', 0.0) for el in ring])
     # Prepend position at the start of the first element.
     s_pos = numpy.concatenate(([0.0], s_pos))
-    return s_pos[get_bool_index(ring, refpts)]
+    return s_pos[get_bool_index(ring, refpts, regex=regex)]
 
 
 def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -32,14 +32,12 @@ location is defined as the entrance of the selected element. *refpts* may be:
 """
 import numpy
 import functools
-import re
 from typing import Callable, Optional, Sequence, Iterator
 from typing import Union, Tuple, List, Type
 from enum import Enum
 from itertools import compress
 from fnmatch import fnmatch
 from .elements import Element, Dipole
-from .options import DConstant
 
 ElementFilter = Callable[[Element], bool]
 BoolRefpts = numpy.ndarray
@@ -593,10 +591,7 @@ def checkname(pattern: str) -> ElementFilter:
 
         Returns an iterator over all with name starting with ``QF``.
     """
-    if DConstant.use_regex:
-        return lambda el: re.match(pattern, el.FamName)
-    else:
-        return lambda el: fnmatch(el.FamName, pattern)
+    return lambda el: fnmatch(el.FamName, pattern)
 
 
 def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -32,6 +32,7 @@ location is defined as the entrance of the selected element. *refpts* may be:
 """
 import numpy
 import functools
+import re
 from typing import Callable, Optional, Sequence, Iterator
 from typing import Union, Tuple, List, Type
 from enum import Enum
@@ -352,7 +353,7 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
-                     endpoint: bool = True) -> Uint32Refpts:
+                     endpoint: bool = True, re=False) -> Uint32Refpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
@@ -361,6 +362,8 @@ def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         uint32_ref (Uint32Refpts): uint32 numpy array used for indexing
@@ -391,7 +394,7 @@ def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts)
+        checkfun = checkname(refpts, re=re)
     else:
         return uint32_refpts(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -451,7 +454,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_bool_index(ring: Sequence[Element], refpts: Refpts,
-                   endpoint: bool = True) -> BoolRefpts:
+                   endpoint: bool = True, re=False) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns a bool array of element indices, selecting ring elements.
 
@@ -460,6 +463,8 @@ def get_bool_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         bool_refs (BoolRefpts):  A bool numpy array used for indexing
@@ -493,7 +498,7 @@ def get_bool_index(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts)
+        checkfun = checkname(refpts, re=re)
     else:
         return bool_refpts(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -569,7 +574,7 @@ def checktype(eltype: Union[type, Tuple[type, ...]]) -> ElementFilter:
     return lambda el: isinstance(el, eltype)
 
 
-def checkname(pattern: str) -> ElementFilter:
+def checkname(pattern: str, re=False) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     r"""Checks the name of an element
 
@@ -581,6 +586,8 @@ def checkname(pattern: str) -> ElementFilter:
     Parameters:
         pattern: Desired :py:class:`.Element` name. Unix shell-style
           wildcards are supported (see :py:func:`fnmatch.fnmatch`)
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         checkfun (ElementFilter):   Element filter function
@@ -591,10 +598,13 @@ def checkname(pattern: str) -> ElementFilter:
 
         Returns an iterator over all with name starting with ``QF``.
     """
-    return lambda el: fnmatch(el.FamName, pattern)
+    if re:
+        return lambda el: re.match(pattern, el.FamName)  
+    else:  
+        return lambda el: fnmatch(el.FamName, pattern)
 
 
-def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
+def refpts_iterator(ring: Sequence[Element], refpts: Refpts, re=False) \
         -> Iterator[Element]:
     r"""Return an iterator over selected elements in a lattice
 
@@ -602,6 +612,8 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         elem_iter (Iterator[Element]):  Iterator over the elements in *ring*
@@ -614,7 +626,7 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts)
+        checkfun = checkname(refpts, re=re)
     else:
         refs = numpy.ravel(refpts)
         if refpts is RefptsCode.All:
@@ -673,7 +685,7 @@ def refpts_count(refpts: RefIndex, n_elements: int,
 
 
 def _refcount(ring: Sequence[Element], refpts: Refpts,
-              endpoint: bool = True) -> int:
+              endpoint: bool = True, re=False) -> int:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns the number of reference points
 
@@ -682,6 +694,8 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         nrefs (int):  The number of reference points
@@ -710,7 +724,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts)
+        checkfun = checkname(refpts, re=re)
     else:
         return refpts_count(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -718,7 +732,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
-def get_elements(ring: Sequence[Element], refpts: Refpts, quiet=True) \
+def get_elements(ring: Sequence[Element], refpts: Refpts, re=False) \
         -> list:
     r"""Returns a list of elements selected by *key*.
 
@@ -728,15 +742,17 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, quiet=True) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     Returns:
         elem_list (list):  list of :py:class:`.Element`\ s matching key
     """
-    return list(refpts_iterator(ring, refpts))
+    return list(refpts_iterator(ring, refpts, re=re))
 
 
 def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
-                     attrname: str, index: Optional[int] = None):
+                     attrname: str, index: Optional[int] = None, re=False):
     r"""Extracts attribute values from selected lattice :py:class:`.Element`\ s.
 
     Parameters:
@@ -746,6 +762,8 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
         attrname:   Attribute name
         index:      index of the value to retrieve if *attrname* is
           an array.
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
           If :py:obj:`None` the full array is retrieved
 
@@ -759,13 +777,13 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
         def getf(elem):
             return getattr(elem, attrname)[index]
 
-    return numpy.array([getf(elem) for elem in refpts_iterator(ring, refpts)])
+    return numpy.array([getf(elem) for elem in refpts_iterator(ring, refpts, re=re)])
 
 
 def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
                      attrname: str, attrvalues, index: Optional[int] = None,
                      increment: Optional[bool] = False,
-                     copy: Optional[bool] = False):
+                     copy: Optional[bool] = False, re=False):
     r"""Set the values of an attribute of an array of elements based on
     their refpts
 
@@ -780,6 +798,8 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
           an array. if :py:obj:`None`, the full array is replaced by
           *attrvalue*
         increment:  Add values to the initial values.
+        re: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
           If :py:obj:`False` the initial value is replaced (Default)
         copy:       If :py:obj:`False`, the modification is done in-place,
@@ -802,18 +822,18 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
     if increment:
         attrvalues += get_value_refpts(ring, refpts,
-                                       attrname, index=index)
+                                       attrname, index=index, re=re)
     else:
         attrvalues = numpy.broadcast_to(attrvalues,
-                                        (_refcount(ring, refpts),))
+                                        (_refcount(ring, refpts, re=re),))
 
     # noinspection PyShadowingNames
     @make_copy(copy)
-    def apply(ring, refpts, values):
-        for elm, val in zip(refpts_iterator(ring, refpts), values):
+    def apply(ring, refpts, values, re):
+        for elm, val in zip(refpts_iterator(ring, refpts, re=re), values):
             setf(elm, val)
 
-    return apply(ring, refpts, attrvalues)
+    return apply(ring, refpts, attrvalues, re)
 
 
 def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -362,7 +362,7 @@ def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -463,7 +463,7 @@ def get_bool_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -586,7 +586,7 @@ def checkname(pattern: str, regex=False) -> ElementFilter:
     Parameters:
         pattern: Desired :py:class:`.Element` name. Unix shell-style
           wildcards are supported (see :py:func:`fnmatch.fnmatch`)
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -612,7 +612,7 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts, regex=False) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -694,7 +694,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -742,7 +742,7 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, regex=False) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
     Returns:
@@ -763,7 +763,7 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
         attrname:   Attribute name
         index:      index of the value to retrieve if *attrname* is
           an array.
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
           If :py:obj:`None` the full array is retrieved
@@ -800,7 +800,7 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
           an array. if :py:obj:`None`, the full array is replaced by
           *attrvalue*
         increment:  Add values to the initial values.
-        re: Use regular expression for refpts string matching;
+        regex: Use regular expression for refpts string matching;
             Default: False (Unix shell-style wildcards)
 
           If :py:obj:`False` the initial value is replaced (Default)

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -831,11 +831,11 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
     # noinspection PyShadowingNames
     @make_copy(copy)
-    def apply(ring, refpts, values, re):
+    def apply(ring, refpts, values, regex):
         for elm, val in zip(refpts_iterator(ring, refpts, regex=regex), values):
             setf(elm, val)
 
-    return apply(ring, refpts, attrvalues, re)
+    return apply(ring, refpts, attrvalues, regex)
 
 
 def get_s_pos(ring: Sequence[Element], refpts: Refpts = All) \

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -32,12 +32,14 @@ location is defined as the entrance of the selected element. *refpts* may be:
 """
 import numpy
 import functools
+import re
 from typing import Callable, Optional, Sequence, Iterator
 from typing import Union, Tuple, List, Type
 from enum import Enum
 from itertools import compress
 from fnmatch import fnmatch
 from .elements import Element, Dipole
+from .options import DConstant
 
 ElementFilter = Callable[[Element], bool]
 BoolRefpts = numpy.ndarray
@@ -591,7 +593,10 @@ def checkname(pattern: str) -> ElementFilter:
 
         Returns an iterator over all with name starting with ``QF``.
     """
-    return lambda el: fnmatch(el.FamName, pattern)
+    if DConstant.use_regex:
+        return lambda el: re.match(pattern, el.FamName)
+    else:
+        return lambda el: fnmatch(el.FamName, pattern)
 
 
 def refpts_iterator(ring: Sequence[Element], refpts: Refpts) \

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -353,7 +353,7 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
-                     endpoint: bool = True, re=False) -> Uint32Refpts:
+                     endpoint: bool = True, regex=False) -> Uint32Refpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
@@ -394,7 +394,7 @@ def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts, re=re)
+        checkfun = checkname(refpts, regex=regex)
     else:
         return uint32_refpts(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -454,7 +454,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_bool_index(ring: Sequence[Element], refpts: Refpts,
-                   endpoint: bool = True, re=False) -> BoolRefpts:
+                   endpoint: bool = True, regex=False) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns a bool array of element indices, selecting ring elements.
 
@@ -498,7 +498,7 @@ def get_bool_index(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts, re=re)
+        checkfun = checkname(refpts, regex=regex)
     else:
         return bool_refpts(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -574,7 +574,7 @@ def checktype(eltype: Union[type, Tuple[type, ...]]) -> ElementFilter:
     return lambda el: isinstance(el, eltype)
 
 
-def checkname(pattern: str, re=False) -> ElementFilter:
+def checkname(pattern: str, regex=False) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     r"""Checks the name of an element
 
@@ -598,13 +598,13 @@ def checkname(pattern: str, re=False) -> ElementFilter:
 
         Returns an iterator over all with name starting with ``QF``.
     """
-    if re:
+    if regex:
         return lambda el: re.match(pattern, el.FamName)
     else:
         return lambda el: fnmatch(el.FamName, pattern)
 
 
-def refpts_iterator(ring: Sequence[Element], refpts: Refpts, re=False) \
+def refpts_iterator(ring: Sequence[Element], refpts: Refpts, regex=False) \
         -> Iterator[Element]:
     r"""Return an iterator over selected elements in a lattice
 
@@ -626,7 +626,7 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts, re=False) \
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts, re=re)
+        checkfun = checkname(refpts, regex=regex)
     else:
         refs = numpy.ravel(refpts)
         if refpts is RefptsCode.All:
@@ -685,7 +685,7 @@ def refpts_count(refpts: RefIndex, n_elements: int,
 
 
 def _refcount(ring: Sequence[Element], refpts: Refpts,
-              endpoint: bool = True, re=False) -> int:
+              endpoint: bool = True, regex=False) -> int:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns the number of reference points
 
@@ -724,7 +724,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
     elif isinstance(refpts, Element):
         checkfun = checktype(type(refpts))
     elif isinstance(refpts, str):
-        checkfun = checkname(refpts, re=re)
+        checkfun = checkname(refpts, regex=regex)
     else:
         return refpts_count(refpts, len(ring), endpoint=endpoint, types=_typ2)
 
@@ -732,7 +732,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
-def get_elements(ring: Sequence[Element], refpts: Refpts, re=False) \
+def get_elements(ring: Sequence[Element], refpts: Refpts, regex=False) \
         -> list:
     r"""Returns a list of elements selected by *key*.
 
@@ -748,11 +748,11 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, re=False) \
     Returns:
         elem_list (list):  list of :py:class:`.Element`\ s matching key
     """
-    return list(refpts_iterator(ring, refpts, re=re))
+    return list(refpts_iterator(ring, refpts, regex=regex))
 
 
 def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
-                     attrname: str, index: Optional[int] = None, re=False):
+                     attrname: str, index: Optional[int] = None, regex=False):
     r"""Extracts attribute values from selected
         lattice :py:class:`.Element`\ s.
 
@@ -779,13 +779,13 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
             return getattr(elem, attrname)[index]
 
     return numpy.array([getf(elem) for elem in refpts_iterator(ring, refpts,
-                                                               re=re)])
+                                                               regex=regex)])
 
 
 def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
                      attrname: str, attrvalues, index: Optional[int] = None,
                      increment: Optional[bool] = False,
-                     copy: Optional[bool] = False, re=False):
+                     copy: Optional[bool] = False, regex=False):
     r"""Set the values of an attribute of an array of elements based on
     their refpts
 
@@ -824,15 +824,15 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
     if increment:
         attrvalues += get_value_refpts(ring, refpts,
-                                       attrname, index=index, re=re)
+                                       attrname, index=index, regex=regex)
     else:
         attrvalues = numpy.broadcast_to(attrvalues,
-                                        (_refcount(ring, refpts, re=re),))
+                                        (_refcount(ring, refpts, regex=regex),))
 
     # noinspection PyShadowingNames
     @make_copy(copy)
     def apply(ring, refpts, values, re):
-        for elm, val in zip(refpts_iterator(ring, refpts, re=re), values):
+        for elm, val in zip(refpts_iterator(ring, refpts, regex=regex), values):
             setf(elm, val)
 
     return apply(ring, refpts, attrvalues, re)

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -599,7 +599,8 @@ def checkname(pattern: str, regex=False) -> ElementFilter:
         Returns an iterator over all with name starting with ``QF``.
     """
     if regex:
-        return lambda el: re.match(pattern, el.FamName)
+        rgx = re.compile(pattern)
+        return lambda el: rgx.fullmatch(el.FamName)
     else:
         return lambda el: fnmatch(el.FamName, pattern)
 

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -599,8 +599,8 @@ def checkname(pattern: str, re=False) -> ElementFilter:
         Returns an iterator over all with name starting with ``QF``.
     """
     if re:
-        return lambda el: re.match(pattern, el.FamName)  
-    else:  
+        return lambda el: re.match(pattern, el.FamName)
+    else:
         return lambda el: fnmatch(el.FamName, pattern)
 
 
@@ -753,7 +753,8 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, re=False) \
 
 def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
                      attrname: str, index: Optional[int] = None, re=False):
-    r"""Extracts attribute values from selected lattice :py:class:`.Element`\ s.
+    r"""Extracts attribute values from selected
+        lattice :py:class:`.Element`\ s.
 
     Parameters:
         ring:           Lattice description
@@ -777,7 +778,8 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
         def getf(elem):
             return getattr(elem, attrname)[index]
 
-    return numpy.array([getf(elem) for elem in refpts_iterator(ring, refpts, re=re)])
+    return numpy.array([getf(elem) for elem in refpts_iterator(ring, refpts,
+                                                               re=re)])
 
 
 def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
@@ -871,13 +873,13 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
     the *y*-axis.
     A positive angle represent a clockwise rotation when looking in
     the direction of the rotation axis.
-    
+
     The transformations are not all commmutative, the tilt is always the
     last transformation applied.
-    
+
     If *relative* is :py:obj:`True`, the previous angle and shifts are
     rebuilt form the *R* and *T* matrix and incremented by the input arguments.
-    
+
     The shift is always conserved regardless of the value of *relative*.
 
     Parameters:

--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -73,7 +73,7 @@ def _fit_tune_chrom(ring: Lattice, index: int, func,
 
 def fit_tune(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
              tol: float = 1.0e-12,
-             dp: Optional[float] = 0, niter: int = 3, re=False
+             dp: Optional[float] = 0, niter: int = 3, re=False,
              **kwargs) -> None:
     """Fits the tunes using 2 families
 
@@ -126,4 +126,4 @@ def fit_chrom(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
     """
     print('\nFitting Chromaticity...')
     _fit_tune_chrom(ring, 2, _get_chrom, refpts1, refpts2, newval, tol=tol,
-                    dp=dp, niter=niter re=re)
+                    dp=dp, niter=niter, re=re)

--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -25,7 +25,7 @@ def _fit_tune_chrom(ring: Lattice, index: int, func,
                     refpts1: Refpts, refpts2: Refpts, newval,
                     tol: Optional[float] = 1.0e-12,
                     dp: Optional[float] = 0, niter: Optional[int] = 3,
-                    re= False, **kwargs):
+                    re=False, **kwargs):
 
     def _get_resp(ring: Lattice, index: int, func, refpts, attname,
                   delta, dp, re=False, **kwargs):
@@ -83,7 +83,7 @@ def fit_tune(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
         refpts2:    Selection of the 2nd family
         newval:     New tunes, in case an non-zero integer part
                     is provided, fit_integer is set to True
-                    
+
     Keyword arguments:
         tol:        Tolerance for the matching; Default: 1.0e-12
         dp:         Momentum deviation. Default: 0
@@ -113,7 +113,7 @@ def fit_chrom(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
         refpts1:    Selection of the 1st family
         refpts2:    Selection of the 2nd family
         newval:     New tunes
-        
+
     Keyword arguments:
         tol:        Tolerance for the matching; Default: 1.0e-12
         dp:         Momentum deviation. Default: 0

--- a/pyat/at/matching/globalfit.py
+++ b/pyat/at/matching/globalfit.py
@@ -25,38 +25,38 @@ def _fit_tune_chrom(ring: Lattice, index: int, func,
                     refpts1: Refpts, refpts2: Refpts, newval,
                     tol: Optional[float] = 1.0e-12,
                     dp: Optional[float] = 0, niter: Optional[int] = 3,
-                    re=False, **kwargs):
+                    regex=False, **kwargs):
 
     def _get_resp(ring: Lattice, index: int, func, refpts, attname,
-                  delta, dp, re=False, **kwargs):
+                  delta, dp, regex=False, **kwargs):
         set_value_refpts(ring, refpts, attname, delta, index=index,
-                         increment=True, re=re)
+                         increment=True, regex=regex)
         datap = func(ring, dp, **kwargs)
         set_value_refpts(ring, refpts, attname, -2*delta, index=index,
-                         increment=True, re=re)
+                         increment=True, regex=regex)
         datan = func(ring, dp, **kwargs)
         set_value_refpts(ring, refpts, attname, delta, index=index,
-                         increment=True, re=re)
+                         increment=True, regex=regex)
         data = numpy.subtract(datap, datan)/(2*delta)
         return data
 
     def _fit(ring, index, func, refpts1, refpts2, newval, J,
-             dp: Optional[float] = 0, re=False, **kwargs):
+             dp: Optional[float] = 0, regex=False, **kwargs):
         val = func(ring, dp, **kwargs)
         dk = numpy.linalg.solve(J, numpy.subtract(newval, val))
         set_value_refpts(ring, refpts1, 'PolynomB', dk[0], index=index,
-                         increment=True, re=re)
+                         increment=True, regex=regex)
         set_value_refpts(ring, refpts2, 'PolynomB', dk[1], index=index,
-                         increment=True, re=re)
+                         increment=True, regex=regex)
         val = func(ring, dp, **kwargs)
         sumsq = numpy.sum(numpy.square(numpy.subtract(val, newval)))
         return sumsq
 
     delta = 1e-6 * 10 ** index
     dq1 = _get_resp(ring, index, func, refpts1, 'PolynomB',
-                    delta, dp, re=re, **kwargs)
+                    delta, dp, regex=regex, **kwargs)
     dq2 = _get_resp(ring, index, func, refpts2, 'PolynomB',
-                    delta, dp, re=re, **kwargs)
+                    delta, dp, regex=regex, **kwargs)
     J = [[dq1[0], dq2[0]], [dq1[1], dq2[1]]]
 
     n = 0
@@ -64,7 +64,7 @@ def _fit_tune_chrom(ring: Lattice, index: int, func,
     print('Initial value', func(ring, dp, **kwargs))
     while sumsq > tol and n < niter:
         sumsq = _fit(ring, index, func, refpts1, refpts2, newval,
-                     J, dp=dp, re=re, **kwargs)
+                     J, dp=dp, regex=regex, **kwargs)
         print('iter#', n, 'Res.', sumsq)
         n += 1
     print('Final value', func(ring, dp, **kwargs), '\n')
@@ -73,7 +73,7 @@ def _fit_tune_chrom(ring: Lattice, index: int, func,
 
 def fit_tune(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
              tol: float = 1.0e-12,
-             dp: Optional[float] = 0, niter: int = 3, re=False,
+             dp: Optional[float] = 0, niter: int = 3, regex=False,
              **kwargs) -> None:
     """Fits the tunes using 2 families
 
@@ -89,7 +89,7 @@ def fit_tune(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
         dp:         Momentum deviation. Default: 0
         niter:      Maximum number of iterations. Default 3
         fit_integer: bool (default=False), use integer tune
-        re:         Using regular expressions for refpt string matching;
+        regex:      Using regular expressions for refpt string matching;
                     Default: False
 
     Typical usage:
@@ -99,12 +99,12 @@ def fit_tune(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
     if numpy.any(numpy.floor(newval) != 0.0):
         kwargs['fit_integer'] = True
     _fit_tune_chrom(ring, 1, _get_tune, refpts1, refpts2, newval, tol=tol,
-                    dp=dp, niter=niter, re=re, **kwargs)
+                    dp=dp, niter=niter, regex=regex, **kwargs)
 
 
 def fit_chrom(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
               tol: Optional[float] = 1.0e-12,
-              dp: Optional[float] = 0, niter: Optional[int] = 3, re=False,
+              dp: Optional[float] = 0, niter: Optional[int] = 3, regex=False,
               **kwargs) -> None:
     """Fit the chromaticities using 2 families
 
@@ -118,7 +118,7 @@ def fit_chrom(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
         tol:        Tolerance for the matching; Default: 1.0e-12
         dp:         Momentum deviation. Default: 0
         niter:      Maximum number of iterations. Default 3
-        re:         Using regular expressions for refpt string matching;
+        regex:      Using regular expressions for refpt string matching;
                     Default: False
 
     Typical usage:
@@ -126,4 +126,4 @@ def fit_chrom(ring: Lattice, refpts1: Refpts, refpts2: Refpts, newval,
     """
     print('\nFitting Chromaticity...')
     _fit_tune_chrom(ring, 2, _get_chrom, refpts1, refpts2, newval, tol=tol,
-                    dp=dp, niter=niter, re=re)
+                    dp=dp, niter=niter, regex=regex)

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -51,7 +51,7 @@ def fortran_align(func):
 
 @fortran_align
 def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
-                 refpts: Refpts = End, regex=False **kwargs):
+                 refpts: Refpts = End, regex=False, **kwargs):
     """
     :py:func:`lattice_pass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -51,7 +51,7 @@ def fortran_align(func):
 
 @fortran_align
 def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
-                 refpts: Refpts = End, regex=False, **kwargs):
+                 refpts: Refpts = End, **kwargs):
     """
     :py:func:`lattice_pass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's
@@ -79,8 +79,6 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
         losses (bool):          Boolean to activate loss maps output
         omp_num_threads (int):  Number of OpenMP threads
           (default: automatic)
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
 
     The following keyword arguments overload the Lattice values
 
@@ -138,7 +136,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refs = get_uint32_index(lattice, refpts, regex=regex)
+    refs = get_uint32_index(lattice, refpts)
     # define properties if lattice is not a Lattice object
     nbunch = getattr(lattice, 'nbunch', 1)
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -51,7 +51,7 @@ def fortran_align(func):
 
 @fortran_align
 def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
-                 refpts: Refpts = End, **kwargs):
+                 refpts: Refpts = End, regex=False **kwargs):
     """
     :py:func:`lattice_pass` tracks particles through each element of a lattice
     calling the element-specific tracking function specified in the Element's
@@ -79,6 +79,8 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
         losses (bool):          Boolean to activate loss maps output
         omp_num_threads (int):  Number of OpenMP threads
           (default: automatic)
+        regex: Use regular expression for refpts string matching;
+            Default: False (Unix shell-style wildcards)
 
     The following keyword arguments overload the Lattice values
 
@@ -136,7 +138,7 @@ def lattice_pass(lattice: Iterable[Element], r_in, nturns: int = 1,
     """
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    refs = get_uint32_index(lattice, refpts)
+    refs = get_uint32_index(lattice, refpts, regex=regex)
     # define properties if lattice is not a Lattice object
     nbunch = getattr(lattice, 'nbunch', 1)
     bunch_currents = getattr(lattice, 'bunch_currents', numpy.zeros(1))


### PR DESCRIPTION
This PR provides a simple switch to activate REGEX in string pattern search as requested in #598 .
The default behavior is unchanged.

Deprecated function `get_refpts` and `get_cells` have not been modified.
For the moment only a local flag is provided as advised in #598. 