### PR TITLE
parallelize get_tunes_harmonic

### DIFF
--- a/pyat/at/physics/frequency_maps.py
+++ b/pyat/at/physics/frequency_maps.py
@@ -205,28 +205,28 @@ def fmap_parallel_track(ring,
             # get the first turn in x
             xfirst = z1[0, 0:tns]
             xfirst = xfirst - numpy.mean(xfirst)
-            pxfirst = z1[1, 0:tns]
-            pxfirst = pxfirst - numpy.mean(pxfirst)
-            xfirstpart = xfirst + 1j*pxfirst
+            # pxfirst = z1[1, 0:tns]
+            # pxfirst = pxfirst - numpy.mean(pxfirst)
+            # xfirstpart = xfirst + 1j*pxfirst
             # get the last turns in x
             xlast = z1[0, tns:2*tns]
             xlast = xlast - numpy.mean(xlast)
-            pxlast = z1[1, tns:2*tns]
-            pxlast = pxlast - numpy.mean(pxlast)
-            xlastpart = xlast + 1j*pxlast
+            # pxlast = z1[1, tns:2*tns]
+            # pxlast = pxlast - numpy.mean(pxlast)
+            # xlastpart = xlast + 1j*pxlast
 
             # get the first turn in y
             yfirst = z1[2, 0:tns]
             yfirst = yfirst - numpy.mean(yfirst)
-            pyfirst = z1[3, 0:tns]
-            pyfirst = pyfirst - numpy.mean(pyfirst)
-            yfirstpart = yfirst + 1j*pyfirst
+            # pyfirst = z1[3, 0:tns]
+            # pyfirst = pyfirst - numpy.mean(pyfirst)
+            # yfirstpart = yfirst + 1j*pyfirst
             # get the last turns in y
             ylast = z1[2, tns:2*tns]
             ylast = ylast - numpy.mean(ylast)
-            pylast = z1[3, tns:2*tns]
-            pylast = pylast - numpy.mean(pylast)
-            ylastpart = ylast + 1j*pylast
+            # pylast = z1[3, tns:2*tns]
+            # pylast = pylast - numpy.mean(pylast)
+            # ylastpart = ylast + 1j*pylast
 
             # calc frequency from array,
             # jump the cycle is no frequency is found

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -187,17 +187,9 @@ def _get_main_single(cents, **kwargs):
             phases = numpy.nan
         return tunes, amps, phases
         
-    cents = numpy.array(cents)
-    if cents.ndim > 1:
-        npart = cents.shape[0]
-    else:
-        cents = [cents]
-        npart = 1
-    tunes = numpy.zeros(npart)
-    amps = numpy.zeros(npart)
-    phases = numpy.zeros(npart)
+    cents = numpy.atleast_2d(cents)
     results = [get_hmain(c) for c in cents]   
-    return numpy.array(results).T
+    return numpy.transpose(results)
     
 
 def _get_main_multi(cents, **kwargs):

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -266,6 +266,8 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
 
        * The tune is defined as the harmonic with the maximum amplitude within
          the search range ``(fmin, fmax)``.
+       * In case a ``Nan`` is present in the input vector or the tune cannot
+         be found within the range, the function returns ``NaN``.
        * For the method ``'interp_fft'``, harmonics are calculated iteratively
          starting from the maximum peak of the raw FFT. ``num_harmonics=1``
          is the default, only the first harmonic is calculated.
@@ -339,6 +341,8 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
 
        * The tune is defined as the harmonic with the maximum amplitude within
          the search range ``(fmin, fmax)``.
+       * In case a ``Nan`` is present in the input vector or the tune cannot
+         be found within the range, the function returns ``NaN``.
        * For the method ``'interp_fft'``, harmonics are calculated iteratively
          starting from the maximum peak of the raw FFT. ``num_harmonics=1``
          is the default, only the first harmonic is calculated.

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -209,8 +209,8 @@ def _get_main_multi(cents, **kwargs):
     ctx = multiprocessing.get_context(start_method)
     args = numpy.array_split(cents, pool_size, axis=0)
     with ctx.Pool(pool_size) as pool:
-        results = pool.map(partial(_get_main_single, **kwargs), cents)
-    results = [numpy.squeeze(results[:][i]) for i in range(3)]
+        results = pool.map(partial(_get_main_single, **kwargs), args) 
+    results = numpy.concatenate(results, axis=1)    
     return results
     
 

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -145,8 +145,8 @@ def get_spectrum_harmonic(cent: numpy.ndarray, method: str = 'interp_fft',
     ha_amp = numpy.abs(numpy.array(ha_amp)) / lc
     ha_tune = numpy.array(ha_tune)
     return ha_tune, ha_amp, ha_phase
-    
-    
+
+
 def _get_max_spectrum(freq, amp, phase, fmin, fmax, method):
     if method == 'interp_fft':
         return freq[0], amp[0], phase[0]
@@ -158,8 +158,8 @@ def _get_max_spectrum(freq, amp, phase, fmin, fmax, method):
     phase = phase[numpy.argmax(amp)]
     amp = numpy.amax(amp)
     return freq, amp, phase
-    
-   
+
+
 def _get_main_single(cents, **kwargs):
 
     def get_hmain(cents):
@@ -175,22 +175,22 @@ def _get_main_single(cents, **kwargs):
         except AtError:
             msg = ('No harmonic found within range, '
                    'consider extending it or increase maxiter')
-            warn(AtWarning(msg)) 
+            warn(AtWarning(msg))
             tunes = numpy.nan
             amps = numpy.nan
-            phases = numpy.nan        
+            phases = numpy.nan
         except ValueError:
             msg = ('Invalid input vector provided')
-            warn(AtWarning(msg)) 
+            warn(AtWarning(msg))
             tunes = numpy.nan
             amps = numpy.nan
             phases = numpy.nan
         return tunes, amps, phases
-        
+
     cents = numpy.atleast_2d(cents)
-    results = [get_hmain(c) for c in cents]   
+    results = [get_hmain(c) for c in cents]
     return numpy.transpose(results)
-    
+
 
 def _get_main_multi(cents, **kwargs):
     cents = numpy.array(cents)
@@ -201,14 +201,13 @@ def _get_main_multi(cents, **kwargs):
     else:
         return _get_main_single(cents, **kwargs)
     if pool_size is None:
-       pool_size = min(npart, multiprocessing.cpu_count())
+        pool_size = min(npart, multiprocessing.cpu_count())
     ctx = multiprocessing.get_context(start_method)
     fun = partial(_get_main_single, **kwargs)
     with ctx.Pool(pool_size) as pool:
-        results = pool.map(fun, cents) 
-    results = numpy.concatenate(results, axis=1)    
+        results = pool.map(fun, cents)
+    results = numpy.concatenate(results, axis=1)
     return results
-    
 
 
 def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
@@ -249,7 +248,7 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
         phase (ndarray): (len(cents), ) array of phases
                          corresponding to the tune
     """
-    if use_mp:       
+    if use_mp:
         tunes, amps, phases = _get_main_multi(cents, num_harmonics=1,
                                               method=method, hann=hann,
                                               pad_length=pad_length,

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -51,8 +51,8 @@ def _compute_coef(samples, freq):
     """
     n = len(samples)
     exponents = numpy.exp(-2j*numpy.pi * freq * numpy.arange(n))
-    coef = numpy.sum(exponents * samples)
-    return coef / n
+    coef = numpy.sum(exponents * samples)/n
+    return coef
 
 
 def _interpolated_fft(samples, num_harmonics, fmin, fmax,
@@ -216,6 +216,7 @@ def _get_main_multi(cents, **kwargs):
 def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                       hann: bool = False,
                       fmin: float = 0, fmax: float = 1,
+                      num_harmonics: int = 1,
                       maxiter: float = 10,
                       pad_length=None,
                       use_mp: bool = False,
@@ -224,7 +225,9 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                       remove_mean: bool = True) -> tuple[numpy.ndarray,
                                                          numpy.ndarray,
                                                          numpy.ndarray]:
-    """Computes tunes, amplitudes and pahses from harmonic analysis
+    """Computes tunes, amplitudes and phases from harmonic analysis
+    The tune is defined as the harmonic with the maximum amplitude
+    within the search range.
 
     Parameters:
         cents:          Centroid motions of the particle
@@ -232,6 +235,8 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                         Default: ``'interp_fft'``
         fmin:           Lower bound for tune search
         fmax:           Upper bound for tune search
+        num_harmonics   Number of harmonics to search for.
+                        Default=1.
         maxiter:        Maximum number of iterations for the search
         hann:           Turn on Hanning window. Default: :py:obj:`False`.
                         Ignored for interpolated FFT
@@ -257,7 +262,8 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                          corresponding to the tune
     """
     if use_mp:
-        tunes, amps, phases = _get_main_multi(cents, num_harmonics=1,
+        tunes, amps, phases = _get_main_multi(cents,
+                                              num_harmonics=num_harmonics,
                                               method=method, hann=hann,
                                               pad_length=pad_length,
                                               fmin=fmin, fmax=fmax,
@@ -266,7 +272,8 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                                               start_method=start_method,
                                               remove_mean=remove_mean)
     else:
-        tunes, amps, phases = _get_main_single(cents, num_harmonics=1,
+        tunes, amps, phases = _get_main_single(cents,
+                                               num_harmonics=num_harmonics,
                                                method=method, hann=hann,
                                                pad_length=pad_length,
                                                fmin=fmin, fmax=fmax,
@@ -278,6 +285,7 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
 def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                        hann: bool = False,
                        fmin: float = 0, fmax: float = 1,
+                       num_harmonics: int = 1,
                        maxiter: float = 10,
                        pad_length=None,
                        use_mp: bool = False,
@@ -285,7 +293,8 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                        start_method: str = None,
                        remove_mean: bool = True,
                        **kwargs) -> numpy.ndarray:
-    """Computes tunes from harmonic analysis
+    """Computes tunes from harmonic analysis. The tune is defined
+    as the harmonic with the maximum amplitude within the search range.
 
     Parameters:
         cents:          Centroid motions of the particle
@@ -293,6 +302,8 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                         Default: ``'interp_fft'``
         fmin:           Lower bound for tune search
         fmax:           Upper bound for tune search
+        num_harmonics   Number of harmonics to search for.
+                        Default=1.
         maxiter:        Maximum number of iterations for the search
         hann:           Turn on Hanning window. Default: :py:obj:`False`.
                         Ignored for interpolated FFT
@@ -313,13 +324,10 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
         tunes (ndarray):    numpy array of length len(cents), max of the
         spectrum within [fmin fmax]
     """
-    num_harmonics = kwargs.pop('num_harmonics', 1)  # Backward compatibility
-    if num_harmonics != 1:
-        msg = "num_harmonics is deprecated and ignored for tune calculation"
-        warn(AtWarning(msg))
     tunes, _, _ = get_main_harmonic(cents, method=method, hann=hann, fmin=fmin,
                                     fmax=fmax, pad_length=pad_length,
                                     use_mp=use_mp, pool_size=pool_size,
                                     start_method=start_method, maxiter=maxiter,
-                                    remove_mean=remove_mean)
+                                    remove_mean=remove_mean,
+                                    num_harmonics=num_harmonics)
     return tunes

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -235,7 +235,7 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                         Default: ``'interp_fft'``
         fmin:           Lower bound for tune search
         fmax:           Upper bound for tune search
-        num_harmonics   Number of harmonics to search for.
+        num_harmonics:  Number of harmonics to search for.
                         Default=1.
         maxiter:        Maximum number of iterations for the search
         hann:           Turn on Hanning window. Default: :py:obj:`False`.
@@ -260,6 +260,18 @@ def get_main_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                              corresponding to the tune
         phase (ndarray): (len(cents), ) array of phases
                          corresponding to the tune
+
+
+    .. note::
+
+       * The tune is defined as the harmonic with the maximum amplitude within
+         the search range ``(fmin, fmax)``.
+       * For the method ``'interp_fft'``, harmonics are calculated iteratively
+         starting from the maximum peak of the raw FFT. ``num_harmonics=1``
+         is the default, only the first harmonic is calculated.
+         However, it is possible that the maximum of the interpolated
+         FFT does not correspond to the maximum of the raw FFT, in which case
+         ``num_harmonics`` has to be increased to get the correct peak.
     """
     if use_mp:
         tunes, amps, phases = _get_main_multi(cents,
@@ -293,8 +305,7 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                        start_method: str = None,
                        remove_mean: bool = True,
                        **kwargs) -> numpy.ndarray:
-    """Computes tunes from harmonic analysis. The tune is defined
-    as the harmonic with the maximum amplitude within the search range.
+    """Computes tunes from harmonic analysis.
 
     Parameters:
         cents:          Centroid motions of the particle
@@ -302,11 +313,11 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
                         Default: ``'interp_fft'``
         fmin:           Lower bound for tune search
         fmax:           Upper bound for tune search
-        num_harmonics   Number of harmonics to search for.
+        num_harmonics:  Number of harmonics to search for.
                         Default=1.
         maxiter:        Maximum number of iterations for the search
         hann:           Turn on Hanning window. Default: :py:obj:`False`.
-                        Ignored for interpolated FFT
+                        Ignored for interpolated FFT.
         pad_length:     Zero pad the input signal.
                         Rounded to the higher power of 2
                         Ignored for interpolated FFT
@@ -323,6 +334,17 @@ def get_tunes_harmonic(cents: numpy.ndarray, method: str = 'interp_fft',
     Returns:
         tunes (ndarray):    numpy array of length len(cents), max of the
         spectrum within [fmin fmax]
+
+    .. note::
+
+       * The tune is defined as the harmonic with the maximum amplitude within
+         the search range ``(fmin, fmax)``.
+       * For the method ``'interp_fft'``, harmonics are calculated iteratively
+         starting from the maximum peak of the raw FFT. ``num_harmonics=1``
+         is the default, only the first harmonic is calculated.
+         However, it is possible that the maximum of the interpolated
+         FFT does not correspond to the maximum of the raw FFT, in which case
+         ``num_harmonics`` has to be increased to get the correct peak.
     """
     tunes, _, _ = get_main_harmonic(cents, method=method, hann=hann, fmin=fmin,
                                     fmax=fmax, pad_length=pad_length,

--- a/pyat/at/physics/harmonic_analysis.py
+++ b/pyat/at/physics/harmonic_analysis.py
@@ -206,7 +206,6 @@ def _get_main_multi(cents, **kwargs):
     fun = partial(_get_main_single, **kwargs)
     with ctx.Pool(pool_size) as pool:
         results = pool.map(fun, cents) 
-    print(numpy.shape(results))
     results = numpy.concatenate(results, axis=1)    
     return results
     

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -136,6 +136,7 @@ def lattice_track(lattice: Iterable[Element], r_in,
         losses (bool):          Boolean to activate loss maps output
         omp_num_threads (int):  Number of OpenMP threads
           (default: automatic)
+        use_mp (bool): Flag to activate multiprocessing (default: False)
         pool_size:              number of processes used when
           *use_mp* is :py:obj:`True`. If None, ``min(npart,nproc)``
           is used. It can be globally set using the variable


### PR DESCRIPTION
A parallelized version of get_tunes_harmonic based on python multiprocessing is proposed.

To be noted: it is important to load the processors to see some some speed-up. In case the workload per processor is too light you may adjust it with the pool_size argument (number of threads)