### PR TITLE
Simple Ring modification to solve energy loss problems

### DIFF
--- a/atintegrators/SimpleQuantDiffPass.c
+++ b/atintegrators/SimpleQuantDiffPass.c
@@ -14,13 +14,11 @@ struct elem
   double betay;
   double sigma_xp;
   double sigma_yp;
-  double U0;
-  double EnergyLossFactor;
 };
 
 void SimpleQuantDiffPass(double *r_in,
            double sigma_xp, double sigma_yp, double espread,
-           double taux, double tauy, double tauz, double EnergyLossFactor,
+           double taux, double tauy, double tauz,
            pcg32_random_t* rng, int num_particles)
 
 {
@@ -36,27 +34,14 @@ void SimpleQuantDiffPass(double *r_in,
     }
     
     if(!atIsNaN(r6[0])) {
-      if(taux!=0.0) {
-        r6[1] -= 2*r6[1]/taux;
-      }
       if(sigma_xp!=0.0) {
         r6[1] += 2*sigma_xp*sqrt(1/taux)*randnorm[0];
       }
       if(sigma_yp!=0.0) {
         r6[3] += 2*sigma_yp*sqrt(1/tauy)*randnorm[1];
       }
-      if(tauy!=0.0) {
-        r6[3] -= 2*r6[3]/tauy;
-      }
       if(espread!=0.0) {
         r6[4] += 2*espread*sqrt(1/tauz)*randnorm[2];
-      }
-      if(tauz!=0.0) {
-        r6[4] -= 2*r6[4]/tauz;
-      }
-      
-      if(EnergyLossFactor>0.0) {
-        r6[4] -= EnergyLossFactor;
       }
     }
   }
@@ -68,7 +53,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 {
 /*  if (ElemData) {*/
         if (!Elem) {
-            double emitx, emity, espread, taux, tauy, tauz, betax, betay, U0, EnergyLossFactor;
+            double emitx, emity, espread, taux, tauy, tauz, betax, betay;
             emitx=atGetDouble(ElemData,"emitx"); check_error();
             emity=atGetDouble(ElemData,"emity"); check_error();
             espread=atGetDouble(ElemData,"espread"); check_error();
@@ -77,7 +62,6 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             tauz=atGetDouble(ElemData,"tauz"); check_error();
             betax=atGetDouble(ElemData,"betax"); check_error();
             betay=atGetDouble(ElemData,"betay"); check_error();
-            U0=atGetDouble(ElemData,"U0"); check_error();
             
             Elem = (struct elem*)atMalloc(sizeof(struct elem));
             Elem->emitx=emitx;
@@ -90,19 +74,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             Elem->betay=betay;
             Elem->sigma_xp=sqrt(emitx/betax);
             Elem->sigma_yp=sqrt(emity/betay);
-            Elem->U0=U0;
-            Elem->EnergyLossFactor=U0/Param->energy;
         }
-        SimpleQuantDiffPass(r_in, Elem->sigma_xp, Elem->sigma_yp, Elem->espread, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, Param->thread_rng, num_particles);
-/*  }
-    else {
-         atFree(Elem->T1);
-         atFree(Elem->T2);
-         atFree(Elem->R1);
-         atFree(Elem->R2);
-         atFree(Elem->EApertures);
-         atFree(Elem->RApertures);
-     }*/
+        SimpleQuantDiffPass(r_in, Elem->sigma_xp, Elem->sigma_yp, Elem->espread, Elem->taux, Elem->tauy, Elem->tauz, Param->thread_rng, num_particles);
     return Elem;
 }
 
@@ -117,7 +90,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         double *r_in;
         const mxArray *ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
-        double emitx, emity, espread, taux, tauy, tauz, betax, betay, sigma_xp, sigma_yp, U0, EnergyLossFactor;
+        double emitx, emity, espread, taux, tauy, tauz, betax, betay, sigma_xp, sigma_yp;
 
         emitx=atGetDouble(ElemData,"emitx"); check_error();
         emity=atGetDouble(ElemData,"emity"); check_error();
@@ -127,19 +100,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         tauz=atGetDouble(ElemData,"tauz"); check_error();
         betax=atGetDouble(ElemData,"betax"); check_error();  
         betay=atGetDouble(ElemData,"betay"); check_error();  
-        U0=atGetDouble(ElemData,"U0"); check_error();  
         sigma_xp=sqrt(emitx/betax);
         sigma_yp=sqrt(emity/betay);
-        EnergyLossFactor=U0/6e9;
         if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        SimpleQuantDiffPass(r_in, sigma_xp, sigma_yp, espread, taux, tauy, tauz, EnergyLossFactor, &pcg32_global, num_particles);
+        SimpleQuantDiffPass(r_in, sigma_xp, sigma_yp, espread, taux, tauy, tauz, &pcg32_global, num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */
-        plhs[0] = mxCreateCellMatrix(9,1);
+        plhs[0] = mxCreateCellMatrix(8,1);
         mxSetCell(plhs[0],0,mxCreateString("emitx"));
         mxSetCell(plhs[0],1,mxCreateString("emity"));
         mxSetCell(plhs[0],2,mxCreateString("espread"));
@@ -148,19 +119,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mxSetCell(plhs[0],5,mxCreateString("tauz"));
         mxSetCell(plhs[0],6,mxCreateString("betax"));
         mxSetCell(plhs[0],7,mxCreateString("betay"));
-        mxSetCell(plhs[0],8,mxCreateString("U0"));
         
-        
-        /*
-        if (nlhs>1) {
-            plhs[1] = mxCreateCellMatrix(6,1);
-            mxSetCell(plhs[1],0,mxCreateString("T1"));
-            mxSetCell(plhs[1],1,mxCreateString("T2"));
-            mxSetCell(plhs[1],2,mxCreateString("R1"));
-            mxSetCell(plhs[1],3,mxCreateString("R2"));
-            mxSetCell(plhs[1],4,mxCreateString("RApertures"));
-            mxSetCell(plhs[1],5,mxCreateString("EApertures"));
-        }*/
     }
     else {
         mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");

--- a/atintegrators/SimpleRadPass.c
+++ b/atintegrators/SimpleRadPass.c
@@ -59,11 +59,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             Elem->U0=U0;
             Elem->EnergyLossFactor=U0/Param->energy;
         }
-        SimpleQuantDiffPass(r_in, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, num_particles);
+        SimpleRadPass(r_in, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, num_particles);
     return Elem;
 }
 
-MODULE_DEF(SimpleQuantDiffPass)        /* Dummy module initialisation */
+MODULE_DEF(SimpleRadPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
@@ -85,7 +85,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        SimpleQuantDiffPass(r_in, taux, tauy, tauz, EnergyLossFactor, num_particles);
+        SimpleRadPass(r_in, taux, tauy, tauz, EnergyLossFactor, num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */

--- a/atintegrators/SimpleRadPass.c
+++ b/atintegrators/SimpleRadPass.c
@@ -1,0 +1,102 @@
+
+#include "atelem.c"
+#include "atrandom.c"
+
+struct elem 
+{
+  double taux;
+  double tauy;
+  double tauz;
+  double U0;
+  double EnergyLossFactor;
+};
+
+void SimpleRadPass(double *r_in,
+           double taux, double tauy, double tauz,
+           double EnergyLossFactor, int num_particles)
+
+{
+  double *r6;
+  int c, i;
+  
+  #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD*10) default(shared) shared(r_in,num_particles) private(c,r6)
+  for (c = 0; c<num_particles; c++) { /*Loop over particles  */
+    r6 = r_in+c*6;
+    
+    if(!atIsNaN(r6[0])) {
+      if(taux!=0.0) {
+        r6[1] -= 2*r6[1]/taux;
+      }
+      if(tauy!=0.0) {
+        r6[3] -= 2*r6[3]/tauy;
+      }
+      if(tauz!=0.0) {
+        r6[4] -= 2*r6[4]/tauz;
+      }
+      if(EnergyLossFactor>0.0) {
+        r6[4] -= EnergyLossFactor;
+      }
+    }
+  }
+}
+
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+                double *r_in, int num_particles, struct parameters *Param)
+{
+/*  if (ElemData) {*/
+        if (!Elem) {
+            double taux, tauy, tauz, U0, EnergyLossFactor;
+            taux=atGetDouble(ElemData,"taux"); check_error();
+            tauy=atGetDouble(ElemData,"tauy"); check_error();
+            tauz=atGetDouble(ElemData,"tauz"); check_error();
+            U0=atGetDouble(ElemData,"U0"); check_error();
+            
+            Elem = (struct elem*)atMalloc(sizeof(struct elem));
+            Elem->taux=taux;
+            Elem->tauy=tauy;
+            Elem->tauz=tauz;
+            Elem->U0=U0;
+            Elem->EnergyLossFactor=U0/Param->energy;
+        }
+        SimpleQuantDiffPass(r_in, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, num_particles);
+    return Elem;
+}
+
+MODULE_DEF(SimpleQuantDiffPass)        /* Dummy module initialisation */
+
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
+#if defined(MATLAB_MEX_FILE)
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+    if (nrhs == 2) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        double taux, tauy, tauz, U0, EnergyLossFactor;
+
+        taux=atGetDouble(ElemData,"taux"); check_error();
+        tauy=atGetDouble(ElemData,"tauy"); check_error();
+        tauz=atGetDouble(ElemData,"tauz"); check_error();
+        U0=atGetDouble(ElemData,"U0"); check_error();
+        EnergyLossFactor=U0/6e9;
+        if (mxGetM(prhs[1]) != 6) mexErrMsgIdAndTxt("AT:WrongArg","Second argument must be a 6 x N matrix");
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+        SimpleQuantDiffPass(r_in, taux, tauy, tauz, EnergyLossFactor, num_particles);
+    }
+    else if (nrhs == 0) {
+        /* list of required fields */
+        plhs[0] = mxCreateCellMatrix(4,1);
+        mxSetCell(plhs[0],0,mxCreateString("taux"));
+        mxSetCell(plhs[0],1,mxCreateString("tauy"));
+        mxSetCell(plhs[0],2,mxCreateString("tauz"));
+        mxSetCell(plhs[0],3,mxCreateString("U0"));        
+    }
+    else {
+        mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");
+    }
+}
+#endif /*defined(MATLAB_MEX_FILE)*/

--- a/atintegrators/SimpleRadiationPass.c
+++ b/atintegrators/SimpleRadiationPass.c
@@ -11,7 +11,7 @@ struct elem
   double EnergyLossFactor;
 };
 
-void SimpleRadPass(double *r_in,
+void SimpleRadiationPass(double *r_in,
            double taux, double tauy, double tauz,
            double EnergyLossFactor, int num_particles)
 
@@ -59,11 +59,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             Elem->U0=U0;
             Elem->EnergyLossFactor=U0/Param->energy;
         }
-        SimpleRadPass(r_in, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, num_particles);
+        SimpleRadiationPass(r_in, Elem->taux, Elem->tauy, Elem->tauz, Elem->EnergyLossFactor, num_particles);
     return Elem;
 }
 
-MODULE_DEF(SimpleRadPass)        /* Dummy module initialisation */
+MODULE_DEF(SimpleRadiationPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
@@ -85,7 +85,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        SimpleRadPass(r_in, taux, tauy, tauz, EnergyLossFactor, num_particles);
+        SimpleRadiationPass(r_in, taux, tauy, tauz, EnergyLossFactor, num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1050,10 +1050,10 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
         self.betay = betay
         super(SimpleQuantDiff, self).__init__(family_name, **kwargs)
 
-class SimpleRadiation(Radiative, Element):
+class SimpleRadiation(_DictLongtMotion, Element):
     """Simple radiation damping and energy loss"""
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
-    default_pass = {False: 'IdentityPass', True: 'SimpleRadPass'}
+    default_pass = {False: 'IdentityPass', True: 'SimpleRadiationPass'}
 
     def __init__(self, family_name: str, 
                  taux: float = 0.0, tauy: float = 0.0,
@@ -1069,7 +1069,7 @@ class SimpleRadiation(Radiative, Element):
             tauz:          Longitudinal damping time [turns]
             U0:            Energy loss per turn [eV]
             
-        Default PassMethod: ``SimpleRadPass``
+        Default PassMethod: ``SimpleRadiationPass``
        """
         kwargs.setdefault('PassMethod', self.default_pass[True])
        

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -990,7 +990,10 @@ class M66(Element):
 class SimpleQuantDiff(_DictLongtMotion, Element):
     """
     Linear tracking element for a simplified quantum diffusion,
-    radiation damping and energy loss
+    radiation damping and energy loss.
+    
+    Note: The damping times are needed to compute the correct
+    kick for the emittance. Radiation damping is NOT applied.
     """
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     default_pass = {False: 'IdentityPass', True: 'SimpleQuantDiffPass'}
@@ -999,7 +1002,7 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
                  betay: float = 1.0, emitx: float = 0.0,
                  emity: float = 0.0, espread: float = 0.0,
                  taux: float = 0.0, tauy: float = 0.0,
-                 tauz: float = 0.0, U0: float = 0.0,
+                 tauz: float = 0.0,
                  **kwargs):
         """
         Args:
@@ -1014,7 +1017,6 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
             taux:          Horizontal damping time [turns]
             tauy:          Vertical damping time [turns]
             tauz:          Longitudinal damping time [turns]
-            U0:             Energy Loss [eV]
             
         Default PassMethod: ``SimpleQuantDiffPass``
        """
@@ -1044,11 +1046,44 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
         if espread > 0.0:
             assert tauz > 0.0, 'if espread is given, tauz must be non zero'
             
-        self.U0 = U0
         self.betax = betax
         self.betay = betay
         super(SimpleQuantDiff, self).__init__(family_name, **kwargs)
 
+class SimpleRadiation(Radiative, Element):
+    """Simple radiation damping and energy loss"""
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
+    default_pass = {False: 'IdentityPass', True: 'SimpleRadPass'}
+
+    def __init__(self, family_name: str, 
+                 taux: float = 0.0, tauy: float = 0.0,
+                 tauz: float = 0.0, U0: float = 0.0,
+                 **kwargs):
+        """
+        Args:
+            family_name:    Name of the element
+            
+        Optional Args:
+            taux:          Horizontal damping time [turns]
+            tauy:          Vertical damping time [turns]
+            tauz:          Longitudinal damping time [turns]
+            U0:            Energy loss per turn [eV]
+            
+        Default PassMethod: ``SimpleRadPass``
+       """
+        kwargs.setdefault('PassMethod', self.default_pass[True])
+       
+        assert taux >= 0.0, 'taux must be greater than or equal to 0'
+        self.taux = taux
+            
+        assert tauy >= 0.0, 'tauy must be greater than or equal to 0'
+        self.tauy = tauy
+
+        assert tauz >= 0.0, 'tauz must be greater than or equal to 0'
+        self.tauz = tauz
+
+        self.U0 = U0            
+        super(SimpleRadiation, self).__init__(family_name, **kwargs)
 
 
 class Corrector(LongElement):

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -50,8 +50,8 @@ _DEFAULT_PASS = {
         ('collective_pass', elt.Collective, 'auto'),
         ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
         ('energyloss_pass', elt.EnergyLoss, 'auto'),
-        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto')
-        ('simplerad_pass', elt.SimpleRadiation, 'auto')
+        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto'),
+        ('simpleradiation_pass', elt.SimpleRadiation, 'auto')
     ),
     True: (
         ('cavity_pass', elt.RFCavity, 'auto'),
@@ -64,7 +64,7 @@ _DEFAULT_PASS = {
         ('collective_pass', elt.Collective, 'auto'),
         ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
         ('energyloss_pass', elt.EnergyLoss, 'auto'),
-        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto')
+        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto'),
         ('simpleradiation_pass', elt.SimpleRadiation, 'auto')
     )
 }

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -51,6 +51,7 @@ _DEFAULT_PASS = {
         ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
         ('energyloss_pass', elt.EnergyLoss, 'auto'),
         ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto')
+        ('simplerad_pass', elt.SimpleRadiation, 'auto')
     ),
     True: (
         ('cavity_pass', elt.RFCavity, 'auto'),
@@ -64,6 +65,7 @@ _DEFAULT_PASS = {
         ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
         ('energyloss_pass', elt.EnergyLoss, 'auto'),
         ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto')
+        ('simpleradiation_pass', elt.SimpleRadiation, 'auto')
     )
 }
 

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -6,7 +6,7 @@ import numpy
 from scipy.optimize import least_squares
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts, EnergyLoss
 from at.lattice import check_radiation, AtError, AtWarning
-from at.lattice import QuantumDiffusion, Collective
+from at.lattice import QuantumDiffusion, Collective, SimpleQuantDiff
 from at.lattice import get_bool_index, set_value_refpts
 from at.constants import clight, Cgamma
 from at.tracking import internal_lpass
@@ -76,7 +76,7 @@ def get_energy_loss(ring: Lattice,
         """Losses from tracking
         """
         ringtmp = ring.disable_6d(RFCavity, QuantumDiffusion, Collective,
-                                  copy=True)
+                                  SimpleQuantDiff, copy=True)
         o6 = numpy.squeeze(internal_lpass(ringtmp, numpy.zeros(6),
                                           refpts=len(ringtmp)))
         if numpy.isnan(o6[0]):

--- a/pyat/test/test_physics.py
+++ b/pyat/test/test_physics.py
@@ -325,7 +325,7 @@ def test_quantdiff(hmba_lattice):
 
 def test_simple_ring():
     ring = physics.simple_ring(6e9, 844, 992, 0.1, 0.2, 6e6, 8.5e-5)
-    assert_equal(len(ring), 4)
+    assert_equal(len(ring), 5)
     assert_equal(ring[-1].PassMethod, 'SimpleQuantDiffPass')
     ring.disable_6d()
     assert_equal(ring[-1].PassMethod, 'IdentityPass')


### PR DESCRIPTION
This is proposed as a solution to #694 .

Old simple ring contained:
`ring = [RF Cavity, M66 no rad, Nonlinear element, SimpleQuantDiff]`
where `SimpleQuantDiff `handled all radiation effects (damping, diffusion and U0)
This setup was problematic due to the fact that `get_energy_loss` could not compute the `U0` without the damping and diffusion, which had some other knock-on problems. 

Now simple ring contains:
`ring = [RF Cavity, M66 no rad, SimpleRadiation, Nonlinear element, SimpleQuantDiff]`
where `SimpleRadiation` is a new PassMethod that only performs U0 and radiation damping and `SimpleQuantDiff` has been modified to only act as the diffusion source for emittance. 

One possible problem that I want to draw to your attention, is that now we have 2 diffusion elements (QuantumDiffusion and SimpleQuantDiff) and I wonder if it is now more convenient to create a `Diffusion` class/group (not sure of the correct noun) and then each element has the property `is_diffusion` to enable cleaner code (for example you can see in `get_energy_loss` I have to mention both elements specifically.

 