### PR TITLE
Display the name of selected elements in plots

### DIFF
--- a/pyat/at/plot/generic.py
+++ b/pyat/at/plot/generic.py
@@ -54,7 +54,9 @@ def baseplot(ring: Lattice, plot_function: Callable, *args, **kwargs):
           for plotting as (primary_axes, secondary_axes).
           Default: create new axes
         slices (int):       Number of slices. Default: 400
-        legend (bool):      Show a legend on the plot
+        legend (bool):      Show a legend on the plot. Default: :py:obj:`True`
+        labels (Refpts):    display the name of selected elements.
+          Default: :py:obj:`None`
         block (bool):       If :py:obj:`True`, block until the figure is closed.
           Default: :py:obj:`False`
         dipole (dict):      Dictionary of properties overloading the default
@@ -94,7 +96,8 @@ def baseplot(ring: Lattice, plot_function: Callable, *args, **kwargs):
         ring.s_range = kwargs.pop('s_range')
 
     # extract synopt arguments
-    synkeys = ['dipole', 'quadrupole', 'sextupole', 'multipole', 'monitor']
+    synkeys = ['dipole', 'quadrupole', 'sextupole', 'multipole',
+               'monitor', 'labels']
     kwkeys = list(kwargs.keys())
     synargs = dict((k, kwargs.pop(k)) for k in kwkeys if k in synkeys)
 

--- a/pyat/at/plot/specific.py
+++ b/pyat/at/plot/specific.py
@@ -71,6 +71,8 @@ def plot_beta(ring: Lattice, **kwargs):
           Default: create new axes
         slices (int):       Number of slices. Default: 400
         legend (bool):      Show a legend on the plot
+        labels (Refpts):    display the name of selected elements.
+          Default: :py:obj:`None`
         block (bool):       If :py:obj:`True`, block until the figure is closed.
           Default: :py:obj:`False`
         dipole (dict):      Dictionary of properties overloading the default
@@ -150,7 +152,7 @@ def plot_linear(ring: Lattice, *keys, **kwargs):
 
           :code:`('dispersion', 0)`:        eta_x
 
-          :code:`('closed_orbit'), [1, 3])`:    x', z'
+          :code:`('closed_orbit', [1, 3])`:    x', z'
 
           :code:`('m44', 2, 2)`:            T33
 
@@ -193,6 +195,8 @@ def plot_linear(ring: Lattice, *keys, **kwargs):
           Default: create new axes
         slices (int):       Number of slices. Default: 400
         legend (bool):      Show a legend on the plot
+        labels (Refpts):    display the name of selected elements.
+          Default: :py:obj:`None`
         block (bool):       If :py:obj:`True`, block until the figure is closed.
           Default: :py:obj:`False`
         dipole (dict):      Dictionary of properties overloading the default

--- a/pyat/at/plot/synopt.py
+++ b/pyat/at/plot/synopt.py
@@ -146,8 +146,8 @@ def plot_synopt(ring: Lattice, axes: matplotlib.axes.Axes = None,
     for idx in ring.get_uint32_index(labels):
         el = ring[idx]
         s = s_pos[idx]
-        axsyn.annotate(el.FamName[:10], xy=[s + 0.5*el.Length, 1.6],
-                       rotation='vertical', horizontalalignment='center',
-                       fontsize='small')
+        axsyn.text(s + 0.5*el.Length, 1.6, el.FamName[:10],
+                   rotation='vertical', horizontalalignment='center',
+                   fontsize='small')
 
     return axsyn

--- a/pyat/at/plot/synopt.py
+++ b/pyat/at/plot/synopt.py
@@ -1,4 +1,5 @@
 """Lattice synoptics"""
+# noinspection PyPackageRequirements
 import matplotlib.axes
 import numpy
 # noinspection PyPackageRequirements
@@ -7,7 +8,7 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 # noinspection PyPackageRequirements
 from matplotlib.collections import PatchCollection
-from at.lattice import Lattice, elements as elts
+from at.lattice import Lattice, Refpts, elements as elts
 
 __all__ = ['plot_synopt']
 
@@ -22,7 +23,8 @@ MONITOR = dict(label='Monitors', linestyle=None, marker=10, color='k')
 # noinspection PyDefaultArgument
 def plot_synopt(ring: Lattice, axes: matplotlib.axes.Axes = None,
                 dipole: dict = {}, quadrupole: dict = {}, sextupole: dict = {},
-                multipole: dict = {}, monitor: dict = {}):
+                multipole: dict = {}, monitor: dict = {},
+                labels: Refpts = None):
     """Plots a synoptic of a lattice
 
     Parameters:
@@ -30,6 +32,7 @@ def plot_synopt(ring: Lattice, axes: matplotlib.axes.Axes = None,
         axes:           :py:class:`~matplotlib.axes.Axes` for plotting the
           synoptic. If :py:obj:`None`, a new figure will be created. Otherwise,
           a new axes object sharing the same x-axis as the given one is created.
+        labels:         display the name of selected elements.
         dipole:         Dictionary of properties overloading the default
           properties. If :py:obj:`None`, dipoles will not be shown.
         quadrupole:     Same definition as for dipole
@@ -139,5 +142,12 @@ def plot_synopt(ring: Lattice, axes: matplotlib.axes.Axes = None,
         y = numpy.zeros(s.shape)
         # noinspection PyUnusedLocal
         monitors = axsyn.plot(s, y, **props)
+
+    for idx in ring.get_uint32_index(labels):
+        el = ring[idx]
+        s = s_pos[idx]
+        axsyn.annotate(el.FamName[:10], xy=[s + 0.5*el.Length, 1.6],
+                       rotation='vertical', horizontalalignment='center',
+                       fontsize='small')
 
     return axsyn


### PR DESCRIPTION
Answers #619.

A new `labels` keyword in plot functions (Lattice.plot_beta()) allows displaying the names of the selected elements.
`labels` may be any of the allowed refpts types (int or bool arrays, class, string…).

Example, for the hmba test lattice:
```python
ring.plot_beta(labels=at.Quadrupole)
```
![Figure_1](https://github.com/atcollab/at/assets/20038121/5b378fd6-be50-49f0-aa3c-340c960fac0f)
