### PR TITLE
Update atsimplering in Matlab

### DIFF
--- a/atmat/atphysics/Radiation/atdisable_6d.m
+++ b/atmat/atphysics/Radiation/atdisable_6d.m
@@ -36,6 +36,8 @@ function [newring,radelemIndex,cavitiesIndex] = atdisable_6d(ring,varargin)
 %   'wigglerpass'	 pass method for wigglers. Default 'auto'
 %   'quantdiffpass'  pass method for quantum diffusion. Default 'auto'
 %   'energylosspass' pass method for atenergyloss element. Default 'auto'
+%   'simplequantdiffpass' pass method for SimpleQuantDiff element. Default 'auto'
+%   'simpleradiationpass' pass method for SimpleRadiation element. Default 'auto'
 %
 %   OUPUTS:
 %   1. NEWRING   Output ring
@@ -65,6 +67,8 @@ function [newring,radelemIndex,cavitiesIndex] = atdisable_6d(ring,varargin)
 [cavipass,varargs]=getoption(varargs,'cavipass',default_pass('auto'));
 [quantdiffpass,varargs]=getoption(varargs,'quantdiffpass',default_pass('auto'));
 [energylosspass,varargs]=getoption(varargs,'energylosspass',default_pass('auto'));
+[simplequantdiffpass,varargs]=getoption(varargs,'simplequantdiffpass',default_pass('auto'));
+[simpleradiationpass,varargs]=getoption(varargs,'simpleradiationpass',default_pass('auto'));
 % Process the positional arguments
 [cavipass,bendpass,quadpass]=getargs(varargs,cavipass,bendpass,quadpass);
 
@@ -77,6 +81,8 @@ modfun.Octupole=autoMultipolePass(octupass);
 modfun.Wiggler=autoMultipolePass(wigglerpass);
 modfun.QuantDiff=autoIdentityPass(quantdiffpass);
 modfun.EnergyLoss=autoIdentityPass(energylosspass);
+modfun.SimpleQuantDiff=autoIdentityPass(simplequantdiffpass);
+modfun.SimpleRadiation=autoIdentityPass(simpleradiationpass);
 modfun.Other=@(elem) elem;
 
 % Generate the new lattice

--- a/atmat/atphysics/Radiation/atenable_6d.m
+++ b/atmat/atphysics/Radiation/atenable_6d.m
@@ -37,6 +37,8 @@ function [newring,radelemIndex,cavitiesIndex,energy] = atenable_6d(ring,varargin
 %   'wigglerpass'    pass method for wigglers. Default 'auto'
 %   'quantdiffpass'  pass method for quantum radiation. default 'auto'
 %   'energylosspass' pass method for energyloss element. default 'auto'
+%   'simplequantdiffpass' pass method for SimpleQuantDiff element. Default 'auto'
+%   'simpleradiationpass' pass method for SimpleRadiation element. Default 'auto'
 %
 %  OUPUTS:
 %  1. NEWRING   Output ring
@@ -66,6 +68,8 @@ function [newring,radelemIndex,cavitiesIndex,energy] = atenable_6d(ring,varargin
 [cavipass,varargs]=getoption(varargs,'cavipass',default_pass('auto'));
 [quantdiffpass,varargs]=getoption(varargs,'quantdiffpass',default_pass('auto'));
 [energylosspass,varargs]=getoption(varargs,'energylosspass',default_pass('auto'));
+[simplequantdiffpass,varargs]=getoption(varargs,'simplequantdiffpass',default_pass('auto'));
+[simpleradiationpass,varargs]=getoption(varargs,'simpleradiationpass',default_pass('auto'));
 % Process the positional arguments
 [cavipass,bendpass,quadpass]=getargs(varargs,cavipass,bendpass,quadpass);
 
@@ -80,6 +84,8 @@ mod.Octupole=autoMultipolePass(octupass,energy);
 mod.Wiggler=autoMultipolePass(wigglerpass,energy);
 mod.QuantDiff=autoClassPass(quantdiffpass);
 mod.EnergyLoss=autoElemPass(energylosspass,'EnergyLossRadPass', energy);
+mod.SimpleQuantDiff=autoClassPass(simplequantdiffpass);
+mod.SimpleRadiation=autoClassPass(simpleradiationpass);
 mod.Other=@(elem) elem;
 
 % Generate the new lattice

--- a/atmat/atphysics/Radiation/atgetU0.m
+++ b/atmat/atphysics/Radiation/atgetU0.m
@@ -76,7 +76,8 @@ end
         % Ensure 6d is enabled
         check_6d(ring,true);
         % Turn cavities off
-        ringtmp=atdisable_6d(ring,'allpass','','cavipass','auto');
+        ringtmp=atdisable_6d(ring,'allpass','','cavipass','auto',...
+            'quantdiffpass','auto','simplequantdiffpass','auto');
         o0=zeros(6,1);
         o6=ringpass(ringtmp,o0);
         U0=-o6(5)*energy;

--- a/atmat/atphysics/Radiation/getclass_6d.m
+++ b/atmat/atphysics/Radiation/getclass_6d.m
@@ -24,10 +24,8 @@ elseif isfield(elem,'PolynomB') && elem.Length > 0
     end
 elseif isfield(elem,'Frequency')
     atclass='RFCavity';
-elseif isfield(elem,'Lmatp') || isfield(elem,'espread')
-    atclass='QuantDiff';
-elseif isfield(elem,'EnergyLoss')
-    atclass='EnergyLoss';
+elseif isfield(elem,'Class')
+    atclass=elem.Class;
 else
     atclass='Other';
 end

--- a/atmat/lattice/atguessclass.m
+++ b/atmat/lattice/atguessclass.m
@@ -54,6 +54,10 @@ elseif isfield(elem,'M66')
     else
         atclass='Matrix66';
     end
+elseif isfield(elem,'damp_mat_diag')
+    atclass='SimpleRadiation';
+elseif isfield(elem,'espread')
+    atclass='SimpleQuantDiff';
 elseif isfield(elem,'xtable')
     atclass='InsertionDeviceKickMap';
 elseif isfield(elem,'Length') && elem.Length~=0

--- a/atmat/lattice/atsimplering.m
+++ b/atmat/lattice/atsimplering.m
@@ -61,8 +61,7 @@ function ring = atsimplering(energy,circumference,hnum,...
 
 clight=PhysConstant.speed_of_light_in_vacuum.value;
 
-[particle,varargs]=getoption(varargin,'Particle',atparticle('relativistic'));
-[qpx,varargs]=getoption(varargs,'Qpx',0.0);
+[qpx,varargs]=getoption(varargin,'Qpx',0.0);
 [qpy,varargs]=getoption(varargs,'Qpy',0.0);
 [A1,varargs]=getoption(varargs,'A1',0.0);
 [A2,varargs]=getoption(varargs,'A2',0.0);
@@ -94,8 +93,6 @@ else
     emity=real(-1i*lambda(2));
 end
 
-gammainv=particle.rest_energy/energy;
-eta = alpha - gammainv*gammainv;
 [vrf,hnum]=broadcast(vrf(:),hnum(:));
 frf = hnum * clight / circumference;
 
@@ -111,7 +108,7 @@ m66(1,5)=(1.0-m66(1,1))*dispx - m66(1,2)*dispxp;
 m66(2,5)=-m66(2,1)*dispx + (1.0-m66(2,2))*dispxp;
 m66(3,5)=(1.0-m66(3,3))*dispy - m66(3,4)*dispyp;
 m66(4,5)=-m66(4,3)*dispy + (1.0-m66(4,4))*dispyp;
-m66(6,5)=eta*circumference;
+m66(6,5)=alpha*circumference;
 
 rf_cavity=cellfun(@makerf,num2cell(vrf),num2cell(frf),num2cell(hnum),'UniformOutput',false);
 lin_elem=atM66('Linear',m66,'Length',circumference);
@@ -127,7 +124,7 @@ quantdiff=atSimpleQuantDiff('SQD','betax',betax,'betay',betay,...
     'emitx',emitx,'emity',emity,'espread',espread,...
     'taux',taux,'tauy',tauy,'tauz',tauz);
 ring=atSetRingProperties([rf_cavity;{lin_elem; nonlin_elem; simple_rad; quantdiff}],...
-    'Energy',energy,'Periodicity',1,'Particle',particle,varargs{:});
+    'Energy',energy,'Periodicity',1,varargs{:});
 
     function rot=rotmat(q)
         cs=cos(2*pi*q);

--- a/atmat/lattice/atsimplering.m
+++ b/atmat/lattice/atsimplering.m
@@ -5,9 +5,10 @@ function ring = atsimplering(energy,circumference,hnum,...
 % A "simple ring" consists of:
 % - A RF cavity
 % - a 6x6 linear transfer map
+% - a simple radiation damping element
 % - a detuning and chromaticity element
 % - a simplified quantum diffusion element which provides the equilibrium
-% emittance, radiation damping and energy loss
+% emittance
 %
 %RING=ATSIMPLERING(ENERGY,CIRCUMFERENCE,HARMONIC_NUMBER,HTUNE,VTUNE,...
 %                  VRF,ALPHAC)
@@ -36,8 +37,14 @@ function ring = atsimplering(energy,circumference,hnum,...
 %RING=ATSIMPLERING(...,'betax',betax,'betay',betay,...)
 %       specify the beta values at origin [m]. Default: 1
 %
-%RING=ATSIMPLERING(...,'betax',betax,'betay',betay,...)
+%RING=ATSIMPLERING(...,'alphax',alphax,'alphay',alpha,...)
 %       specify the alpha values at origin. Default: 0
+%
+%RING=ATSIMPLERING(...,'dispx',dispx,'dispxp',dispxp,...)
+%       specify the horizontal dispersion and derivative at origin. Default: 0
+%
+%RING=ATSIMPLERING(...,'dispy',dispy,'dispyp',dispyp,...)
+%       specify the vertical dispersion and derivative at origin. Default: 0
 %
 %RING=ATSIMPLERING(...,'emitx',emitx,'emity',emity,...)
 %       specify the equilibrium emittance. Default: 0, meaning no quantum
@@ -45,6 +52,9 @@ function ring = atsimplering(energy,circumference,hnum,...
 %
 %RING=ATSIMPLERING(...,'taux',taux,'tauy',tauy,'tauz',tauz,...)
 %       specify the damping times. Default: 0, meaning no damping
+%
+%RING=ATSIMPLERING(...,'espread',espread,...)
+%       specify the energy spread. Default: 0
 %
 %RING=ATSIMPLERING(...,'U0',U0,...)
 %       specify the emergy loss per turn [eV]. Default: 0
@@ -61,7 +71,11 @@ clight=PhysConstant.speed_of_light_in_vacuum.value;
 [tauy,varargs]=getoption(varargs,'tauy',0.0);
 [tauz,varargs]=getoption(varargs,'tauz',0.0);
 [sigma,varargs]=getoption(varargs,'sigma',[]);
-[espread,varargs]=getoption(varargs,'Espread',0.0);
+[espread,varargs]=getoption(varargs,'espread',0.0);
+[dispx, varargs]=getoption(varargs,'dispx',0.0);
+[dispxp, varargs]=getoption(varargs,'dispxp',0.0);
+[dispy, varargs]=getoption(varargs,'dispy',0.0);
+[dispyp, varargs]=getoption(varargs,'dispyp',0.0);
 [U0,varargs]=getoption(varargs,'U0',0.0);
 if isempty(sigma)
     [alphax,varargs]=getoption(varargs,'alphax',0.0);
@@ -87,21 +101,32 @@ frf = hnum * clight / circumference;
 
 rots=blkdiag(rotmat(qx), rotmat(qy));
 
+dampx = damp(taux);
+dampy = damp(tauy);
+dampz = damp(tauz);
+
 m66=eye(6);
 m66(1:4,1:4)=am*rots/am;
+m66(1,5)=(1.0-m66(1,1))*dispx - m66(1,2)*dispxp;
+m66(2,5)=-m66(2,1)*dispx + (1.0-m66(2,2))*dispxp;
+m66(3,5)=(1.0-m66(3,3))*dispy - m66(3,4)*dispyp;
+m66(4,5)=-m66(4,3)*dispy + (1.0-m66(4,4))*dispyp;
 m66(6,5)=eta*circumference;
 
 rf_cavity=cellfun(@makerf,num2cell(vrf),num2cell(frf),num2cell(hnum),'UniformOutput',false);
 lin_elem=atM66('Linear',m66,'Length',circumference);
-nonlin_elem=atbaselem('NonLinear','DeltaQPass',...
+nonlin_elem=atbaselem('NonLinear','DeltaQPass','Class','NonLinear',...
     'Betax',betax,'Betay',betay,...
     'Alphax',alphax,'Alphay',alphay,...
     'Qpx',qpx,'Qpy',qpy,...
     'A1',A1,'A2',A2,'A3',A3);
+simple_rad = atbaselem('SR','SimpleRadiationPass','Class','SimpleRadiation',...
+    'dispx',dispx,'dispxp',dispxp,'dispy',dispy,'dispyp',dispyp,...
+    'damp_mat_diag',[dampx, dampx, dampy, dampy, dampz, dampz], 'U0', U0);
 quantdiff=atSimpleQuantDiff('SQD','betax',betax,'betay',betay,...
     'emitx',emitx,'emity',emity,'espread',espread,...
-    'taux',taux,'tauy',tauy,'tauz',tauz,'U0',U0);
-ring=atSetRingProperties([rf_cavity;{lin_elem;nonlin_elem;quantdiff}],...
+    'taux',taux,'tauy',tauy,'tauz',tauz);
+ring=atSetRingProperties([rf_cavity;{lin_elem; nonlin_elem; simple_rad; quantdiff}],...
     'Energy',energy,'Periodicity',1,'Particle',particle,varargs{:});
 
     function rot=rotmat(q)
@@ -119,6 +144,14 @@ ring=atSetRingProperties([rf_cavity;{lin_elem;nonlin_elem;quantdiff}],...
         nv=max(numel(v),numel(h));
         h(1:nv,1)=h;
         v(1:nv,1)=v;
+    end
+
+    function d = damp(tau)
+        if tau == 0.0
+            d = 1.0;
+        else
+            d = exp(-1.0/tau);
+        end
     end
 
     function cavity=makerf(v,f,h)

--- a/atmat/lattice/element_creation/atSimpleQuantDiff.m
+++ b/atmat/lattice/element_creation/atSimpleQuantDiff.m
@@ -4,32 +4,29 @@ function elem = atSimpleQuantDiff(fname,varargin)
 %ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...)
 %   FAMNAME:   family name
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Betax',BETAX,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'betax',BETAX,...)
 %   BETAX:   Horizontal beta function. Default: 1.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Betay',BETAY,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'betay',BETAY,...)
 %   BETAY:   Vertical beta function. Default: 1.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Emitx',EMITX,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'emitx',EMITX,...)
 %   EMITX:   Horizontal equilibrium emittance. Default: 0.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Emity',EMITY,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'emity',EMITY,...)
 %   EMITY:   Vertical equilibrium emittance. Default: 0.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Espread',ESPREAD,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'espread',ESPREAD,...)
 %   ESPREAD: Equilibrium momentum spread. Default: 0.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Taux',TAU_X,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'taux',TAU_X,...)
 %   TAU_X: Horizontal damping time. Default: 0.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Tauy',TAU_Y,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'tauy',TAU_Y,...)
 %   TAU_Y: Vertical damping time. Default: 0.0
 %
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'Tauz',TAU_Z,...)
+%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'tauz',TAU_Z,...)
 %   TAU_Z: Longitudinal damping time. Default: 0.0
-%
-%ELEM=ATSIMPLEQUANTDIFF(FAMNAME,...,'U0',U0,...)
-%   U0:     Energy loss [eV]. Default: 0.0
 
 [rsrc,method]=decodeatargs({'SimpleQuantDiffPass'},varargin);
 [method,rsrc]=getoption(rsrc,'PassMethod',method);
@@ -42,9 +39,8 @@ function elem = atSimpleQuantDiff(fname,varargin)
 [taux,rsrc]       = getoption(rsrc,'taux',0.0);
 [tauy,rsrc]       = getoption(rsrc,'tauy',0.0);
 [tauz,rsrc]       = getoption(rsrc,'tauz',0.0);
-[U0,rsrc]         = getoption(rsrc,'U0',0.0);
 elem=atbaselem(fname,method,'Class',cl,'betax',betax,'betay',betay,...
     'emitx',emitx,'emity',emity,'espread',espread,...
     'taux',taux,'tauy',tauy,'tauz',tauz,...
-    'U0',U0,rsrc{:});
+    rsrc{:});
 end


### PR DESCRIPTION
In #710, the passmethods used in "simple rings" were modified. This branch corrects the Matlab function `atsimplering`, to generate the same elements as in python: a `SimpleRadiation` and a `SimpleQuantDiffPass`.

These two elements are correctly handled in `atenable_6d`/`atdisable_6d`.