### PR TITLE
Fix Lattice.reduce

### DIFF
--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -14,8 +14,6 @@ from abc import ABC
 from collections.abc import Generator, Iterable
 from typing import Any, Optional
 
-import numpy as np
-
 
 def _array(value, shape=(-1,), dtype=numpy.float64):
     # Ensure proper ordering(F) and alignment(A) for "C" access in integrators
@@ -459,12 +457,12 @@ class LongElement(Element):
         def compatible_field(fieldname):
             f1 = getattr(self, fieldname, None)
             f2 = getattr(other, fieldname, None)
-            if f1 is None and f2 is None:   # no such field
+            if f1 is None and f2 is None:  # no such field
                 return True
             elif f1 is None or f2 is None:  # only one
                 return False
-            else:                           # both
-                return np.all(f1 == f2)
+            else:  # both
+                return numpy.all(f1 == f2)
 
         if not (type(other) is type(self) and self.PassMethod == other.PassMethod):
             return False

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -12,7 +12,9 @@ import numpy
 from copy import copy, deepcopy
 from abc import ABC
 from collections.abc import Generator, Iterable
-from typing import Optional
+from typing import Any, Optional
+
+import numpy as np
 
 
 def _array(value, shape=(-1,), dtype=numpy.float64):
@@ -371,7 +373,7 @@ class Element(object):
         """Return a deep copy of the element"""
         return deepcopy(self)
 
-    def items(self) -> Generator[tuple, None, None]:
+    def items(self) -> Generator[tuple[str, Any], None, None]:
         """Iterates through the data members"""
         for k, v in vars(self).items():
             yield k, v
@@ -454,8 +456,22 @@ class LongElement(Element):
         return element_list
 
     def is_compatible(self, other) -> bool:
-        return type(other) is type(self) and \
-               self.PassMethod == other.PassMethod
+        def compatible_field(fieldname):
+            f1 = getattr(self, fieldname, None)
+            f2 = getattr(other, fieldname, None)
+            if f1 is None and f2 is None:   # no such field
+                return True
+            elif f1 is None or f2 is None:  # only one
+                return False
+            else:                           # both
+                return np.all(f1 == f2)
+
+        if not (type(other) is type(self) and self.PassMethod == other.PassMethod):
+            return False
+        for fname in ("RApertures", "EApertures"):
+            if not compatible_field(fname):
+                return False
+        return True
 
     def merge(self, other) -> None:
         super().merge(other)


### PR DESCRIPTION
Fixes #732: @simoneliuzzo reported a different behaviour the "reduce" function between Matlab and python: in python, drifts with different `RApertures` or `EApertures` attributes are considered compatible and are merged by `Lattice.reduce()`

The resulting lattice behaves differently from the original one, so this is considered as a bug.

This PR solves this.

Side remark: the new `pytest` release (8.0.0) crashes in the AT sequence test. This looks related to a problem with `pytest_lazy_fixture`. We have to force "`pytest < 8.0.0`" temporarily until this is understood.