### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
+        cache: pip
 
     - name: Build and install at
       run: python -m pip install ".[plot, doc]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
+        cache: pip
 
     - name: Set up MATLAB
       uses: matlab-actions/setup-matlab@v1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -39,8 +39,8 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings. Options compatible with the 'black' code formatter
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --extend-ignore=E203,E704 --extend-select=W504 --per-file-ignores='*/__init__.py:F401,F403' --statistics
 
     - name: Test with pytest and coverage
       working-directory: pyat

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
 
     - name: Build and install at with tests
       run: python -m pip install -e ".[dev]"


### PR DESCRIPTION
- The action `setup-python` is updated v5 to avoid a warning:
  `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4.`
- The `flake8` options are modified for compatibility with the `black` code formatter. In particular, the recommended line length is set to 88,
- `pytest` is restricted to release <8 because the new version 8.0.0 make the test sequence crash.

Note that the Matlab actions (`setup-matlab` and `run-command`) are not yet upgraded to use Node.js 20, so they still trigger the warning.