### PR TITLE
Preserve the case of RingParam attribute names

### DIFF
--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -132,7 +132,7 @@ def ringparam_filter(
             ringparams.append(elem)
             for k, v in elem.items():
                 if k not in _param_ignore:
-                    params.setdefault(_param_to_lattice.get(k, k.lower()), v)
+                    params.setdefault(_param_to_lattice.get(k, k), v)
             if keep_all:
                 pars = vars(elem).copy()
                 name = pars.pop("FamName")
@@ -282,7 +282,7 @@ def load_var(matlat: Sequence[dict], **kwargs) -> Lattice:
 
 def matlab_ring(ring: Lattice) -> Generator[Element, None, None]:
     """Prepend a RingParam element to a lattice"""
-    dct = dict((_matattr_map.get(k, k.title()), v) for k, v in ring.attrs.items())
+    dct = dict((_matattr_map.get(k, k), v) for k, v in ring.attrs.items())
     famname = dct.pop("FamName")
     energy = dct.pop("Energy")
     yield RingParam(famname, energy, **dct)

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -10,8 +10,7 @@ from at.lattice import Lattice
 from at.load import register_format
 from at.load.utils import element_from_string
 # imports necessary in' globals()' for 'eval'
-# noinspection PyUnresolvedReferences
-from at.lattice import Particle
+from at.lattice import Particle  # noqa: F401
 
 __all__ = ['load_repr', 'save_repr']
 


### PR DESCRIPTION
This corrects a bug reported in #743: the name all unexpected attributes in a Matlab `RingParam` element is converted to lower case in the python `Lattice` object. When saving back to .mat or .m file, the attribute name is restored to a new `RingParam` element by capitalising its 1st letter. So the restored name may differ from the original name.

Now, the names of all unexpected attributes are kept unchanged between the Matlab `RingParam` element and the python `Lattice` object.