### PR TITLE
Collective bugfix

### DIFF
--- a/pyat/at/collective/beam_loading.py
+++ b/pyat/at/collective/beam_loading.py
@@ -112,8 +112,6 @@ class BeamLoadingElement(RFCavity, Collective):
                         _beta=float, _wakefact=float, _nslice=int,
                         ZCuts=lambda v: _array(v),
                         _nturns=int, _phis=float,
-                        _turnhistory=lambda v: _array(v),
-                        _vbunch=lambda v: _array(v),
                         _vbeam_phasor=lambda v: _array(v, shape=(2,)),
                         _vbeam=lambda v: _array(v, shape=(2,)),
                         _vcav=lambda v: _array(v, shape=(2,)),

--- a/pyat/at/collective/beam_loading.py
+++ b/pyat/at/collective/beam_loading.py
@@ -207,6 +207,32 @@ class BeamLoadingElement(RFCavity, Collective):
                                    numpy.pi-psi])
 
     @property
+    def Nslice(self):
+        """Number of slices per bunch"""
+        return self._nslice
+
+    @Nslice.setter
+    def Nslice(self, nslice):
+        self._nslice = nslice
+        self.clear_history()
+
+    @property
+    def Nturns(self):
+        """Number of turn for the wake field"""
+        return self._nturns
+
+    @Nturns.setter
+    def Nturns(self, nturns):
+        self._nturns = nturns
+        self.clear_history()
+
+    @property
+    def TurnHistory(self):
+        """Turn history of the slices center of mass"""
+        return self._turnhistory
+
+
+    @property
     def ResFrequency(self):
         """Resonator frequency"""
         return self.Frequency/(1-numpy.tan(self.Vgen[1])/(2*self.Qfactor))

--- a/pyat/at/tracking/utils.py
+++ b/pyat/at/tracking/utils.py
@@ -67,7 +67,7 @@ def initialize_lpass(lattice: Iterable[Element], nturns: int,
     """Function to initialize keyword arguments for lattice tracking"""
     if not isinstance(lattice, list):
         lattice = list(lattice)
-    unfoldbeam = kwargs.pop('unfold_beam', False)
+    unfoldbeam = kwargs.pop('unfold_beam', True)
     nbunch, bspos, bcurrents = _get_bunch_config(lattice, unfoldbeam)
     kwargs.update(bunch_currents=bcurrents, bunch_spos=bspos)
     no_bm = _set_beam_monitors(lattice, nbunch, nturns)

--- a/pyat/examples/CollectiveEffects/BeamLoading.py
+++ b/pyat/examples/CollectiveEffects/BeamLoading.py
@@ -113,7 +113,7 @@ for i in numpy.arange(Nturns):
     if i == kickTurn:
         part[4, :] += 3e-3
 
-    at.track_function(fring, part, nturns=1)
+    fring.track(part, nturns=1, refpts=None, in_place=True)
 
     # Gather particles over all cores (compatible with MPI on or off)
     allPartsg = comm.gather(part)
@@ -132,7 +132,8 @@ for i in numpy.arange(Nturns):
 if rank == 0:
     qscoh = numpy.zeros(Nbunches)
     for ib in numpy.arange(Nbunches):
-        qs = harmonic_analysis.get_tunes_harmonic(dp_all[kickTurn:, ib],
+        dp_dat = dp_all[kickTurn:, ib] - numpy.mean(dp_all[kickTurn:, ib])
+        qs = harmonic_analysis.get_tunes_harmonic(dp_dat,
                                                   num_harmonics=20,
                                                   fmin=1e-5, fmax=0.1)
         qscoh[ib] = qs

--- a/pyat/examples/CollectiveEffects/LCBI_run.py
+++ b/pyat/examples/CollectiveEffects/LCBI_run.py
@@ -82,7 +82,7 @@ def launch():
     part[4, :] = 0
     part[5, :] = 0
 
-    at.track_function(fring, part, nturns=nturns)
+    fring.track(part, nturns=nturns, refpts=None, in_place=True)
 
     dp_all = bmon.means[4, :, :]
     z_all = bmon.means[5, :, :]

--- a/pyat/examples/CollectiveEffects/LongDistribution.py
+++ b/pyat/examples/CollectiveEffects/LongDistribution.py
@@ -78,7 +78,7 @@ id0 = 0
 for t in numpy.arange(Nturns):
     if t % 1000 == 0:
         print('Tracking turn ', t, ' of ', Nturns)
-    fring.track(part, in_place=True)
+    fring.track(part, in_place=True, refpts=None)
 
     if t > Nturns-numAve:
 

--- a/pyat/examples/CollectiveEffects/RobinsonInstability.py
+++ b/pyat/examples/CollectiveEffects/RobinsonInstability.py
@@ -48,7 +48,7 @@ fring.append(bmon)
 sigm = at.sigma_matrix(ring.radiation_on(copy=True))
 part = at.beam(Npart, sigm)
 
-at.track_function(fring, part, nturns=nturns)
+fring.track(part, nturns=nturns, refpts=None, in_place=True)
 
 dp_all = bmon.means[4, 0, :]
 

--- a/pyat/examples/CollectiveEffects/TRW_run.py
+++ b/pyat/examples/CollectiveEffects/TRW_run.py
@@ -90,7 +90,7 @@ def launch():
     part[0, :] = 1e-6
     part[1, :] = 0
 
-    at.track_function(fring, part, nturns=nturns)
+    fring.track(part, nturns=nturns, refpts=None, in_place=True)
 
     x_all = bmon.means[0, :, :]
     xp_all = bmon.means[1, :, :]


### PR DESCRIPTION
Hello,

Sneaky bug was introduced with the new tracking interface. Unfold beam default was wrongly set, this meant that for the last month, the bunch_spos that was passed to the PassMethod was an array of zeros. All multibunch simulations completely wrong.

I also take this opportunity to fix two other minor things.

1. removal of the couple of the array conversions in BeamLoadingElement. It was squashing the arrays to a 1d array instead of keeping the good shape. (TurnHistory and Vbunch).
2. BeamLoadingElement did not inherit from WakeElement, which is fine but there were a few features that were not taken over. I stole a couple of properties to do with Nslice / Nturns and TurnHistory and copied them onto the BeamLoadingElement.

