### PR TITLE
Remove the warning when calling plot_beta in transfer line mode

### DIFF
--- a/pyat/at/plot/specific.py
+++ b/pyat/at/plot/specific.py
@@ -16,7 +16,7 @@ def pldata_beta_disp(ring: Lattice, refpts: Refpts, **kwargs):
     """Generates data for plotting beta functions and dispersion"""
 
     # compute linear optics at the required locations
-    data0, _, data = get_optics(ring, refpts=refpts, get_chrom=True, **kwargs)
+    data0, _, data = get_optics(ring, refpts=refpts, **kwargs)
 
     # Extract the plot data
     s_pos = data['s_pos']


### PR DESCRIPTION
Whe calling `plot_beta` in transfer line mode, using the `twiss_in` keyword, a warning is emitted because of the presence of the `get_chrom` keyword. `get_chrom` is useless here, so it is removed.