### PR TITLE
make_copy decorator not working for lattice defined as list

### DIFF
--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -282,7 +282,12 @@ def make_copy(copy: bool) -> Callable:
         def copy_decorator(func):
             @functools.wraps(func)
             def wrapper(ring, refpts, *args, **kwargs):
-                ring = ring.replace(refpts)
+                try:
+                    ring = ring.replace(refpts)
+                except AttributeError:
+                    check = get_bool_index(ring, refpts)
+                    ring = [el.deepcopy() if ok else el 
+                            for el, ok in zip(ring, check)]
                 func(ring, refpts, *args, **kwargs)
                 return ring
             return wrapper

--- a/pyat/at/tracking/utils.py
+++ b/pyat/at/tracking/utils.py
@@ -10,7 +10,7 @@ from ..lattice import Lattice, Element
 from ..lattice import BeamMoments, Collective, QuantumDiffusion
 from ..lattice import SimpleQuantDiff, VariableMultipole
 from ..lattice import elements, refpts_iterator, set_value_refpts
-from ..lattice import DConstant, checktype, get_bool_index
+from ..lattice import DConstant, checktype, checkattr, get_bool_index
 
 
 __all__ = ['fortran_align', 'get_bunches', 'format_results',
@@ -34,7 +34,10 @@ def _set_beam_monitors(ring: Sequence[Element], nbunch: int, nturns: int):
 
 
 def variable_refs(ring):
-    return get_bool_index(ring, checktype(_DISABLE_ELEMS))
+    idref = get_bool_index(ring, checkattr('PassMethod', 'IdentityPass'))
+    varref = get_bool_index(ring, checktype(_DISABLE_ELEMS))
+    varref = varref & ~idref
+    return varref
 
 
 def has_collective(ring) -> bool:


### PR DESCRIPTION
The make copy decorator in lattice/utils.py accepts list but uses the function ring.replace() that only works for lattice objects.
This was causing problems in the disable_varelem function in tracking/utils.py

Two corrective actions are proposed:
-disable element only when they vary and their passmethod is not already identitypass
-catch error in case the lattice is a list and do not use the replace() function

