### PR TITLE
Bug fix in atdisable_6d: keep the Energy field in cavities.

### DIFF
--- a/atmat/atphysics/Radiation/atdisable_6d.m
+++ b/atmat/atphysics/Radiation/atdisable_6d.m
@@ -102,7 +102,7 @@ end
         elseif strcmp(newpass, 'auto')
             modfun=@varelem;
         else
-            modfun=setpass(newpass);
+            modfun=setpassenergy(newpass);
         end
         
         function elem=varelem(elem)
@@ -121,7 +121,7 @@ end
             if strcmp(newpass, 'auto')
                 newpass=defpass;
             end
-            modfun=setpass(newpass);
+            modfun=setpassenergy(newpass);
         end
     end
 
@@ -146,6 +146,13 @@ end
     end
 
     function setfun=setpass(npass)
+        function elem=newelem(elem)
+            elem.PassMethod=npass;
+        end
+        setfun=@newelem;
+    end
+
+    function setfun=setpassenergy(npass)
         function elem=newelem(elem)
             elem.PassMethod=npass;
             if isfield(elem,'Energy'), elem=rmfield(elem,'Energy'); end


### PR DESCRIPTION
`atdisable_6d` removes the `Energy` field in all elements, including RF cavities. The `Energy` field is not used in cavity processing, however it is taken as the definition of the ring energy if there is no `RingParam` element. So this creates problems for rings without `RinpParam` element.

In this PR, the `Energy` field is kept only in RF cavities.