### PR TITLE
Fix a few "simple ring" problems

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1082,7 +1082,7 @@ class RFCavity(LongtMotion, LongElement):
 
 class M66(Element):
     """Linear (6, 6) transfer matrix"""
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["M66"]
     _conversions = dict(Element._conversions, M66=_array66)
 
     def __init__(self, family_name: str, m66=None, **kwargs):
@@ -1096,7 +1096,8 @@ class M66(Element):
         if m66 is None:
             m66 = numpy.identity(6)
         kwargs.setdefault('PassMethod', 'Matrix66Pass')
-        super(M66, self).__init__(family_name, M66=m66, **kwargs)
+        kwargs.setdefault("M66", m66)
+        super(M66, self).__init__(family_name, **kwargs)
 
 
 class SimpleQuantDiff(_DictLongtMotion, Element):
@@ -1165,7 +1166,10 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
 
 class SimpleRadiation(_DictLongtMotion, Radiative, Element):
     """Simple radiation damping and energy loss"""
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ['taux', 'tauy', 'tauz']
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
+    _conversions = dict(Element._conversions, U0=float,
+                        damp_mat_diag=lambda v: _array(v, shape=(6,)))
+
     default_pass = {False: 'IdentityPass', True: 'SimpleRadiationPass'}
 
     def __init__(self, family_name: str,
@@ -1184,8 +1188,6 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
 
         Default PassMethod: ``SimpleRadiationPass``
        """
-        kwargs.setdefault('PassMethod', self.default_pass[True])
-
         assert taux >= 0.0, 'taux must be greater than or equal to 0'
         if taux == 0.0:
             dampx = 1
@@ -1204,11 +1206,10 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
         else:
             dampz = numpy.exp(-1/tauz)
 
-        self.U0 = U0
-
-        self.damp_mat_diag = numpy.array([dampx, dampx,
-                                          dampy, dampy,
-                                          dampz, dampz])
+        kwargs.setdefault('PassMethod', self.default_pass[True])
+        kwargs.setdefault("U0", U0)
+        kwargs.setdefault("damp_mat_diag",
+                          numpy.array([dampx, dampx, dampy, dampy, dampz, dampz]))
 
         super(SimpleRadiation, self).__init__(family_name, **kwargs)
 

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -57,7 +57,8 @@ _alias_map = {'rbend': elt.Dipole,
               'ap': elt.Aperture,
               'ringparam': RingParam,
               'wig': elt.Wiggler,
-              'insertiondevicekickmap': idtable_element.InsertionDeviceKickMap
+              'insertiondevicekickmap': idtable_element.InsertionDeviceKickMap,
+              'matrix66': elt.M66,
               }
 
 
@@ -86,7 +87,8 @@ _param_to_lattice = {'Energy': 'energy', 'Periodicity': 'periodicity',
 # Python to Matlab class translation
 _matclass_map = {
         'Dipole': 'Bend',
-        'InsertionDeviceKickMap': 'InsertionDeviceKickMap'
+        'InsertionDeviceKickMap': 'InsertionDeviceKickMap',
+        'M66': 'Matrix66',
         }
 
 # Python to Matlab type translation

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -117,6 +117,7 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
                 emity: float = 0.0, espread: float = 0.0,
                 taux: float = 0.0, tauy: float = 0.0,
                 tauz: float = 0.0, U0: float = 0.0,
+                name: str = "",
                 particle: Union[str, Particle] = 'relativistic',
                 TimeLag: bool = False
                 ) -> Lattice:
@@ -166,6 +167,7 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
         tauz: longitudinal radiation damping time [turns], Default=0
           ignored if tauz=0
         U0: energy loss [eV] (positive number), Default=0
+        name: Name of the lattice
         particle: circulating particle. May be
           'relativistic', 'electron', 'positron', 'proton'
           or a Particle object
@@ -179,12 +181,6 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
     Returns:
         ring:    Simple ring
     """
-    if not isinstance(particle, Particle):
-        particle = Particle(particle)
-    # compute slip factor
-    gammainv = particle.rest_energy / energy
-    eta = alpha - gammainv*gammainv
-
     harmonic_number = numpy.atleast_1d(harmonic_number)
     Vrf = numpy.atleast_1d(Vrf)
     try:
@@ -231,7 +227,7 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
     
     M44 = 1.
     M45 = 0.
-    M54 = eta*circumference
+    M54 = alpha*circumference
     M55 = 1
 
     Mat66 = numpy.array([[M00, M01, 0., 0., M04, 0.],
@@ -267,6 +263,6 @@ def simple_ring(energy: float, circumference: float, harmonic_number: int,
 
     # Assemble all elements into the lattice object
     ring = Lattice(all_cavities + [lin_elem, nonlin_elem, simplerad, quantdiff],
-                   energy=energy, particle=particle, periodicity=1)
+                   name=name, energy=energy, particle=particle, periodicity=1)
 
     return ring


### PR DESCRIPTION
This fixes a few problems with simple rings:

#### 1. Momentum compaction
The momentum compaction is not exactly as specified: let's generate a ring with `alpha = 1.e-4`:
```python
ring=at.simple_ring(6e9, 844.39, 992, 0.21, 0.34, 6e6, 1.e-4)
ringnorad = ring.disable_6d(copy=True)
ringnorad.mcf
9.999274666869721e-05
```
The small difference comes from the fact that the M54 term of the linear transfer matrix is built using `eta`, slip factor. But the 6th coordinate is the path lengthening &beta;c&tau;, and not the delay. See how `alpha` is computed in `get_mcf`. Using alpha gives the correct result.

#### 2. `repr()` output of `SimpleRadiation` elements
Corrected so that evaluating the output string generates the correct element.

#### 2. Transfer of "simple rings" in .mat files
Simple rings are now correctly transferred through` .mat` files