### PR TITLE
Fix attribute names in Simple Ring

### DIFF
--- a/atintegrators/SimpleQuantDiffPass.c
+++ b/atintegrators/SimpleQuantDiffPass.c
@@ -4,14 +4,14 @@
 
 struct elem 
 {
-  double emit_x;
-  double emit_y;
-  double sigma_dp;
-  double tau_x;
-  double tau_y;
-  double tau_z;
-  double beta_x;
-  double beta_y;
+  double emitx;
+  double emity;
+  double espread;
+  double taux;
+  double tauy;
+  double tauz;
+  double betax;
+  double betay;
   double sigma_xp;
   double sigma_yp;
   double U0;
@@ -19,8 +19,8 @@ struct elem
 };
 
 void SimpleQuantDiffPass(double *r_in,
-           double sigma_xp, double sigma_yp, double sigma_dp,
-           double tau_x, double tau_y, double tau_z, double EnergyLossFactor,
+           double sigma_xp, double sigma_yp, double espread,
+           double taux, double tauy, double tauz, double EnergyLossFactor,
            pcg32_random_t* rng, int num_particles)
 
 {
@@ -36,23 +36,23 @@ void SimpleQuantDiffPass(double *r_in,
     }
     
     if(!atIsNaN(r6[0])) {
-      if(tau_x!=0.0) {
-        r6[1] -= 2*r6[1]/tau_x;
+      if(taux!=0.0) {
+        r6[1] -= 2*r6[1]/taux;
       }
       if(sigma_xp!=0.0) {
-        r6[1] += 2*sigma_xp*sqrt(1/tau_x)*randnorm[0];
+        r6[1] += 2*sigma_xp*sqrt(1/taux)*randnorm[0];
       }
       if(sigma_yp!=0.0) {
-        r6[3] += 2*sigma_yp*sqrt(1/tau_y)*randnorm[1];
+        r6[3] += 2*sigma_yp*sqrt(1/tauy)*randnorm[1];
       }
-      if(tau_y!=0.0) {
-        r6[3] -= 2*r6[3]/tau_y;
+      if(tauy!=0.0) {
+        r6[3] -= 2*r6[3]/tauy;
       }
-      if(sigma_dp!=0.0) {
-        r6[4] += 2*sigma_dp*sqrt(1/tau_z)*randnorm[2];
+      if(espread!=0.0) {
+        r6[4] += 2*espread*sqrt(1/tauz)*randnorm[2];
       }
-      if(tau_z!=0.0) {
-        r6[4] -= 2*r6[4]/tau_z;
+      if(tauz!=0.0) {
+        r6[4] -= 2*r6[4]/tauz;
       }
       
       if(EnergyLossFactor>0.0) {
@@ -68,32 +68,32 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 {
 /*  if (ElemData) {*/
         if (!Elem) {
-            double emit_x, emit_y, sigma_dp, tau_x, tau_y, tau_z, beta_x, beta_y, U0, EnergyLossFactor;
-            emit_x=atGetDouble(ElemData,"emit_x"); check_error();
-            emit_y=atGetDouble(ElemData,"emit_y"); check_error();
-            sigma_dp=atGetDouble(ElemData,"sigma_dp"); check_error();
-            tau_x=atGetDouble(ElemData,"tau_x"); check_error();
-            tau_y=atGetDouble(ElemData,"tau_y"); check_error();
-            tau_z=atGetDouble(ElemData,"tau_z"); check_error();
-            beta_x=atGetDouble(ElemData,"beta_x"); check_error();
-            beta_y=atGetDouble(ElemData,"beta_y"); check_error();
+            double emitx, emity, espread, taux, tauy, tauz, betax, betay, U0, EnergyLossFactor;
+            emitx=atGetDouble(ElemData,"emitx"); check_error();
+            emity=atGetDouble(ElemData,"emity"); check_error();
+            espread=atGetDouble(ElemData,"espread"); check_error();
+            taux=atGetDouble(ElemData,"taux"); check_error();
+            tauy=atGetDouble(ElemData,"tauy"); check_error();
+            tauz=atGetDouble(ElemData,"tauz"); check_error();
+            betax=atGetDouble(ElemData,"betax"); check_error();
+            betay=atGetDouble(ElemData,"betay"); check_error();
             U0=atGetDouble(ElemData,"U0"); check_error();
             
             Elem = (struct elem*)atMalloc(sizeof(struct elem));
-            Elem->emit_x=emit_x;
-            Elem->emit_y=emit_y;
-            Elem->sigma_dp=sigma_dp;
-            Elem->tau_x=tau_x;
-            Elem->tau_y=tau_y;
-            Elem->tau_z=tau_z;
-            Elem->beta_x=beta_x;
-            Elem->beta_y=beta_y;
-            Elem->sigma_xp=sqrt(emit_x/beta_x);
-            Elem->sigma_yp=sqrt(emit_y/beta_y);
+            Elem->emitx=emitx;
+            Elem->emity=emity;
+            Elem->espread=espread;
+            Elem->taux=taux;
+            Elem->tauy=tauy;
+            Elem->tauz=tauz;
+            Elem->betax=betax;
+            Elem->betay=betay;
+            Elem->sigma_xp=sqrt(emitx/betax);
+            Elem->sigma_yp=sqrt(emity/betay);
             Elem->U0=U0;
             Elem->EnergyLossFactor=U0/Param->energy;
         }
-        SimpleQuantDiffPass(r_in, Elem->sigma_xp, Elem->sigma_yp, Elem->sigma_dp, Elem->tau_x, Elem->tau_y, Elem->tau_z, Elem->EnergyLossFactor, Param->thread_rng, num_particles);
+        SimpleQuantDiffPass(r_in, Elem->sigma_xp, Elem->sigma_yp, Elem->espread, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, Param->thread_rng, num_particles);
 /*  }
     else {
          atFree(Elem->T1);
@@ -117,37 +117,37 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double *r_in;
         const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
-        double emit_x, emit_y, sigma_dp, tau_x, tau_y, tau_z, beta_x, beta_y, sigma_xp, sigma_yp, U0, EnergyLossFactor;
+        double emitx, emity, espread, taux, tauy, tauz, betax, betay, sigma_xp, sigma_yp, U0, EnergyLossFactor;
 
-        emit_x=atGetDouble(ElemData,"emit_x"); check_error();
-        emit_y=atGetDouble(ElemData,"emit_y"); check_error();
-        sigma_dp=atGetDouble(ElemData,"sigma_dp"); check_error();
-        tau_x=atGetDouble(ElemData,"tau_x"); check_error();
-        tau_y=atGetDouble(ElemData,"tau_y"); check_error();
-        tau_z=atGetDouble(ElemData,"tau_z"); check_error();
-        beta_x=atGetDouble(ElemData,"beta_x"); check_error();  
-        beta_y=atGetDouble(ElemData,"beta_y"); check_error();  
+        emitx=atGetDouble(ElemData,"emitx"); check_error();
+        emity=atGetDouble(ElemData,"emity"); check_error();
+        espread=atGetDouble(ElemData,"espread"); check_error();
+        taux=atGetDouble(ElemData,"taux"); check_error();
+        tauy=atGetDouble(ElemData,"tauy"); check_error();
+        tauz=atGetDouble(ElemData,"tauz"); check_error();
+        betax=atGetDouble(ElemData,"betax"); check_error();  
+        betay=atGetDouble(ElemData,"betay"); check_error();  
         U0=atGetDouble(ElemData,"U0"); check_error();  
-        sigma_xp=sqrt(emit_x/beta_x);
-        sigma_yp=sqrt(emit_y/beta_y);
+        sigma_xp=sqrt(emitx/betax);
+        sigma_yp=sqrt(emity/betay);
         EnergyLossFactor=U0/6e9;
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        SimpleQuantDiffPass(r_in, sigma_xp, sigma_yp, sigma_dp, tau_x, tau_y, tau_z, EnergyLossFactor, &pcg32_global, num_particles);
+        SimpleQuantDiffPass(r_in, sigma_xp, sigma_yp, espread, taux, tauy, tauz, EnergyLossFactor, &pcg32_global, num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */
         plhs[0] = mxCreateCellMatrix(9,1);
-        mxSetCell(plhs[0],0,mxCreateString("emit_x"));
-        mxSetCell(plhs[0],1,mxCreateString("emit_y"));
-        mxSetCell(plhs[0],2,mxCreateString("sigma_dp"));
-        mxSetCell(plhs[0],3,mxCreateString("tau_x"));
-        mxSetCell(plhs[0],4,mxCreateString("tau_y"));
-        mxSetCell(plhs[0],5,mxCreateString("tau_z"));
-        mxSetCell(plhs[0],6,mxCreateString("beta_x"));
-        mxSetCell(plhs[0],7,mxCreateString("beta_y"));
+        mxSetCell(plhs[0],0,mxCreateString("emitx"));
+        mxSetCell(plhs[0],1,mxCreateString("emity"));
+        mxSetCell(plhs[0],2,mxCreateString("espread"));
+        mxSetCell(plhs[0],3,mxCreateString("taux"));
+        mxSetCell(plhs[0],4,mxCreateString("tauy"));
+        mxSetCell(plhs[0],5,mxCreateString("tauz"));
+        mxSetCell(plhs[0],6,mxCreateString("betax"));
+        mxSetCell(plhs[0],7,mxCreateString("betay"));
         mxSetCell(plhs[0],8,mxCreateString("U0"));
         
         

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -991,58 +991,58 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     default_pass = {False: 'IdentityPass', True: 'SimpleQuantDiffPass'}
 
-    def __init__(self, family_name: str, beta_x: Optional[float]=1.0,
-                 beta_y: Optional[float]=1.0, emit_x: Optional[float]=0.0,
-                 emit_y: Optional[float]=0.0, sigma_dp: Optional[float]=0.0,
-                 tau_x: Optional[float]=0.0, tau_y: Optional[float]=0.0,
-                 tau_z: Optional[float]=0.0, U0: Optional[float]=0.0,
+    def __init__(self, family_name: str, betax: Optional[float]=1.0,
+                 betay: Optional[float]=1.0, emitx: Optional[float]=0.0,
+                 emity: Optional[float]=0.0, espread: Optional[float]=0.0,
+                 taux: Optional[float]=0.0, tauy: Optional[float]=0.0,
+                 tauz: Optional[float]=0.0, U0: Optional[float]=0.0,
                  **kwargs):
         """
         Args:
             family_name:    Name of the element
             
         Optional Args:
-            beta_x:         Horizontal beta function at element [m]
-            beta_y:         Vertical beta function at element [m]
-            emit_x:         Horizontal equilibrium emittance [m.rad]
-            emit_y:         Vertical equilibrium emittance [m.rad]
-            sigma_dp:       Equilibrium energy spread
-            tau_x:          Horizontal damping time [turns]
-            tau_y:          Vertical damping time [turns]
-            tau_z:          Longitudinal damping time [turns]
+            betax:         Horizontal beta function at element [m]
+            betay:         Vertical beta function at element [m]
+            emitx:         Horizontal equilibrium emittance [m.rad]
+            emity:         Vertical equilibrium emittance [m.rad]
+            espread:       Equilibrium energy spread
+            taux:          Horizontal damping time [turns]
+            tauy:          Vertical damping time [turns]
+            tauz:          Longitudinal damping time [turns]
             U0:             Energy Loss [eV]
             
         Default PassMethod: ``SimpleQuantDiffPass``
        """
         kwargs.setdefault('PassMethod', self.default_pass[True])
        
-        assert tau_x>=0.0, 'tau_x must be greater than or equal to 0'
-        self.tau_x = tau_x
+        assert taux>=0.0, 'taux must be greater than or equal to 0'
+        self.taux = taux
             
-        assert tau_y>=0.0, 'tau_y must be greater than or equal to 0'
-        self.tau_y = tau_y
+        assert tauy>=0.0, 'tauy must be greater than or equal to 0'
+        self.tauy = tauy
 
-        assert tau_z>=0.0, 'tau_z must be greater than or equal to 0'
-        self.tau_z = tau_z
+        assert tauz>=0.0, 'tauz must be greater than or equal to 0'
+        self.tauz = tauz
 
-        assert emit_x>=0.0, 'emit_x must be greater than or equal to 0'
-        self.emit_x = emit_x
-        if emit_x>0.0:
-            assert tau_x>0.0, 'if emit_x is given, tau_x must be non zero'
+        assert emitx>=0.0, 'emitx must be greater than or equal to 0'
+        self.emitx = emitx
+        if emitx>0.0:
+            assert taux>0.0, 'if emitx is given, taux must be non zero'
             
-        assert emit_y>=0.0, 'emit_x must be greater than or equal to 0'
-        self.emit_y = emit_y
-        if emit_y>0.0:
-            assert tau_y>0.0, 'if emit_y is given, tau_y must be non zero'
+        assert emity>=0.0, 'emity must be greater than or equal to 0'
+        self.emity = emity
+        if emity>0.0:
+            assert tauy>0.0, 'if emity is given, tauy must be non zero'
             
-        assert sigma_dp>=0.0, 'sigma_dp must be greater than or equal to 0'
-        self.sigma_dp = sigma_dp
-        if sigma_dp>0.0:
-            assert tau_z>0.0, 'if sigma_dp is given, tau_z must be non zero'
+        assert espread>=0.0, 'espread must be greater than or equal to 0'
+        self.espread = espread
+        if espread>0.0:
+            assert tauz>0.0, 'if espread is given, tauz must be non zero'
             
         self.U0 = U0
-        self.beta_x = beta_x
-        self.beta_y = beta_y
+        self.betax = betax
+        self.betay = betay
         super(SimpleQuantDiff, self).__init__(family_name, **kwargs)
 
 

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -991,11 +991,11 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     default_pass = {False: 'IdentityPass', True: 'SimpleQuantDiffPass'}
 
-    def __init__(self, family_name: str, betax: Optional[float]=1.0,
-                 betay: Optional[float]=1.0, emitx: Optional[float]=0.0,
-                 emity: Optional[float]=0.0, espread: Optional[float]=0.0,
-                 taux: Optional[float]=0.0, tauy: Optional[float]=0.0,
-                 tauz: Optional[float]=0.0, U0: Optional[float]=0.0,
+    def __init__(self, family_name: str, betax: float = 1.0,
+                 betay: float = 1.0, emitx: float = 0.0,
+                 emity: float = 0.0, espread: float = 0.0,
+                 taux: float = 0.0, tauy: float = 0.0,
+                 tauz: float = 0.0, U0: float = 0.0,
                  **kwargs):
         """
         Args:
@@ -1016,29 +1016,29 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
        """
         kwargs.setdefault('PassMethod', self.default_pass[True])
        
-        assert taux>=0.0, 'taux must be greater than or equal to 0'
+        assert taux >= 0.0, 'taux must be greater than or equal to 0'
         self.taux = taux
             
-        assert tauy>=0.0, 'tauy must be greater than or equal to 0'
+        assert tauy >= 0.0, 'tauy must be greater than or equal to 0'
         self.tauy = tauy
 
-        assert tauz>=0.0, 'tauz must be greater than or equal to 0'
+        assert tauz >= 0.0, 'tauz must be greater than or equal to 0'
         self.tauz = tauz
 
-        assert emitx>=0.0, 'emitx must be greater than or equal to 0'
+        assert emitx >= 0.0, 'emitx must be greater than or equal to 0'
         self.emitx = emitx
-        if emitx>0.0:
-            assert taux>0.0, 'if emitx is given, taux must be non zero'
+        if emitx > 0.0:
+            assert taux > 0.0, 'if emitx is given, taux must be non zero'
             
-        assert emity>=0.0, 'emity must be greater than or equal to 0'
+        assert emity >= 0.0, 'emity must be greater than or equal to 0'
         self.emity = emity
-        if emity>0.0:
-            assert tauy>0.0, 'if emity is given, tauy must be non zero'
+        if emity > 0.0:
+            assert tauy > 0.0, 'if emity is given, tauy must be non zero'
             
-        assert espread>=0.0, 'espread must be greater than or equal to 0'
+        assert espread >= 0.0, 'espread must be greater than or equal to 0'
         self.espread = espread
-        if espread>0.0:
-            assert tauz>0.0, 'if espread is given, tauz must be non zero'
+        if espread > 0.0:
+            assert tauz > 0.0, 'if espread is given, tauz must be non zero'
             
         self.U0 = U0
         self.betax = betax

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -147,22 +147,22 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
         * A2: cross term for amplitude detuning coefficient, Default=0
         * A3: vertical amplitude detuning coefficient, Default=0
         * emitx: horizontal equilibrium emittance [m.rad], Default=0
-            ignored if emit_x=0
+            ignored if emitx=0
         * emity: vertical equilibrium emittance [m.rad], Default=0
-            ignored if emit_y=0
+            ignored if emity=0
         * espread: equilibrium momentum spread, Default=0
             ignored if espread=0
         * taux: horizontal radiation damping time [turns], Default=0
-            ignored if tau_x=0
+            ignored if taux=0
         * tauy: vertical radiation damping time [turns], Default=0
-            ignored if tau_y=0
+            ignored if tauy=0
         * tauz: longitudinal radiation damping time [turns], Default=0
-            ignored if tau_z=0
+            ignored if tauz=0
         * U0: - energy loss [eV] (positive number), Default=0
         * TimeLag: Set the timelag of the cavities, Default=0. Can be scalar
             or sequence of scalars (as with harmonic_number and Vrf).
 
-    If the given emit_x,emit_y or sigma_dp is 0, then no equlibrium emittance
+    If the given emitx, emity or espread is 0, then no equlibrium emittance
     is applied in this plane.
     If the given tau is 0, then no radiation damping is applied for this plane.
 

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -105,14 +105,14 @@ def fast_ring(ring: Lattice, split_inds=[]) -> Tuple[Lattice, Lattice]:
 
 def simple_ring(energy: float, circumference: float, harmonic_number: int,
                 Qx: float, Qy: float, Vrf: float, alpha: float,
-                beta_x: Optional[float]=1.0, beta_y: Optional[float]=1.0,
-                alpha_x: Optional[float]=0.0, alpha_y: Optional[float]=0.0,
+                betax: Optional[float]=1.0, betay: Optional[float]=1.0,
+                alphax: Optional[float]=0.0, alphay: Optional[float]=0.0,
                 Qpx: Optional[float]=0.0, Qpy: Optional[float]=0.0,
                 A1: Optional[float]=0.0, A2: Optional[float]=0.0,
-                A3: Optional[float]=0.0, emit_x: Optional[float]=0.0,
-                emit_y: Optional[float]=0.0, sigma_dp: Optional[float]=0.0,
-                tau_x: Optional[float]=0.0, tau_y: Optional[float]=0.0,
-                tau_z: Optional[float]=0.0, U0: Optional[float]=0.0,
+                A3: Optional[float]=0.0, emitx: Optional[float]=0.0,
+                emity: Optional[float]=0.0, espread: Optional[float]=0.0,
+                taux: Optional[float]=0.0, tauy: Optional[float]=0.0,
+                tauz: Optional[float]=0.0, U0: Optional[float]=0.0,
                 TimeLag: Optional[bool]=False
                 ):
     """Generates a "simple ring" based on a given dictionary
@@ -137,26 +137,26 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
         * alpha (momentum compaction factor)
 
     Optional Arguments:
-        * beta_x: horizontal beta function [m], Default=1
-        * beta_y: vertical beta function [m], Default=1
-        * alpha_x: horizontal alpha function, Default=0
-        * alpha_y: vertical alpha function, Default=0
+        * betax: horizontal beta function [m], Default=1
+        * betay: vertical beta function [m], Default=1
+        * alphax: horizontal alpha function, Default=0
+        * alphay: vertical alpha function, Default=0
         * Qpx: horizontal linear chromaticity, Default=0
         * Qpy: vertical linear chromaticity, Default=0
         * A1: horizontal amplitude detuning coefficient, Default=0
         * A2: cross term for amplitude detuning coefficient, Default=0
         * A3: vertical amplitude detuning coefficient, Default=0
-        * emit_x: horizontal equilibrium emittance [m.rad], Default=0
+        * emitx: horizontal equilibrium emittance [m.rad], Default=0
             ignored if emit_x=0
-        * emit_y: vertical equilibrium emittance [m.rad], Default=0
+        * emity: vertical equilibrium emittance [m.rad], Default=0
             ignored if emit_y=0
-        * sigma_dp: equilibrium momentum spread, Default=0
-            ignored if sigma_dp=0
-        * tau_x: horizontal radiation damping time [turns], Default=0
+        * espread: equilibrium momentum spread, Default=0
+            ignored if espread=0
+        * taux: horizontal radiation damping time [turns], Default=0
             ignored if tau_x=0
-        * tau_y: vertical radiation damping time [turns], Default=0
+        * tauy: vertical radiation damping time [turns], Default=0
             ignored if tau_y=0
-        * tau_z: longitudinal radiation damping time [turns], Default=0
+        * tauz: longitudinal radiation damping time [turns], Default=0
             ignored if tau_z=0
         * U0: - energy loss [eV] (positive number), Default=0
         * TimeLag: Set the timelag of the cavities, Default=0. Can be scalar
@@ -170,7 +170,6 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
     Returns:
         ring (Lattice):    Simple ring
     """
-
     # compute slip factor
     gamma = energy / e_mass
     eta = alpha - 1/gamma**2
@@ -202,15 +201,15 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
     s_dphi_y = numpy.sin(2*numpy.pi*Qy)
     c_dphi_y = numpy.cos(2*numpy.pi*Qy)
 
-    M00 = c_dphi_x + alpha_x * s_dphi_x
-    M01 = beta_x * s_dphi_x
-    M10 = -(1. + alpha_x**2) / beta_x * s_dphi_x
-    M11 = c_dphi_x - alpha_x * s_dphi_x
+    M00 = c_dphi_x + alphax * s_dphi_x
+    M01 = betax * s_dphi_x
+    M10 = -(1. + alphax**2) / betax * s_dphi_x
+    M11 = c_dphi_x - alphax * s_dphi_x
 
-    M22 = c_dphi_y + alpha_y * s_dphi_y
-    M23 = beta_y * s_dphi_y
-    M32 = -(1. + alpha_y**2) / beta_y * s_dphi_y
-    M33 = c_dphi_y - alpha_y * s_dphi_y
+    M22 = c_dphi_y + alphay * s_dphi_y
+    M23 = betay * s_dphi_y
+    M32 = -(1. + alphay**2) / betay * s_dphi_y
+    M33 = c_dphi_y - alphay * s_dphi_y
 
     M44 = 1.
     M45 = 0.
@@ -230,15 +229,15 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
     lin_elem = M66('Linear', m66=Mat66, Length=circumference)
 
     # Generate the simple quantum diffusion element
-    quantdiff = SimpleQuantDiff('SQD', beta_x=beta_x, beta_y=beta_y,
-                                emit_x=emit_x, emit_y=emit_y,
-                                sigma_dp=sigma_dp, tau_x=tau_x,
-                                tau_y=tau_y, tau_z=tau_z, U0=U0)
+    quantdiff = SimpleQuantDiff('SQD', betax=betax, betay=betay,
+                                emitx=emitx, emity=emity,
+                                espread=espread, taux=taux,
+                                tauy=tauy, tauz=tauz, U0=U0)
 
     # Generate the detuning element
     nonlin_elem = Element('NonLinear', PassMethod='DeltaQPass',
-                          Betax=beta_x, Betay=beta_y,
-                          Alphax=alpha_x, Alphay=alpha_y,
+                          Betax=betax, Betay=betay,
+                          Alphax=alphax, Alphay=alphay,
                           Qpx=Qpx, Qpy=Qpy,
                           A1=A1, A2=A2, A3=A3)
 

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -105,15 +105,15 @@ def fast_ring(ring: Lattice, split_inds=[]) -> Tuple[Lattice, Lattice]:
 
 def simple_ring(energy: float, circumference: float, harmonic_number: int,
                 Qx: float, Qy: float, Vrf: float, alpha: float,
-                betax: Optional[float]=1.0, betay: Optional[float]=1.0,
-                alphax: Optional[float]=0.0, alphay: Optional[float]=0.0,
-                Qpx: Optional[float]=0.0, Qpy: Optional[float]=0.0,
-                A1: Optional[float]=0.0, A2: Optional[float]=0.0,
-                A3: Optional[float]=0.0, emitx: Optional[float]=0.0,
-                emity: Optional[float]=0.0, espread: Optional[float]=0.0,
-                taux: Optional[float]=0.0, tauy: Optional[float]=0.0,
-                tauz: Optional[float]=0.0, U0: Optional[float]=0.0,
-                TimeLag: Optional[bool]=False
+                betax: float = 1.0, betay: float = 1.0,
+                alphax: float = 0.0, alphay: float = 0.0,
+                Qpx: float = 0.0, Qpy: float = 0.0,
+                A1: float = 0.0, A2: float = 0.0,
+                A3: float = 0.0, emitx: float = 0.0,
+                emity: float = 0.0, espread: float = 0.0,
+                taux: float = 0.0, tauy: float = 0.0,
+                tauz: float = 0.0, U0: float = 0.0,
+                TimeLag: bool = False
                 ):
     """Generates a "simple ring" based on a given dictionary
        of global parameters

--- a/pyat/examples/CollectiveEffects/LongDistribution.py
+++ b/pyat/examples/CollectiveEffects/LongDistribution.py
@@ -78,7 +78,7 @@ id0 = 0
 for t in numpy.arange(Nturns):
     if t % 1000 == 0:
         print('Tracking turn ', t, ' of ', Nturns)
-    at.track_function(fring, part)
+    fring.track(part, in_place=True)
 
     if t > Nturns-numAve:
 


### PR DESCRIPTION
This PR addresses the main comments from @lfarv in #647 . However I would like to discuss a bit the other comments.

I don't feel that there is any added value allowing a twiss_in input for simple_ring. In order to generate a twiss_in style input, you need a ring to begin with. In this case it is much easier to use fast_ring to generate your new ring and not bother using simple_ring.

I cannot really envisage a scenario where I might have only the output of some tracking results (a sigma matrix) and then I have to find an equivalent lattice to give me these parameters (where I still have to provide tunes and other non-linear parameters). 
 