### PR TITLE
Fix at disable_6d

### DIFF
--- a/atmat/atphysics/Radiation/getclass_6d.m
+++ b/atmat/atphysics/Radiation/getclass_6d.m
@@ -1,22 +1,26 @@
 function atclass=getclass_6d(elem)
 %GETCLASS_6D    Private. Guess class for 6d motion
 %
-% Returns the element class ignoring its Class field
+% Returns the element class ignoring its Class field when non-ambiguous
 % Simplified and faster version of atguessclass
 
 if isfield(elem,'BendingAngle')
     atclass='Bend';
 elseif isfield(elem,'PolynomB') && elem.Length > 0
-    maxorder=elem.MaxOrder+1;
-    loworder=find(abs(elem.PolynomB(2:maxorder))~=0,1);
-    if isempty(loworder)
-        atclass='Drift';
-    elseif loworder==1
-        atclass='Quadrupole';
-    elseif loworder==2
-        atclass='Sextupole';
+    if isfield(elem, 'Class')
+        atclass=elem.Class;
     else
-        atclass='Multipole';
+        maxorder=elem.MaxOrder+1;
+        loworder=find(abs(elem.PolynomB(2:maxorder))~=0,1);
+        if isempty(loworder)
+            atclass='Drift';
+        elseif loworder==1
+            atclass='Quadrupole';
+        elseif loworder==2
+            atclass='Sextupole';
+        else
+            atclass='Multipole';
+        end
     end
 elseif isfield(elem,'Frequency')
     atclass='RFCavity';


### PR DESCRIPTION
When turning radiation off, at `disable_6d` considered multipoles with PolynomB == zeros as drifts, so kept the passmethod unchanged. This is corrected by taking into account the `Class` field for multipoles if it exists, before scanning PolynomB.