### PR TITLE
Support of python 3.12, 64-bit wheels only 

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.0
+        uses: pypa/cibuildwheel@v2.16.2
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           if-no-files-found: error
 
   build_sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ doc = ["Sphinx ~= 7.2", "myst-parser", "myst-nb", "pydata-sphinx-theme ~= 0.14",
 
 [tool.cibuildwheel]
 # Pypy does not have Scipy so we cannot support it.
-build = ["cp3{7,8,9,10,11,12}*"]
+# build = ["cp3{7,8,9,10,11,12}*"]
+build = ["cp312*"]
 #skip = ["*-musllinux*", "*_i686", "*win32"]
 build-verbosity = "1"
 # "build" frontend fails on windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ doc = ["Sphinx ~= 7.2", "myst-parser", "myst-nb", "pydata-sphinx-theme ~= 0.14",
 # Pypy does not have Scipy so we cannot support it.
 # build = ["cp3{7,8,9,10,11,12}*"]
 build = ["cp312*"]
-#skip = ["*-musllinux*", "*_i686", "*win32"]
+skip = ["cp312-win32", "cp312-*_i686"]
 build-verbosity = "1"
 # "build" frontend fails on windows
 # build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.7"
 dependencies = [
@@ -39,8 +40,9 @@ Home="https://atcollab.github.io/at/"
 [project.optional-dependencies]
 mpi = ["mpi4py"]
 plot = ["matplotlib"]
-dev = ["pytest >= 2.9", "pytest-lazy-fixture", "pytest-cov", "flake8"]
-doc = ["Sphinx ~= 5.3", "myst-parser", "pydata-sphinx-theme ~= 0.11.0", "sphinx-copybutton"]
+dev = ["pytest >= 2.9", "pytest-lazy-fixture"]
+doc = ["Sphinx ~= 7.2", "myst-parser", "myst-nb", "pydata-sphinx-theme ~= 0.14",
+    "sphinx_design", "sphinx-copybutton"]
 
 # tool.setuptools is still in BETA, so we keep temporarily setup.cfg
 
@@ -57,7 +59,7 @@ doc = ["Sphinx ~= 5.3", "myst-parser", "pydata-sphinx-theme ~= 0.11.0", "sphinx-
 
 [tool.cibuildwheel]
 # Pypy does not have Scipy so we cannot support it.
-build = ["cp3{7,8,9,10,11}*"]
+build = ["cp3{7,8,9,10,11,12}*"]
 #skip = ["*-musllinux*", "*_i686", "*win32"]
 build-verbosity = "1"
 # "build" frontend fails on windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ doc = ["Sphinx ~= 7.2", "myst-parser", "myst-nb", "pydata-sphinx-theme ~= 0.14",
 
 [tool.cibuildwheel]
 # Pypy does not have Scipy so we cannot support it.
-# build = ["cp3{7,8,9,10,11,12}*"]
-build = ["cp312*"]
+build = ["cp3{7,8,9,10,11,12}*"]
+# Skip 32-bit builds starting with python 3.12
 skip = ["cp312-win32", "cp312-*_i686"]
 build-verbosity = "1"
 # "build" frontend fails on windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Home="https://atcollab.github.io/at/"
 [project.optional-dependencies]
 mpi = ["mpi4py"]
 plot = ["matplotlib"]
-dev = ["pytest >= 2.9", "pytest-lazy-fixture"]
+dev = ["pytest >= 2.9", "pytest-lazy-fixture", "pytest-cov", "flake8"]
 doc = ["Sphinx ~= 7.2", "myst-parser", "myst-nb", "pydata-sphinx-theme ~= 0.14",
     "sphinx_design", "sphinx-copybutton"]
 


### PR DESCRIPTION
python 3.12 is officially released, so it's now included in tests and in release builds.

Numpy does not provide 32-bit wheels (binary builds) for recent versions. It's therefore impossible to build 32-bit wheels for PyAT starting with python 3.12. We still provide 32-bit Windows and Linux builds for the previous python versions. But we may consider removing completely 32-bit builds in the future (building from source is still possible if needed).