### PR TITLE
removes ByError from sbend help in matlab

### DIFF
--- a/atintegrators/sbend.m
+++ b/atintegrators/sbend.m
@@ -1,6 +1,6 @@
 function z=sbend(fname,L,A,A1,A2,K,method)
 %SBEND Creates a sector bend element in old AT versions (Obsolete)
-%BEND('FAMILYNAME',  Length[m], BendingAngle[rad], EntranceAngle[rad],
+%SBEND('FAMILYNAME',  Length[m], BendingAngle[rad], EntranceAngle[rad],
 %	ExitAngle[rad], K, 'METHOD')
 %	creates a new family in the FAMLIST - a structure with fields
 %		FamName        	family name

--- a/atintegrators/sbend.m
+++ b/atintegrators/sbend.m
@@ -8,7 +8,6 @@ function z=sbend(fname,L,A,A1,A2,K,method)
 %		BendingAngle		total bending angle [rad]
 %		EntranceAngle		[rad] (0 - for sector bends)
 %		ExitAngle			[rad] (0 - for sector bends)
-%		ByError				error in the dipole field relative to the design value 
 %		K						quadrupole K-value for combined funtion bends
 %		PassMethod        name of the function to use for tracking
 % returns assigned address in the FAMLIST that is uniquely identifies


### PR DESCRIPTION
This Pull Request solves issue #676  by removing ByError, and adding an S to BEND in the SBEND help.