### PR TITLE
Correct the attribute name of solenoids in Matlab

### DIFF
--- a/atmat/Contents.m
+++ b/atmat/Contents.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.4.1 (#656) 18-Sep-2023
+% Version 2.4.1 (#663) 22-Sep-2023
 %
 %   atdiag           - Tests AT intallation
 %   atdisplay        - checks the verbosity level in the global variable GLOBVAL

--- a/atmat/at.m
+++ b/atmat/at.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.4.1 (#656) 18-Sep-2023
+% Version 2.4.1 (#663) 22-Sep-2023
 %
 % The Accelerator Toolbox was originally created by Andrei Terebilo.
 % Development is now continued by a multi-laboratory collaboration, <a href="matlab:web('https://github.com/atcollab')">atcollab</a>
@@ -140,4 +140,4 @@
 %
 %       <a href="matlab:help symplectify">symplectify</a>              - Makes a matrix more symplectic
 %
-%<a href="matlab:web('/Applications/MATLAB_R2023a.app/help/3ptoolbox/atacceleratortoolbox/doc/AT_page.html')">See documentation for AT</a>
+%<a href="matlab:web('/Applications/MATLAB_R2023b.app/help/3ptoolbox/atacceleratortoolbox/doc/AT_page.html')">See documentation for AT</a>

--- a/atmat/lattice/element_creation/atsolenoid.m
+++ b/atmat/lattice/element_creation/atsolenoid.m
@@ -31,13 +31,14 @@ function Elem=atsolenoid(fname,varargin)
 %          atthinmultipole, atmarker, atcorrector
 
 % Input parser for option
-[rsrc,L,KS,method]  = decodeatargs({0,0,'SolenoidLinearPass'},varargin);
+[rsrc,L,K,method]   = decodeatargs({0,0,'SolenoidLinearPass'},varargin);
 [L,rsrc]            = getoption(rsrc,'Length',L);
-[KS,rsrc]           = getoption(rsrc,'KS',KS);
+[K,rsrc]            = getoption(rsrc,'KS',K);  % Kept for compatibilty
+[K,rsrc]            = getoption(rsrc,'K',K);   % Correct attribute name
 [method,rsrc]       = getoption(rsrc,'PassMethod',method);
 [cl,rsrc]           = getoption(rsrc,'Class','Solenoid');
 
 % Gradient setting if not specified explicitly
 Elem=atbaselem(fname,method,'Class',cl,'Length',L,...
-    'KS',KS,rsrc{:});
+    'K',K,rsrc{:});
 end


### PR DESCRIPTION
Fixes #660 reported by @simoneliuzzo: the strength of a solenoid should be `K` instead of `KS`.
In `atsolenoid`, the strength may be inout either in the 3rd positional argument (no problem), but also as keyword `KS`. This is kept for compatibility, and the correct `K` keyword is added: any can be used.