### PR TITLE
Fix .mat file loading

### DIFF
--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -182,7 +182,7 @@ def find_class(
             low = -1
         return low
 
-    class_name = elem_dict.get("Class", "")
+    class_name = elem_dict.pop("Class", "")
     try:
         return _CLASS_MAP[class_name.lower()]
     except KeyError:


### PR DESCRIPTION
This fixes a regression bug: when reading .mat files, the Matlab-specific "Class" attribute is kept in all elements. This is a leftover from tests in #744.

**This bug does not affect at all the behaviour of AT**, however the presence of this unexpected element attribute is disturbing.

The fix is obvious: a line is back to how it was previously, so please give a fast answer, thanks!