### PR TITLE
Bug fix in atgeometry

### DIFF
--- a/atmat/Contents.m
+++ b/atmat/Contents.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.4.1 (#657) 18-Sep-2023
+% Version 2.4.1 (#667) 05-Oct-2023
 %
 %   atdiag           - Tests AT intallation
 %   atdisplay        - checks the verbosity level in the global variable GLOBVAL

--- a/atmat/at.m
+++ b/atmat/at.m
@@ -1,5 +1,5 @@
 % Accelerator Toolbox
-% Version 2.4.1 (#657) 18-Sep-2023
+% Version 2.4.1 (#667) 05-Oct-2023
 %
 % The Accelerator Toolbox was originally created by Andrei Terebilo.
 % Development is now continued by a multi-laboratory collaboration, <a href="matlab:web('https://github.com/atcollab')">atcollab</a>

--- a/atmat/lattice/survey/atgeometry.m
+++ b/atmat/lattice/survey/atgeometry.m
@@ -20,7 +20,7 @@ function  [posdata,radius] = atgeometry(ring,varargin)
 %       a scalar offset value is equivalent to [0 OFFSET]
 %
 %POSDATA=ATGEOMETRY(...,'centered')
-%       The offset is set as [0 RADIUS 0]
+%       The offset is set as [0 RADIUS]
 %
 %POSDATA=ATGEOMETRY(...,'Hangle',h_angle)
 %       Set the initial trajectory angle
@@ -28,11 +28,12 @@ function  [posdata,radius] = atgeometry(ring,varargin)
 %
 %See also: ATGEOMETRY3
 
-[thetac,args]=getoption(varargin,'Hangle',0);
-centered=getflag(args,'centered');
-[refpts,offset]=parseargs({1:length(ring)+1,[0 0]},args);
+[centered,args]=getflag(varargin,'centered');
+[theta0,args]=getoption(args,'Hangle',0);
+[refpts,offset]=getargs(args,1:length(ring)+1,[0 0]);
 xc=0;
 yc=0;
+thetac=theta0;
 if isscalar(offset)
     yc=offset;
 else
@@ -40,9 +41,10 @@ else
     yc=offset(2);
 end
 [xx,yy,txy,lg,tr]=cellfun(@incr,[{struct()};ring]);    % Add a dummy element to get the origin
-radius=-(yc+xc/tan(thetac));
+radius=-(yc+xc/tan(thetac-theta0));
 if centered
-    yy=yy+radius;
+    xx=xx-radius*sin(theta0);
+    yy=yy+radius*cos(theta0);
 end
 posdata=struct('x',num2cell(xx(refpts)),'y',num2cell(yy(refpts)),...
     'angle',num2cell(txy(refpts)),'long',num2cell(lg(refpts)),...

--- a/atmat/lattice/survey/atgeometry.m
+++ b/atmat/lattice/survey/atgeometry.m
@@ -40,7 +40,7 @@ if isscalar(offset)
     offset=[0 offset];
 end
 [xx,yy,txy,lg,tr]=cellfun(@incr,[{struct()};ring]);    % Add a dummy element to get the origin
-dff=mod(thetac+epsil, 2*pi)+epsil;
+dff=mod(thetac+epsil, 2*pi)-epsil;
 if abs(dff) < epsil         % Full ring
     xcenter=mean(xx);
     ycenter=mean(yy);

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -355,7 +355,7 @@ def uint32_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
-                     endpoint: bool = True, regex=False) -> Uint32Refpts:
+                     endpoint: bool = True, regex: bool = False) -> Uint32Refpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns an integer array of element indices, selecting ring elements.
 
@@ -364,8 +364,8 @@ def get_uint32_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         uint32_ref (Uint32Refpts): uint32 numpy array used for indexing
@@ -456,7 +456,7 @@ def bool_refpts(refpts: RefIndex, n_elements: int,
 
 # noinspection PyIncorrectDocstring
 def get_bool_index(ring: Sequence[Element], refpts: Refpts,
-                   endpoint: bool = True, regex=False) -> BoolRefpts:
+                   endpoint: bool = True, regex: bool = False) -> BoolRefpts:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns a bool array of element indices, selecting ring elements.
 
@@ -465,8 +465,8 @@ def get_bool_index(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         bool_refs (BoolRefpts):  A bool numpy array used for indexing
@@ -576,7 +576,7 @@ def checktype(eltype: Union[type, Tuple[type, ...]]) -> ElementFilter:
     return lambda el: isinstance(el, eltype)
 
 
-def checkname(pattern: str, regex=False) -> ElementFilter:
+def checkname(pattern: str, regex: bool = False) -> ElementFilter:
     # noinspection PyUnresolvedReferences
     r"""Checks the name of an element
 
@@ -588,8 +588,8 @@ def checkname(pattern: str, regex=False) -> ElementFilter:
     Parameters:
         pattern: Desired :py:class:`.Element` name. Unix shell-style
           wildcards are supported (see :py:func:`fnmatch.fnmatch`)
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         checkfun (ElementFilter):   Element filter function
@@ -607,7 +607,7 @@ def checkname(pattern: str, regex=False) -> ElementFilter:
         return lambda el: fnmatch(el.FamName, pattern)
 
 
-def refpts_iterator(ring: Sequence[Element], refpts: Refpts, regex=False) \
+def refpts_iterator(ring: Sequence[Element], refpts: Refpts, regex: bool = False) \
         -> Iterator[Element]:
     r"""Return an iterator over selected elements in a lattice
 
@@ -615,8 +615,8 @@ def refpts_iterator(ring: Sequence[Element], refpts: Refpts, regex=False) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         elem_iter (Iterator[Element]):  Iterator over the elements in *ring*
@@ -688,7 +688,7 @@ def refpts_count(refpts: RefIndex, n_elements: int,
 
 
 def _refcount(ring: Sequence[Element], refpts: Refpts,
-              endpoint: bool = True, regex=False) -> int:
+              endpoint: bool = True, regex: bool = False) -> int:
     # noinspection PyUnresolvedReferences, PyShadowingNames
     r"""Returns the number of reference points
 
@@ -697,8 +697,8 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         endpoint:   if :py:obj:`True`, allow *len(ring)* as a
           special index, referring to the end of the last element.
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         nrefs (int):  The number of reference points
@@ -735,7 +735,7 @@ def _refcount(ring: Sequence[Element], refpts: Refpts,
 
 
 # noinspection PyUnusedLocal,PyIncorrectDocstring
-def get_elements(ring: Sequence[Element], refpts: Refpts, regex=False) \
+def get_elements(ring: Sequence[Element], refpts: Refpts, regex: bool = False) \
         -> list:
     r"""Returns a list of elements selected by *key*.
 
@@ -745,8 +745,8 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, regex=False) \
         ring:           Lattice description
         refpts:         Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         elem_list (list):  list of :py:class:`.Element`\ s matching key
@@ -755,7 +755,7 @@ def get_elements(ring: Sequence[Element], refpts: Refpts, regex=False) \
 
 
 def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
-                     attrname: str, index: Optional[int] = None, regex=False):
+                     attrname: str, index: Optional[int] = None, regex: bool = False):
     r"""Extracts attribute values from selected
         lattice :py:class:`.Element`\ s.
 
@@ -765,11 +765,9 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
           See ":ref:`Selecting elements in a lattice <refpts>`"
         attrname:   Attribute name
         index:      index of the value to retrieve if *attrname* is
-          an array.
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
-
-          If :py:obj:`None` the full array is retrieved
+          an array. If :py:obj:`None` the full array is retrieved
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         attrvalues: numpy Array of attribute values.
@@ -787,8 +785,8 @@ def get_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
 def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
                      attrname: str, attrvalues, index: Optional[int] = None,
-                     increment: Optional[bool] = False,
-                     copy: Optional[bool] = False, regex=False):
+                     increment: bool = False,
+                     copy: bool = False, regex: bool = False):
     r"""Set the values of an attribute of an array of elements based on
     their refpts
 
@@ -802,11 +800,9 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
         index:      index of the value to set if *attrname* is
           an array. if :py:obj:`None`, the full array is replaced by
           *attrvalue*
-        increment:  Add values to the initial values.
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
-
-          If :py:obj:`False` the initial value is replaced (Default)
+        increment:  If :py:obj:`True`, *attrvalues* are added to the initial values.
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
         copy:       If :py:obj:`False`, the modification is done in-place,
 
           If :py:obj:`True`, return a shallow copy of the lattice. Only the
@@ -816,7 +812,7 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
 
              a shallow copy means that all non-modified
              elements are shared with the original lattice.
-             Any further modification will affect in both lattices.
+             Any further modification will affect both lattices.
     """
     if index is None:
         def setf(elem, value):
@@ -841,7 +837,7 @@ def set_value_refpts(ring: Sequence[Element], refpts: Refpts,
     return apply(ring, refpts, attrvalues, regex)
 
 
-def get_s_pos(ring: Sequence[Element], refpts: Refpts = All, regex=False) \
+def get_s_pos(ring: Sequence[Element], refpts: Refpts = All, regex: bool = False) \
         -> Sequence[float]:
     # noinspection PyUnresolvedReferences
     r"""Returns the locations of selected elements
@@ -850,8 +846,8 @@ def get_s_pos(ring: Sequence[Element], refpts: Refpts = All, regex=False) \
         ring:       Lattice description
         refpts:     Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
-        regex: Use regular expression for refpts string matching;
-            Default: False (Unix shell-style wildcards)
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         s_pos:  Array of locations of the elements selected by *refpts*
@@ -969,7 +965,7 @@ def tilt_elem(elem: Element, rots: float, relative: bool = False) -> None:
 
 
 def shift_elem(elem: Element, deltax: float = 0.0, deltaz: float = 0.0,
-               relative: Optional[bool] = False) -> None:
+               relative: bool = False) -> None:
     r"""Sets the transverse displacement of an :py:class:`.Element`
 
     The translation vectors are stored in the :pycode:`T1` and :pycode:`T2`
@@ -1072,9 +1068,9 @@ def get_geometry(ring: List[Element],
        >>> geomdata, radius = get_geometry(ring)
     """
 
-    geom_dtype = [('x', numpy.float64),
-                  ('y', numpy.float64),
-                  ('angle', numpy.float64)]
+    geom_dtype = [("x", numpy.float64),
+                  ("y", numpy.float64),
+                  ("angle", numpy.float64)]
     geomdata = numpy.recarray((len(ring)+1, ), dtype=geom_dtype)
     xx = numpy.zeros(len(ring)+1)
     yy = numpy.zeros(len(ring)+1)
@@ -1120,7 +1116,7 @@ def get_geometry(ring: List[Element],
     else:
         xx += x0
         yy += y0
-    geomdata['x'] = xx
-    geomdata['y'] = yy
-    geomdata['angle'] = angle
+    geomdata["x"] = xx
+    geomdata["y"] = yy
+    geomdata["angle"] = angle
     return geomdata, radius

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -1043,17 +1043,24 @@ def set_shift(ring: Sequence[Element], dxs, dzs, relative=False) -> None:
 
 
 def get_geometry(ring: List[Element],
+                 refpts: Refpts = All,
                  start_coordinates: Tuple[float, float, float] = (0, 0, 0),
-                 centered: bool = False):
+                 centered: bool = False,
+                 regex: bool = False
+                 ):
     # noinspection PyShadowingNames
     r"""Compute the 2D ring geometry in cartesian coordinates
 
     Parameters:
         ring:               Lattice description.
+        refpts:     Element selection key.
+          See ":ref:`Selecting elements in a lattice <refpts>`"
         start_coordinates:  *x*, *y*, *angle* at starting point. *x* and *y* are
           ignored if *centered* is :py:obj:`True`.
         centered:           if :py:obj:`True` the coordinates origin is the
           center of the ring.
+        regex: Use regular expression for *refpts* string matching instead of
+          Unix shell-style wildcards.
 
     Returns:
         geomdata:           recarray containing, x, y, angle.
@@ -1071,7 +1078,9 @@ def get_geometry(ring: List[Element],
     geom_dtype = [("x", numpy.float64),
                   ("y", numpy.float64),
                   ("angle", numpy.float64)]
-    geomdata = numpy.recarray((len(ring)+1, ), dtype=geom_dtype)
+    boolrefs = get_bool_index(ring, refpts, endpoint=True, regex=regex)
+    nrefs = refpts_count(boolrefs, len(ring))
+    geomdata = numpy.recarray((nrefs, ), dtype=geom_dtype)
     xx = numpy.zeros(len(ring)+1)
     yy = numpy.zeros(len(ring)+1)
     angle = numpy.zeros(len(ring)+1)
@@ -1116,7 +1125,7 @@ def get_geometry(ring: List[Element],
     else:
         xx += x0
         yy += y0
-    geomdata["x"] = xx
-    geomdata["y"] = yy
-    geomdata["angle"] = angle
+    geomdata["x"] = xx[boolrefs]
+    geomdata["y"] = yy[boolrefs]
+    geomdata["angle"] = angle[boolrefs]
     return geomdata, radius

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -40,7 +40,7 @@ from itertools import compress
 from fnmatch import fnmatch
 from .elements import Element, Dipole
 
-_EPSIL = 1.0e-3
+_GEOMETRY_EPSIL = 1.0e-3
 
 ElementFilter = Callable[[Element], bool]
 BoolRefpts = numpy.ndarray
@@ -1097,11 +1097,11 @@ def get_geometry(ring: List[Element],
         yy[ind+1] = y
         angle[ind+1] = t
 
-    dff = (t+_EPSIL) % (2.0*numpy.pi) - _EPSIL
-    if abs(dff) < _EPSIL:
+    dff = (t + _GEOMETRY_EPSIL) % (2.0 * numpy.pi) - _GEOMETRY_EPSIL
+    if abs(dff) < _GEOMETRY_EPSIL:
         xcenter = numpy.mean(xx)
         ycenter = numpy.mean(yy)
-    elif abs(dff-numpy.pi) < _EPSIL:
+    elif abs(dff-numpy.pi) < _GEOMETRY_EPSIL:
         xcenter = 0.5*x
         ycenter = 0.5*y
     else:


### PR DESCRIPTION
Fixes a bug in `atgeometry` reported by @simoneliuzzo.

The `centered` flag now works as expected.

However, the computation of the radius is made using the 1st and last points. For a full ring, these points almost coincide, which makes the computation very imprecise. This happens for both Matlab and python.

For better results, the computation of the radius should be completely rewritten by taking all points into account (noting that this "polygonal" radius is not a constant…). This if left for another pull request.