### PR TITLE
set correct size for zero acceptance in grid and vector configuration

### DIFF
--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -264,7 +264,11 @@ def get_grid_boundary(mask, grid, config):
         msg = ("No particle survived, please check your grid "
                "or lattice. Acceptance set to [0.0, 0.0].")
         warnings.warn(AtWarning(msg))
-        return numpy.zeros((2, 1))
+        cnt = numpy.flip(config.shape)
+        if len(cnt) == 1:
+            return numpy.zeros(2)
+        else:
+            return numpy.zeros((2, 1))            
 
     if config.mode is GridMode.RADIAL:
         return radial_boundary(mask, grid)


### PR DESCRIPTION
This is a follow-up of #707 #714. No the correct shape is returned both for a vector or a grid. Hopefully this is the last iteration.