### PR TITLE
perf: improve by a factor ~ 10 the performance

### DIFF
--- a/atmat/atphysics/Radiation/ElementRadiation.m
+++ b/atmat/atphysics/Radiation/ElementRadiation.m
@@ -10,20 +10,18 @@ function [I1, I2, I3, I4, I5, I6, Iv] = ElementRadiation(ring, lindata, varargin
 
 [quadon, ~] = getoption(varargin, 'UseQuadrupoles', true);
 
-% Much faster with indices
-dipoleIdx = findcells(ring, 'BendingAngle');
-angle = atgetfieldvalues(ring, dipoleIdx, 'BendingAngle');
+% Look for dipole elements with non zero angles
 isdipole = atgetcells(ring, 'BendingAngle');
-isdipole(dipoleIdx) = isfinite(angle) & (angle ~= 0);
+angle = atgetfieldvalues(ring, isdipole, 'BendingAngle');
+isdipole(isdipole) = (angle ~= 0);
 
+% Look for quadrupole elements with non zero focusing
 if quadon
     isquadrupole = atgetcells(ring, 'Class', 'Quadrupole');
-    quadIdx = findcells(ring, 'Class', 'Quadrupole');
-    pb = atgetfieldvalues(ring, quadIdx, 'PolynomB', {2});
-    isquadrupole(quadIdx) = (pb ~= 0);
+    pb = atgetfieldvalues(ring, isquadrupole, 'PolynomB', {2});
+    isquadrupole(isquadrupole) = (pb ~= 0);
 
     iselement = isdipole | isquadrupole;
-
 else
     iselement = isdipole;
 end

--- a/atmat/atphysics/Radiation/ElementRadiation.m
+++ b/atmat/atphysics/Radiation/ElementRadiation.m
@@ -1,5 +1,5 @@
-function [I1,I2,I3,I4,I5,I6,Iv] = ElementRadiation(ring,lindata,varargin)
-%ELEMENTRADIATION	Compute the radiation integrals in dipoles
+function [I1, I2, I3, I4, I5, I6, Iv] = ElementRadiation(ring, lindata, varargin)
+%ELEMENTRADIATION - Compute the radiation integrals in dipoles
 %and quadrupoles
 
 % Analytical integration from:
@@ -8,140 +8,162 @@ function [I1,I2,I3,I4,I5,I6,Iv] = ElementRadiation(ring,lindata,varargin)
 % R.H. Helm, M.J. Lee, P.L. Morton and M. Sands
 % SLAC-PUB-1193, March 1973
 
-[quadon, ~]=getoption(varargin,'UseQuadrupoles', true);
-angle=atgetfieldvalues(ring,'BendingAngle');
-isdipole=isfinite(angle) & (angle~=0);
+[quadon, ~] = getoption(varargin, 'UseQuadrupoles', true);
+
+% Much faster with indices
+dipoleIdx = findcells(ring, 'BendingAngle');
+angle = atgetfieldvalues(ring, dipoleIdx, 'BendingAngle');
+isdipole = atgetcells(ring, 'BendingAngle');
+isdipole(dipoleIdx) = isfinite(angle) & (angle ~= 0);
 
 if quadon
-    class=atgetcells(ring,'Class','Quadrupole');
-    pb = atgetfieldvalues(ring,'PolynomB',{2});
-    isquadrupole=class & (pb~=0);
+    isquadrupole = atgetcells(ring, 'Class', 'Quadrupole');
+    quadIdx = findcells(ring, 'Class', 'Quadrupole');
+    pb = atgetfieldvalues(ring, quadIdx, 'PolynomB', {2});
+    isquadrupole(quadIdx) = (pb ~= 0);
+
     iselement = isdipole | isquadrupole;
+
 else
     iselement = isdipole;
 end
-vini=lindata([iselement;false])';
-vend=lindata([false;iselement])';
 
-[di1,di2,di3,di4,di5,di6,div]=cellfun(@elrad,ring(iselement),num2cell(vini),num2cell(vend));
-I1=sum(di1);
-I2=sum(di2);
-I3=sum(di3);
-I4=sum(di4);
-I5=sum(di5);
-I6=sum(di6);
-Iv=sum(div);
+vini = lindata([iselement; false])';
+vend = lindata([false; iselement])';
 
-    function [di1,di2,di3,di4,di5,di6,div]=elrad(elem,dini,dend)
-        betax0 = dini.beta(1);
-        betaz0 = dini.beta(2);
-        alphax0 = dini.alpha(1);
-        eta0 = dini.Dispersion(1);
-        etap0 = dini.Dispersion(2);
-        try
-            theta = elem.BendingAngle;
-        catch
-            xpi = dini.ClosedOrbit(2)/(1+dini.ClosedOrbit(5));
-            xpo = dend.ClosedOrbit(2)/(1+dini.ClosedOrbit(5));
-            theta = xpi-xpo;
-        end
-        if abs(theta)<1.0e-7
-            di1 = 0.0;
-            di2 = 0.0;
-            di3 = 0.0;
-            di4 = 0.0;
-            di5 = 0.0;
-            di6 = 0.0;
-            div = 0.0;
-            return
-        end
-        try
-            ange = elem.EntranceAngle;
-        catch
-            ange = 0.0;
-        end
-        try
-            ango = elem.ExitAngle;
-        catch
-            ango = 0.0;
-        end
-        ll = elem.Length;       
-        rho = ll / theta;
-        rho2 = rho * rho;
-        K = getfoc(elem);
-        kx2 = K + 1.0/rho2;
-        kz2 = -K;
-        eps1 = tan(ange) / rho;
-        eps2 = tan(ango) / rho;
+[di1, di2, di3, di4, di5, di6, div] = cellfun(@elrad, ring(iselement), num2cell(vini), num2cell(vend));
+I1 = sum(di1);
+I2 = sum(di2);
+I3 = sum(di3);
+I4 = sum(di4);
+I5 = sum(di5);
+I6 = sum(di6);
+Iv = sum(div);
 
-        eta3 = dend.Dispersion(1);
-        alphax1 = alphax0 - betax0*eps1;
-        gammax1 = (1.0 + alphax1 * alphax1) / betax0;
-        alphaz1 = dini.alpha(2) + betaz0*eps1;
-        alphaz2 = dend.alpha(2) - dend.beta(2)*eps2;
-        gammaz1 = (1.0 + alphaz1*alphaz1) / betaz0;
-        etap1 = etap0 + eta0*eps1;
-        etap2 = dend.Dispersion(2) - eta3*eps2;
+function [di1, di2, di3, di4, di5, di6, div] = elrad(elem, dini, dend)
+    betax0 = dini.beta(1);
+    betaz0 = dini.beta(2);
+    alphax0 = dini.alpha(1);
+    eta0 = dini.Dispersion(1);
+    etap0 = dini.Dispersion(2);
 
-        h0 = gammax1*eta0*eta0 + 2.0*alphax1*eta0*etap1 + betax0*etap1*etap1;
-
-        if kx2 ~= 0.0
-            if kx2 > 0.0         % Focusing
-                kl = ll * sqrt(kx2);
-                ss = sin(kl) / kl;
-                cc = cos(kl);
-            else                % Defocusing
-                kl = ll * sqrt(-kx2);
-                ss = sinh(kl) / kl;
-                cc = cosh(kl);
-            end
-            eta_ave = (theta - (etap2 - etap1)) / kx2 / ll;
-            bb = 2.0 * (alphax1*eta0 + betax0*etap1) * rho;
-            aa = -2.0 * (alphax1*etap1 + gammax1*eta0) * rho;
-            h_ave = h0 + (aa * (1.0-ss) + bb * (1.0-cc) / ll ...
-                          + gammax1 * (3.0-4.0*ss+ss*cc) / 2.0 / kx2 ...
-                          - alphax1 * (1.0-cc)^2 / kx2 / ll ...
-                          + betax0 * (1.0-ss*cc) / 2.0 ...
-                          ) / kx2 / rho2;
-        else
-            eta_ave = 0.5 * (eta0 + eta3) - ll*ll / 12.0 / rho;
-            hp0 = 2.0 * (alphax1 * eta0 + betax0 * etap1) / rho;
-            h2p0 = 2.0 * (-alphax1*etap1 + betax0/rho - gammax1*eta0) / rho;
-            h_ave = h0 + hp0*ll/2.0 + h2p0*ll*ll/6.0 ...
-                - alphax1*ll^3/4.0/rho2 ...
-                + gammax1*ll^4/20.0/rho2;
-        end
-        if kz2 ~= 0.0
-            bz_ave=(gammaz1 + kz2*betaz0 + (alphaz2-alphaz1)/ll)/2/kz2;
-        else
-            bz_ave=betaz0-alphaz1*ll + gammaz1*ll*ll/3;
-        end
-
-        di1 = eta_ave * ll / rho;
-        di2 = ll / rho2;
-        di3 = ll / abs(rho) / rho2;
-        di4 = eta_ave * ll * (2.0*K+1.0/rho2) / rho ...
-            - (eta0*eps1 + eta3*eps2)/rho;
-        di5 = h_ave * ll / abs(rho) / rho2;
-        di6 = kz2^2*eta_ave^2*ll;
-        div = abs(theta)/rho2*bz_ave;
+    try
+        theta = elem.BendingAngle;
+    catch
+        xpi = dini.ClosedOrbit(2) / (1 + dini.ClosedOrbit(5));
+        xpo = dend.ClosedOrbit(2) / (1 + dini.ClosedOrbit(5));
+        theta = xpi - xpo;
     end
 
-    function K=getfoc(elem)
-        if isfield(elem,'PolynomB') && length(elem.PolynomB) >= 2
-            K = elem.PolynomB(2);
-            if isfield(elem,'K') && elem.K ~= K
-                warning('AT:InconsistentK',...
-                'Values in K and PolynomB(2) are different. Using PolynomB(2)');
-            end
-        elseif isfield(elem,'K')
-            K = elem.K;
-            if K ~= 0
-                warning('AT:InconsistentK','PolynomB(2) is missing. Using K');
-            end
-        else
-            K = 0;
-        end
+    if abs(theta) < 1.0e-7
+        di1 = 0.0;
+        di2 = 0.0;
+        di3 = 0.0;
+        di4 = 0.0;
+        di5 = 0.0;
+        di6 = 0.0;
+        div = 0.0;
+        return
     end
+
+    try
+        ange = elem.EntranceAngle;
+    catch
+        ange = 0.0;
+    end
+
+    try
+        ango = elem.ExitAngle;
+    catch
+        ango = 0.0;
+    end
+
+    ll = elem.Length;
+    rho = ll / theta;
+    rho2 = rho * rho;
+    K = getfoc(elem);
+    kx2 = K + 1.0 / rho2;
+    kz2 = -K;
+    eps1 = tan(ange) / rho;
+    eps2 = tan(ango) / rho;
+
+    eta3 = dend.Dispersion(1);
+    alphax1 = alphax0 - betax0 * eps1;
+    gammax1 = (1.0 + alphax1 * alphax1) / betax0;
+    alphaz1 = dini.alpha(2) + betaz0 * eps1;
+    alphaz2 = dend.alpha(2) - dend.beta(2) * eps2;
+    gammaz1 = (1.0 + alphaz1 * alphaz1) / betaz0;
+    etap1 = etap0 + eta0 * eps1;
+    etap2 = dend.Dispersion(2) - eta3 * eps2;
+
+    h0 = gammax1 * eta0 * eta0 + 2.0 * alphax1 * eta0 * etap1 + betax0 * etap1 * etap1;
+
+    if kx2 ~= 0.0
+
+        if kx2 > 0.0 % Focusing
+            kl = ll * sqrt(kx2);
+            ss = sin(kl) / kl;
+            cc = cos(kl);
+        else % Defocusing
+            kl = ll * sqrt(-kx2);
+            ss = sinh(kl) / kl;
+            cc = cosh(kl);
+        end
+
+        eta_ave = (theta - (etap2 - etap1)) / kx2 / ll;
+        bb = 2.0 * (alphax1 * eta0 + betax0 * etap1) * rho;
+        aa = -2.0 * (alphax1 * etap1 + gammax1 * eta0) * rho;
+        h_ave = h0 + (aa * (1.0 - ss) + bb * (1.0 - cc) / ll ...
+            + gammax1 * (3.0 - 4.0 * ss + ss * cc) / 2.0 / kx2 ...
+            - alphax1 * (1.0 - cc) ^ 2 / kx2 / ll ...
+            + betax0 * (1.0 - ss * cc) / 2.0 ...
+        ) / kx2 / rho2;
+    else
+        eta_ave = 0.5 * (eta0 + eta3) - ll * ll / 12.0 / rho;
+        hp0 = 2.0 * (alphax1 * eta0 + betax0 * etap1) / rho;
+        h2p0 = 2.0 * (-alphax1 * etap1 + betax0 / rho - gammax1 * eta0) / rho;
+        h_ave = h0 + hp0 * ll / 2.0 + h2p0 * ll * ll / 6.0 ...
+            - alphax1 * ll ^ 3/4.0 / rho2 ...
+            + gammax1 * ll ^ 4/20.0 / rho2;
+    end
+
+    if kz2 ~= 0.0
+        bz_ave = (gammaz1 + kz2 * betaz0 + (alphaz2 - alphaz1) / ll) / 2 / kz2;
+    else
+        bz_ave = betaz0 - alphaz1 * ll + gammaz1 * ll * ll / 3;
+    end
+
+    di1 = eta_ave * ll / rho;
+    di2 = ll / rho2;
+    di3 = ll / abs(rho) / rho2;
+    di4 = eta_ave * ll * (2.0 * K + 1.0 / rho2) / rho ...
+        - (eta0 * eps1 + eta3 * eps2) / rho;
+    di5 = h_ave * ll / abs(rho) / rho2;
+    di6 = kz2 ^ 2 * eta_ave ^ 2 * ll;
+    div = abs(theta) / rho2 * bz_ave;
 end
 
+function K = getfoc(elem)
+
+    if isfield(elem, 'PolynomB') && length(elem.PolynomB) >= 2
+        K = elem.PolynomB(2);
+
+        if isfield(elem, 'K') && elem.K ~= K
+            warning('AT:InconsistentK', ...
+            'Values in K and PolynomB(2) are different. Using PolynomB(2)');
+        end
+
+    elseif isfield(elem, 'K')
+        K = elem.K;
+
+        if K ~= 0
+            warning('AT:InconsistentK', 'PolynomB(2) is missing. Using K');
+        end
+
+    else
+        K = 0;
+    end
+
+end
+
+end


### PR DESCRIPTION
key: using atgetfieldvalues with indices

Atsummary was very slow when calling ElementRadiation.

The main reason is the call of the function atgetfieldvalues for the full ring.
It is very slow if the full ring is used instead of the indices where the required field is present.

This a quick fix
% SLOW when elements do not have the 'BendingAngle'
% angle=atgetfieldvalues(ring,'BendingAngle');
% isdipole=isfinite(angle) & (angle~=0);

% Much faster with indices
dipoleIdx=findcells(ring,'BendingAngle');
angle=atgetfieldvalues(ring, dipoleIdx, 'BendingAngle');
isdipole = atgetcells(ring,'BendingAngle');
isdipole(dipoleIdx) = isfinite(angle) & (angle~=0);

This could be maybe improved evermore.
A a SOLEIL II lattice the gain to run atsummary is a factor 10 (1.5 s instead of 15 s).

**The 2 main modifications are when calling atgetfieldvalues for dipoles and quadrupole.**

The rest of the modifications are only style.