### PR TITLE
Fix the creation of .mat files

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -884,10 +884,6 @@ class Sextupole(Multipole):
         super(Sextupole, self).__init__(family_name, length, [], poly_b,
                                         **kwargs)
 
-    def items(self) -> Generator[Tuple, None, None]:
-        yield from super().items()
-        yield 'H', self.H
-
 
 class Octupole(Multipole):
     """Octupole element, with no changes from multipole at present"""


### PR DESCRIPTION
This fixes a bug reported by @oscarxblanco  [here](https://github.com/atcollab/at/pull/597#issuecomment-1631335119).

The following sequence:

1. Saving a .mat file in PyAT
2. reading the file in Matlab
3. saving as a .m file in Matlab
4. Reading the ,m fill-in python 

throws an Exception when reading sextuples.

Explanation: The attribute `H` (sextuple strength) exists as a property in python, but does not exist in Matlab. It is not present in .mat files created in Matlab, but does exist in .mat files created in python. When reading such a file in Matlab, the sextupoles get an unexpected `H` attribute, which has no detrimental effect, However when saving in a .m file, `H` is printed as a "exotic" attribute, which is wrongly interpreted.

In this PR, `H` does not appear in .mat files created in python.