### PR TITLE
Fix the dtype of geometry data

### DIFF
--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -1065,13 +1065,13 @@ def get_geometry(ring: List[Element],
        >>> geomdata, radius = get_geometry(ring)
     """
 
-    geom_dtype = [('x', numpy.float64, (1, )),
-                  ('y', numpy.float64, (1, )),
-                  ('angle', numpy.float64, (1, ))]
+    geom_dtype = [('x', numpy.float64),
+                  ('y', numpy.float64),
+                  ('angle', numpy.float64)]
     geomdata = numpy.recarray((len(ring)+1, ), dtype=geom_dtype)
-    xx = numpy.zeros((len(ring)+1, 1))
-    yy = numpy.zeros((len(ring)+1, 1))
-    angle = numpy.zeros((len(ring)+1, 1))
+    xx = numpy.zeros(len(ring)+1)
+    yy = numpy.zeros(len(ring)+1)
+    angle = numpy.zeros(len(ring)+1)
     x, y, t = start_coordinates
     x0, y0, t0 = start_coordinates
 


### PR DESCRIPTION
The data type of geometry data (output of `Lattice.get_geometry`) is incorrect:

`geodata.x` has shape (n, 1) instead of (n,)
`geodata[0].x` is a (1,) array instead of a scalar

This PR fixes that, but has consequences on existing code making use of this data.

In most cases, the present output needs a `squeeze()`, which would still work though now useless. In other cases code will break

Keeping `get_geometry` unchanged is of course possible, at the cost of unnecessary complexity of user code…

Please advise !

Note for @simoneliuzzo : this appeared when trying to implement a GeometryObservable