### PR TITLE
Release 0.4.0

### DIFF
--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -159,7 +159,8 @@ The ``## What's changed`` section should be split into ``## Bug fixes`` and
 ``## New features``. It must be filtered to keep only the python changes, ignoring
 the Matlab ones. The tags on each pull request are there to help in this filtering.
 
-The release notes should start with a paragraph pointing out the main modifications.
+The release notes should start with a ``## Main modifications`` section summarising
+the important points of the new release.
 
 They must end with a section pointing out ``## Incompatibilities`` and mentioning the
 necessary actions before upgrading to this release.

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -105,11 +105,13 @@ To do this, we use the continuous integration service Github Actions.
 When a tag of the form pyat-* is pushed to Github, wheels for each
 supported platform will be built and automatically uploaded as an 'artifact'.
 
-The version number is of the form of three dot separated numbers:
-``major.minor.patch``. Major versions include major new functionalities but
-may introduce incompatibilites with previous versions. Minor versions offer
-new features without any incompatibility. Patch versions are reserved for
-bug fixes.
+We use `Semantic Versioning <https://semver.org/>`_ for this project. As documented
+by the full specification, we use a version number with three dot-separated
+numbers: ``MAJOR.MINOR.PATCH``. Increment the:
+
+* MAJOR version when you make incompatible API changes
+* MINOR version when you add functionality in a backward compatible manner
+* PATCH version when you make backward compatible bug fixes
 
 Release procedure
 -----------------
@@ -132,8 +134,8 @@ Determine the minimum ``numpy`` and ``scipy`` versions:
 * the version ensuring the requirements necessary to **run** PyAT is set in the
   ``dependencies`` item of the ``[project]`` section of ``pyproject.toml``
 * The version required to **build** PyAT is set in the ``requires`` item of the
-  ``[build]`` section of ``pyproject.toml``. It depends on the python version and
-  must be higher or equal to the "run" version.
+  ``[build-system]`` section of ``pyproject.toml``. It depends on the python version
+  and must be higher or equal to the "run" version.
 * To avoid version conflicts with the user's existing libraries, the pre-compiled
   binaries are built with the exact minimum library versions. This ensures that the
   user's libraries are more recent than the one AT has been compiled with. For
@@ -145,14 +147,15 @@ Determine the minimum ``numpy`` and ``scipy`` versions:
 Prepare the "Release notes"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A draft can be obtained by creating a new tag on GitHub. Click "Draft a new release"
-in the releases page, choose a new tag like "pyat-x.y.z", select
-the master branch as target. In the description area, choose the present release in
-the "previous tag" pull-down, and press "Generate release notes".
+in the releases page, choose a new tag in the form ``pyat-x.y.z`` with the correct
+incremented version number. The ``pyat-`` prefix is necessary to identify python releases.
+Select the master branch as target. In the description area, choose the current
+release in the "previous tag" pull-down, and press "Generate release notes".
 
 The generated notes can now be copied and edited. You can then either cancel or
 save the release as a draft while editing the release notes.
 
-The ``## What's changed`` section should be splitted in ``## Bug fixes`` and
+The ``## What's changed`` section should be split into ``## Bug fixes`` and
 ``## New features``. It must be filtered to keep only the python changes, ignoring
 the Matlab ones. The tags on each pull request are there to help in this filtering.
 
@@ -175,7 +178,7 @@ Build the release
 ~~~~~~~~~~~~~~~~~
 
 Now either go back to the draft release saved above, or start again the procedure,
-but now going to the end.
+but now finalising with the ``Publish`` button.
 
 If all goes well, there will be a build of "Build and upload wheels and sdist"
 associated with the tag ``pyat-x.y.z``: on the `Github Actions page <https://github.com/atcollab/at/actions/workflows/build-python-wheels.yml>`_. This build will have

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -136,9 +136,9 @@ Determine the minimum ``numpy`` and ``scipy`` versions:
 * The version required to **build** PyAT is set in the ``requires`` item of the
   ``[build-system]`` section of ``pyproject.toml``. It depends on the python version
   and must be higher or equal to the "run" version.
-* To avoid version conflicts with the user's existing libraries, the pre-compiled
-  binaries are built with the exact minimum library versions. This ensures that the
-  user's libraries are more recent than the one AT has been compiled with. For
+* To avoid ABI compatibility issues, the pre-compiled binaries are built with the
+  earliest possible version of numpy for the given Python version.. This ensures that
+  the user's libraries are more recent than the one AT has been compiled with. For
   that, a copy of ``pyproject.toml`` named ``githubproject.toml`` is used for
   compilation. In this copy, the numpy version specifications are set using ``~=``
   instead of minimum (``>=``). Apart from these lines, the 2 files

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -140,8 +140,8 @@ Determine the minimum ``numpy`` and ``scipy`` versions:
   binaries are built with the exact minimum library versions. This ensures that the
   user's libraries are more recent than the one AT has been compiled with. For
   that, a copy of ``pyproject.toml`` named ``githubproject.toml`` is used for
-  compilation. In this copy, the numpy version specifications are set using strict
-  equality(``==``) instead of minimum (``>=``). Apart from these lines, the 2 files
+  compilation. In this copy, the numpy version specifications are set using ``~=``
+  instead of minimum (``>=``). Apart from these lines, the 2 files
   should be strictly identical.
 
 Prepare the "Release notes"

--- a/pyat/developers.rst
+++ b/pyat/developers.rst
@@ -137,7 +137,7 @@ Determine the minimum ``numpy`` and ``scipy`` versions:
   ``[build-system]`` section of ``pyproject.toml``. It depends on the python version
   and must be higher or equal to the "run" version.
 * To avoid ABI compatibility issues, the pre-compiled binaries are built with the
-  earliest possible version of numpy for the given Python version.. This ensures that
+  earliest possible version of numpy for the given Python version. This ensures that
   the user's libraries are more recent than the one AT has been compiled with. For
   that, a copy of ``pyproject.toml`` named ``githubproject.toml`` is used for
   compilation. In this copy, the numpy version specifications are set using ``~=``


### PR DESCRIPTION
A new version may be released. It's a minor maintenance version before releasing 1.0
I propose to postpone the description of deprecated features to the 1.0 version.

This branch includes improved developer notes describing the proposed release procedure,

This release may still wait for the pending minor modifications.

The proposed release notes are:

## Main modifications
This releases introduces:
* Time-dependent multipole strengths (sine wave, white noise, user-defined)
* Updated values of the physical constants
* Compatibility with python 3.11
* 3d element rotations (tilt, pitch, yaw)
* Plot of the &Sigma; beam matrix
* Multibunch Wakefield
* Multibunch beamloading
* Beam monitor element (statistics on the particle distribution)
* Extend the definition of `refpts` to string patterns, regular expressions, `None`, `All`, `End` special values
* Improved documentation and examples

## Bug fixes
* quantpass bugfixes by @swhite2401 in https://github.com/atcollab/at/pull/504
* Take "QuantPass" into account when checking 6D motion by @lfarv in https://github.com/atcollab/at/pull/507
* Failure of GitHub action for Matlab compilation error by @lfarv in https://github.com/atcollab/at/pull/535
* at.sigma_matrix bug fix by @lfarv in https://github.com/atcollab/at/pull/536
* Fix bug in convolve_wakefun by @lcarver in https://github.com/atcollab/at/pull/550
* Bug fix on atrotatelattice by @lfarv in https://github.com/atcollab/at/pull/569
* Fix circular imports by @lfarv in https://github.com/atcollab/at/pull/570
* BugFix: refpts=None in get_lifetime by @swhite2401 in https://github.com/atcollab/at/pull/580
* Fix bug in memory allocation of wake method by @lcarver in https://github.com/atcollab/at/pull/579
* Correct return type of wakefunc_long_resonator by @lfarv in https://github.com/atcollab/at/pull/591
* Fix compilation with OPENMP=1 by @lfarv in https://github.com/atcollab/at/pull/607

## New features
* Multibunch wakefieldpass by @swhite2401 in https://github.com/atcollab/at/pull/493
* Introduce an RF frequency shift input to specify off-momentum computation by @lfarv in https://github.com/atcollab/at/pull/505
* Variable multipole by @swhite2401 in https://github.com/atcollab/at/pull/510
* Improve patpass by @lfarv in https://github.com/atcollab/at/pull/515
* Upgrade scipy requirement to 1.4.0 by @lfarv in https://github.com/atcollab/at/pull/520
* Python 3.11 by @lfarv in https://github.com/atcollab/at/pull/523
* Element rotations by @swhite2401 in https://github.com/atcollab/at/pull/519
* Multibunch Beamloading by @swhite2401 in https://github.com/atcollab/at/pull/516
* Beam monitor by @swhite2401 in https://github.com/atcollab/at/pull/521
* Update the python version spec by @lfarv in https://github.com/atcollab/at/pull/526
* random generators compatibility with parallel processing by @lfarv in https://github.com/atcollab/at/pull/513
* Unfold beam by @swhite2401 in https://github.com/atcollab/at/pull/524
* Update at.beam by @lfarv in https://github.com/atcollab/at/pull/531
* Use the ct coordinate in the variable multipole pass method by @carmignani in https://github.com/atcollab/at/pull/532
* Update quantum diffusion pass methods by @lfarv in https://github.com/atcollab/at/pull/534
* at.beam improvement by @lfarv in https://github.com/atcollab/at/pull/537
* Collective unit tests by @swhite2401 in https://github.com/atcollab/at/pull/539
* New plot_sigma() plotting function by @lfarv in https://github.com/atcollab/at/pull/541
* Stub files for C extensions by @lfarv in https://github.com/atcollab/at/pull/542
* relax chromaticity test for numpy 1.24 by @lfarv in https://github.com/atcollab/at/pull/545
* Improvement of the "refpts" argument by @lfarv in https://github.com/atcollab/at/pull/547
* Momentum offset for 6d orbit by @swhite2401 in https://github.com/atcollab/at/pull/540
* do not split elements with IdTablePass method by @oscarxblanco in https://github.com/atcollab/at/pull/563
* Frequency Analysis by @oscarxblanco in https://github.com/atcollab/at/pull/556
* IdTablePass by @oscarxblanco in https://github.com/atcollab/at/pull/558
* Axis definitions by @lfarv in https://github.com/atcollab/at/pull/566
* Develop lattice by @lfarv in https://github.com/atcollab/at/pull/565
* Improve the import order by @lfarv in https://github.com/atcollab/at/pull/576
* zero length elements in lifetime calculation by @swhite2401 in https://github.com/atcollab/at/pull/577
* Lattice operators by @swhite2401 in https://github.com/atcollab/at/pull/573
* ringparam always returns an emittance by @swhite2401 in https://github.com/atcollab/at/pull/583
* Acceptance shift zero + docs by @swhite2401 in https://github.com/atcollab/at/pull/588
* Restore the standard behaviour of reversed(Lattice) by @lfarv in https://github.com/atcollab/at/pull/589
* Energy loss relative tolerance by @swhite2401 in https://github.com/atcollab/at/pull/596
* Relaxed passmethod coherence tests when loading files by @lfarv in https://github.com/atcollab/at/pull/600
* Documentation for Collective Effects by @lcarver in https://github.com/atcollab/at/pull/599
* regex option by @swhite2401 in https://github.com/atcollab/at/pull/601

## Incompatibilities
* None expected

## New Contributors
* @oscarxblanco made their first contribution in https://github.com/atcollab/at/pull/563
* @pcsch made their first contribution in https://github.com/atcollab/at/pull/587

**Full Changelog**: https://github.com/atcollab/at/compare/pyat-0.3.0...pyat-0.4.0