### PR TITLE
The DPStep keyword in linopt6 raises an error for 4D lattices

### DIFF
--- a/pyat/at/physics/orbit.py
+++ b/pyat/at/physics/orbit.py
@@ -31,6 +31,7 @@ def _orbit_dp(ring: Lattice, dp: float = None, guess: Orbit = None, **kwargs):
     convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
+    kwargs.pop('DPStep', DConstant.DPStep)
     rem = kwargs.keys()
     if len(rem) > 0:
         raise AtError(f'Unexpected keywords for orbit_dp: {", ".join(rem)}')
@@ -76,6 +77,7 @@ def _orbit_dct(ring: Lattice, dct: float = None, guess: Orbit = None, **kwargs):
     convergence = kwargs.pop('convergence', DConstant.OrbConvergence)
     max_iterations = kwargs.pop('max_iterations', DConstant.OrbMaxIter)
     xy_step = kwargs.pop('XYStep', DConstant.XYStep)
+    kwargs.pop('DPStep', DConstant.DPStep)
     rem = kwargs.keys()
     if len(rem) > 0:
         raise AtError(f'Unexpected keywords for orbit_dct: {", ".join(rem)}')


### PR DESCRIPTION
The `DPStep` keyword in `linopt2/4/6` is forwarded to `find_orbit4/6` and `find_m44/66`, where it raises an error for 4D lattices.

For keeping the same signature in both cases, `DPStep` is now allowed (but unused) in `find_orbit4` and `find_m44`