### PR TITLE
Fix compilation with OPENMP=1

### DIFF
--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -69,12 +69,15 @@ void BndMPoleSymplectic4QuantPass(double* r, double le, double irho, double* A, 
     double pi = 3.14159265358979;
     double alpha0 = qe * qe / (4 * pi * epsilon0 * hbar * clight);
 
+/*  The behaviour of random generators with OpenMP is doubtful. OpenMP disabled until
+    it's understood
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
     shared(r, num_particles, R1, T1, R2, T2, RApertures, EApertures,                                        \
         irho, gap, A, B, L1, L2, K1, K2, max_order, num_int_steps, rng,                                     \
         FringeBendEntrance, entrance_angle, fint1, FringeBendExit, exit_angle, fint2,                       \
         FringeQuadEntrance, useLinFrEleEntrance, FringeQuadExit, useLinFrEleExit, fringeIntM0, fringeIntP0, \
         emass, E0, hbar, clight, alpha0, qe, SL)
+*/
     for (int c = 0; c < num_particles; c++) { /* Loop over particles  */
         double* r6 = r + c * 6;
         if (!atIsNaN(r6[0])) {

--- a/atintegrators/BndMPoleSymplectic4QuantPass.c
+++ b/atintegrators/BndMPoleSymplectic4QuantPass.c
@@ -71,7 +71,7 @@ void BndMPoleSymplectic4QuantPass(double* r, double le, double irho, double* A, 
 
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
     shared(r, num_particles, R1, T1, R2, T2, RApertures, EApertures,                                        \
-        irho, gap, A, B, L1, L2, K1, K2, max_order, num_int_steps,                                          \
+        irho, gap, A, B, L1, L2, K1, K2, max_order, num_int_steps, rng,                                     \
         FringeBendEntrance, entrance_angle, fint1, FringeBendExit, exit_angle, fint2,                       \
         FringeQuadEntrance, useLinFrEleEntrance, FringeQuadExit, useLinFrEleExit, fringeIntM0, fringeIntP0, \
         emass, E0, hbar, clight, alpha0, qe, SL)

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -14,7 +14,7 @@ void QuantDiffPass(double* r_in, double* Lmatp, int nturn,
      */
 {
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
-    shared(r_in, num_particles, Lmatp)
+    shared(r_in, num_particles, Lmatp, rng)
     for (int c = 0; c < num_particles; c++) {
         /*Loop over particles  */
         int i, j;

--- a/atintegrators/QuantDiffPass.c
+++ b/atintegrators/QuantDiffPass.c
@@ -13,8 +13,11 @@ void QuantDiffPass(double* r_in, double* Lmatp, int nturn,
      * 1-d array of 6*N elements
      */
 {
+/*  The behaviour of random generators with OpenMP is doubtful. OpenMP disabled until
+    it's understood
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
     shared(r_in, num_particles, Lmatp, rng)
+*/
     for (int c = 0; c < num_particles; c++) {
         /*Loop over particles  */
         int i, j;

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -63,7 +63,7 @@ void StrMPoleSymplectic4QuantPass(double* r, double le, double* A, double* B,
     }
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
     shared(r, num_particles, R1, T1, R2, T2, RApertures, EApertures,                                        \
-        A, B, L1, L2, K1, K2, max_order, num_int_steps,                                                     \
+        A, B, L1, L2, K1, K2, max_order, num_int_steps, rng,                                                \
         FringeQuadEntrance, useLinFrEleEntrance, FringeQuadExit, useLinFrEleExit, fringeIntM0, fringeIntP0, \
         emass, E0, hbar, clight, alpha0, qe, SL)
     for (int c = 0; c < num_particles; c++) { /* Loop over particles  */

--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -61,11 +61,14 @@ void StrMPoleSymplectic4QuantPass(double* r, double le, double* A, double* B,
         B[0] -= sin(KickAngle[0]) / le;
         A[0] += sin(KickAngle[1]) / le;
     }
+/*  The behaviour of random generators with OpenMP is doubtful. OpenMP disabled until
+    it's understood
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
     shared(r, num_particles, R1, T1, R2, T2, RApertures, EApertures,                                        \
         A, B, L1, L2, K1, K2, max_order, num_int_steps, rng,                                                \
         FringeQuadEntrance, useLinFrEleEntrance, FringeQuadExit, useLinFrEleExit, fringeIntM0, fringeIntP0, \
         emass, E0, hbar, clight, alpha0, qe, SL)
+*/
     for (int c = 0; c < num_particles; c++) { /* Loop over particles  */
         double* r6 = r + c * 6;
         if (!atIsNaN(r6[0])) {

--- a/atintegrators/TestRandomPass.c
+++ b/atintegrators/TestRandomPass.c
@@ -64,7 +64,7 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        IdentityPass(r_in,&pcg32_global,&pcg32_global,num_particles);
+        RandomPass(r_in,&pcg32_global,&pcg32_global,num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */

--- a/atintegrators/TestRandomPass.c
+++ b/atintegrators/TestRandomPass.c
@@ -1,0 +1,82 @@
+/* RandomPass.c
+   Accelerator Toolbox
+
+   Test of random generators
+ */
+
+#include "atelem.c"
+#include "atlalib.c"
+#include "atrandom.c"
+
+struct elem 
+{
+};
+
+static void RandomPass(double *r_in,
+        pcg32_random_t* common_rng,
+        pcg32_random_t* thread_rng,
+        int num_particles)
+{	
+    double common_val = atrandn_r(common_rng, 0.0, 0.001);
+
+    for (int c = 0; c<num_particles; c++) {	/*Loop over particles  */
+        double *r6 = r_in+c*6;
+        double thread_val = atrandn_r(thread_rng, 0.0, 0.001);
+        r6[0] = thread_val;
+        r6[2] = common_val;
+        r6[4] = 0.0;
+        r6[5] = 0.0;
+    }
+
+    #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
+    shared(r_in, num_particles, common_val, thread_rng)
+    for (int c = 0; c<num_particles; c++) {	/*Loop over particles  */
+        double *r6 = r_in+c*6;
+        double thread_val = atrandn_r(thread_rng, 0.0, 0.001);
+        r6[1] = thread_val;
+        r6[3] = common_val;
+    }
+}
+
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
+{
+    if (!Elem) {
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+    }
+    RandomPass(r_in,Param->common_rng,Param->thread_rng,num_particles);
+    return Elem;
+}
+
+MODULE_DEF(TestRandomPass)        /* Dummy module initialisation */
+
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
+#if defined(MATLAB_MEX_FILE)
+void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+    if (nrhs == 2) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+        IdentityPass(r_in,&pcg32_global,&pcg32_global,num_particles);
+    }
+    else if (nrhs == 0) {
+        /* list of required fields */
+        plhs[0] = mxCreateCellMatrix(1,0);
+        
+        if (nlhs>1) {
+            /* list of optional fields */
+            plhs[1] = mxCreateCellMatrix(1,0);
+        }
+    }
+    else {
+        mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");
+    }
+}
+#endif /*defined(MATLAB_MEX_FILE)*/

--- a/atintegrators/TestRandomPass.c
+++ b/atintegrators/TestRandomPass.c
@@ -10,6 +10,7 @@
 
 struct elem 
 {
+    int dummy;  /* to make Windows compiler happy */
 };
 
 static void RandomPass(double *r_in,


### PR DESCRIPTION
Fixes a bug reported in #592.
The fix for compiling with OpenMP was easy, but it revealed a [problem with random generators](https://github.com/atcollab/at/issues/592#issuecomment-1500188375).

This PR solves the problem of compilation failure with OPENMP=1, but OpenMP is disabled in the `BndMPoleSymplectic4QuantPass`, `StrMPoleSymplectic4QuantPass` and `QuantDiffPass` passmethods until the random generation of quantum emission is validated with OpenMP.

I keep the issue #592 open because it documents the remaining problem. A dummy passmethod called `TestRandomPass` is temporarily added to the repository: it checks the random generators with and without OpenMP. The direct output of Gaussian distribution looks correct.