### PR TITLE
BugFix: normalization by 0 in get_timelag_fromU0

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -20,16 +20,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
 
     - uses: actions/checkout@v4
 
-    - name: Set up python 3.10
+    - name: Set up python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: pip
 
     - name: Set up MATLAB

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Set up python 3.9
+    - name: Set up python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         cache: pip
 
     - name: Set up MATLAB

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,6 +21,20 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
+        include:
+          - os: macos-13
+            python-version: '3.7'
+          - os: macos-13
+            python-version: '3.8'
+          - os: macos-13
+            python-version: '3.9'
+
 
     steps:
 

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -132,7 +132,10 @@ def get_timelag_fromU0(ring: Lattice,
 
     def eq(x, freq, rfv, tl0, u0):
         omf = 2*numpy.pi*freq/clight
-        eq1 = (numpy.sum(-rfv*numpy.sin(omf*(x-tl0)))-u0)/u0
+        if u0 > 0.0:
+            eq1 = (numpy.sum(-rfv*numpy.sin(omf*(x-tl0)))-u0)/u0
+        else:
+            eq1 = numpy.sum(-rfv * numpy.sin(omf * (x - tl0)))
         eq2 = numpy.sum(-omf*rfv*numpy.cos(omf*(x-tl0)))
         if eq2 > 0:
             return numpy.sqrt(eq1**2+eq2**2)


### PR DESCRIPTION
This PR is a follow-up of #757 
For multiple RF systems the synchronous phase is solved numerically. The system was normalized to U0 to prevent tolerance issues for the search of the stable point in the the presence of large energy loss per turn.
This normalization resulted in issue in get_timelag_fromU0 (called by findorbit6 and fastring) in the presence of multiple RF systems when radiations are off.
This issue is resolve by applying the normalization only when U0>0.