### PR TITLE
set YLim when synopt is true

### DIFF
--- a/atmat/atplot/xplot.m
+++ b/atmat/atplot/xplot.m
@@ -65,6 +65,7 @@ end
 set(ax,'XLim',[smin smax],'XGrid','on','YGrid','on',leftargs{:});
 xlabel(ax,'s [m]');
 if synopt
+    if ax.YLim(1) > 0, ax.YLim(1) = 0; end % change YLim to see synopt
     curve.lattice=atplotsyn(ax,ring,varargs{:});  % Plot lattice elements
 end
 lines=[curve.left;curve.right];


### PR DESCRIPTION
Dear all,

this Pull Request addresses a small issue in AT matlab reported in #722 where the synoptics is not visible.

This PR sets the vertical Axis limits in order to display the synoptics.
