### PR TITLE
Save and load lattices in JSON format

### DIFF
--- a/atmat/lattice/atdivelem.m
+++ b/atmat/lattice/atdivelem.m
@@ -37,8 +37,8 @@ if isfield(elem,'BendingAngle')
     line=atsetfieldvalues(line,'ExitAngle',0.0);
 end
 if isfield(elem,'KickAngle')
-    line=atsetfieldvalues(line,'KickAngle',{1,1},el.KickAngle(1,1)*frac(:)/sum(frac));
-    line=atsetfieldvalues(line,'KickAngle',{1,2},el.KickAngle(1,2)*frac(:)/sum(frac));
+    line=atsetfieldvalues(line,'KickAngle',{1},el.KickAngle(1)*frac(:)/sum(frac));
+    line=atsetfieldvalues(line,'KickAngle',{2},el.KickAngle(2)*frac(:)/sum(frac));
 end
 
 line{1}=mvfield(line{1},entrancef);     % Set back entrance fields

--- a/atmat/lattice/atloadlattice.m
+++ b/atmat/lattice/atloadlattice.m
@@ -83,14 +83,14 @@ lattice=atSetRingProperties(lattice,varargs{:});
 
     function [lattice, opts]=load_json(fpath, opts)
         data=jsondecode(fileread(fpath));
-        prms=data.parameters;
-        name=prms.name;
-        energy=prms.energy;
-        periodicity=prms.periodicity;
-        particle=atparticle.loadobj(prms.particle);
-        harmnumber=prms.harmonic_number;
-        prms=rmfield(prms,{'name','energy','periodicity','particle','harmonic_number'});
-        args=[fieldnames(prms) struct2cell(prms)]';
+        props=data.properties;
+        name=props.name;
+        energy=props.energy;
+        periodicity=props.periodicity;
+        particle=atparticle.loadobj(props.particle);
+        harmnumber=props.harmonic_number;
+        props=rmfield(props,{'name','energy','periodicity','particle','harmonic_number'});
+        args=[fieldnames(props) struct2cell(props)]';
         lattice=atSetRingProperties(data.elements,...
             'FamName', name,...
             'Energy', energy,...

--- a/atmat/lattice/atloadlattice.m
+++ b/atmat/lattice/atloadlattice.m
@@ -83,6 +83,12 @@ lattice=atSetRingProperties(lattice,varargs{:});
 
     function [lattice, opts]=load_json(fpath, opts)
         data=jsondecode(fileread(fpath));
+        % File signature for later use
+        try
+            atjson=data.atjson;
+        catch
+            atjson=1;
+        end
         props=data.properties;
         name=props.name;
         energy=props.energy;

--- a/atmat/lattice/atwritejson.m
+++ b/atmat/lattice/atwritejson.m
@@ -1,0 +1,64 @@
+function varargout=atwritejson(ring, varargin)
+%ATWRITEJSON Create a JSON file to store an AT lattice
+%
+%JS=ATWRITEJSON(RING)
+%   Return the JSON representation of RING as a character array
+%
+%ATWRITEJSON(RING, FILENAME)
+%   Write the JSON representation of RING to the file FILENAME
+%
+%ATWRITEJSON(RING, ..., 'compact', true)
+%   If compact is true, write a compact JSON file (no linefeeds)
+%
+%see also atloadlattice
+
+[compact, varargs]=getoption(varargin, 'compact', false);
+[filename, ~]=getargs(varargs,[]);
+
+if ~isempty(filename)
+    %get filename information
+    [pname,fname,ext]=fileparts(filename);
+
+    %Check file extension
+    if isempty(ext), ext='.json'; end
+
+    % Make fullname
+    fn=fullfile(pname,[fname ext]);
+
+    % Open file to be written
+    [fid,mess]=fopen(fullfile(pname,[fname ext]),'wt');
+
+    if fid==-1
+        error('AT:FileErr','Cannot Create file %s\n%s',fn,mess);
+    else
+        fprintf(fid, sjson(ring));
+        fclose(fid);
+    end
+    varargout={};
+else
+    varargout={sjson(ring)};
+end
+
+    function jsondata=sjson(ring)
+        ok=~atgetcells(ring, 'Class', 'RingParam');
+        data.elements=ring(ok);
+        data.parameters=get_params(ring);
+        jsondata=jsonencode(data, 'PrettyPrint', ~compact);
+    end
+
+    function prms=get_params(ring)
+        [name, energy, part, periodicity, harmonic_number]=...
+            atGetRingProperties(ring,'FamName', 'Energy', 'Particle',...
+            'Periodicity', 'HarmNumber');
+        prms=struct('name', name, 'energy', energy, 'periodicity', periodicity,...
+            'particle', saveobj(part), 'harmonic_number', harmonic_number);
+        idx=atlocateparam(ring);
+        p2=rmfield(ring{idx},{'FamName','PassMethod','Length','Class',...
+            'Energy', 'Particle','Periodicity','cell_harmnumber'});
+        for nm=fieldnames(p2)'
+            na=nm{1};
+            prms.(na)=p2.(na);
+        end
+    end
+
+end

--- a/atmat/lattice/atwritejson.m
+++ b/atmat/lattice/atwritejson.m
@@ -22,9 +22,6 @@ if ~isempty(filename)
     %Check file extension
     if isempty(ext), ext='.json'; end
 
-    % Make fullname
-    fn=fullfile(pname,[fname ext]);
-
     % Open file to be written
     [fid,mess]=fopen(fullfile(pname,[fname ext]),'wt');
 
@@ -42,22 +39,26 @@ end
     function jsondata=sjson(ring)
         ok=~atgetcells(ring, 'Class', 'RingParam');
         data.elements=ring(ok);
-        data.parameters=get_params(ring);
+        data.properties=get_params(ring);
         jsondata=jsonencode(data, 'PrettyPrint', ~compact);
     end
 
     function prms=get_params(ring)
+        % Get "standard" properties
         [name, energy, part, periodicity, harmonic_number]=...
             atGetRingProperties(ring,'FamName', 'Energy', 'Particle',...
             'Periodicity', 'HarmNumber');
         prms=struct('name', name, 'energy', energy, 'periodicity', periodicity,...
             'particle', saveobj(part), 'harmonic_number', harmonic_number);
+        % Add user-defined properties
         idx=atlocateparam(ring);
-        p2=rmfield(ring{idx},{'FamName','PassMethod','Length','Class',...
-            'Energy', 'Particle','Periodicity','cell_harmnumber'});
-        for nm=fieldnames(p2)'
-            na=nm{1};
-            prms.(na)=p2.(na);
+        if ~isempty(idx)
+            p2=rmfield(ring{idx},{'FamName','PassMethod','Length','Class',...
+                'Energy', 'Particle','Periodicity','cell_harmnumber'});
+            for nm=fieldnames(p2)'
+                na=nm{1};
+                prms.(na)=p2.(na);
+            end
         end
     end
 

--- a/atmat/lattice/atwritejson.m
+++ b/atmat/lattice/atwritejson.m
@@ -53,8 +53,10 @@ end
         % Add user-defined properties
         idx=atlocateparam(ring);
         if ~isempty(idx)
-            p2=rmfield(ring{idx},{'FamName','PassMethod','Length','Class',...
-                'Energy', 'Particle','Periodicity','cell_harmnumber'});
+            flist={'FamName','PassMethod','Length','Class',...
+                'Energy', 'Particle','Periodicity','cell_harmnumber'};
+            present=isfield(ring{idx}, flist);
+            p2=rmfield(ring{idx},flist(present));
             for nm=fieldnames(p2)'
                 na=nm{1};
                 prms.(na)=p2.(na);

--- a/atmat/lattice/atwritejson.m
+++ b/atmat/lattice/atwritejson.m
@@ -38,6 +38,7 @@ end
 
     function jsondata=sjson(ring)
         ok=~atgetcells(ring, 'Class', 'RingParam');
+        data.atjson= 1;
         data.elements=ring(ok);
         data.properties=get_params(ring);
         jsondata=jsonencode(data, 'PrettyPrint', ~compact);

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -370,7 +370,9 @@ class Element(object):
     def definition(self) -> tuple[str, tuple, dict]:
         """tuple (class_name, args, kwargs) defining the element"""
         attrs = dict(self.items())
-        arguments = tuple(attrs.pop(k, getattr(self, k)) for k in self._BUILD_ATTRIBUTES)
+        arguments = tuple(attrs.pop(
+            k, getattr(self, k)) for k in self._BUILD_ATTRIBUTES
+        )
         defelem = self.__class__(*arguments)
         keywords = dict(
             (k, v)

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -280,11 +280,9 @@ class Element(object):
             raise
 
     def __str__(self):
-        attrs = dict(self.items())
         return "\n".join(
             [self.__class__.__name__ + ":"]
-            + [f"{k:>14}: {attrs.pop(k)!s}" for k in ["FamName", "Length", "PassMethod"]]
-            + [f"{k:>14}: {v!s}" for k, v in attrs.items()]
+            + [f"{k:>14}: {v!s}" for k, v in self.items()]
         )
 
     def __repr__(self):
@@ -376,14 +374,17 @@ class Element(object):
         defelem = self.__class__(*arguments)
         keywords = dict(
             (k, v)
-            for k, v in sorted(attrs.items())
+            for k, v in attrs.items()
             if not numpy.array_equal(v, getattr(defelem, k, None))
         )
         return self.__class__.__name__, arguments, keywords
 
     def items(self) -> Generator[tuple[str, Any], None, None]:
         """Iterates through the data members"""
-        for k, v in vars(self).items():
+        v = vars(self).copy()
+        for k in ["FamName", "Length", "PassMethod"]:
+            yield k, v.pop(k)
+        for k, v in sorted(v.items()):
             yield k, v
 
     def is_compatible(self, other: Element) -> bool:

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -5,7 +5,6 @@ Each element has a default PassMethod attribute for which it should have the
 appropriate attributes.  If a different PassMethod is set, it is the caller's
 responsibility to ensure that the appropriate attributes are present.
 """
-
 from __future__ import annotations
 
 import abc
@@ -13,12 +12,9 @@ import re
 from abc import ABC
 from collections.abc import Generator, Iterable
 from copy import copy, deepcopy
-from typing import Any, Optional
+from typing import Optional, Any
 
 import numpy
-
-# noinspection PyProtectedMember
-from .variables import _nop
 
 
 def _array(value, shape=(-1,), dtype=numpy.float64):
@@ -31,17 +27,8 @@ def _array66(value):
     return _array(value, shape=(6, 6))
 
 
-def _float(value) -> float:
-    return float(value)
-
-
-def _int(value, vmin: Optional[int] = None, vmax: Optional[int] = None) -> int:
-    intv = int(value)
-    if vmin is not None and intv < vmin:
-        raise ValueError(f"Value must be greater of equal to {vmin}")
-    if vmax is not None and intv > vmax:
-        raise ValueError(f"Value must be smaller of equal to {vmax}")
-    return intv
+def _nop(value):
+    return value
 
 
 class LongtMotion(ABC):
@@ -57,7 +44,6 @@ class LongtMotion(ABC):
     * ``set_longt_motion(self, enable, new_pass=None, copy=False, **kwargs)``
       must enable or disable longitudinal motion.
     """
-
     @abc.abstractmethod
     def _get_longt_motion(self):
         return False
@@ -119,8 +105,7 @@ class _DictLongtMotion(LongtMotion):
 
         Defines a class such that :py:meth:`set_longt_motion` will select
         ``'IdentityPass'`` or ``'IdentityPass'``.
-    """
-
+        """
     def _get_longt_motion(self):
         return self.PassMethod != self.default_pass[False]
 
@@ -178,20 +163,16 @@ class _Radiative(LongtMotion):
         if new_pass is None or new_pass == self.PassMethod:
             return self if copy else None
         if enable:
-
             def setpass(el):
                 el.PassMethod = new_pass
                 el.Energy = kwargs['energy']
-
         else:
-
             def setpass(el):
                 el.PassMethod = new_pass
                 try:
                     del el.Energy
                 except AttributeError:
                     pass
-
         if copy:
             newelem = deepcopy(self)
             setpass(newelem)
@@ -261,7 +242,7 @@ class Element(object):
     """Base class for AT elements"""
 
     _BUILD_ATTRIBUTES = ['FamName']
-    _conversions = dict(FamName=str, PassMethod=str, Length=_float,
+    _conversions = dict(FamName=str, PassMethod=str, Length=float,
                         R1=_array66, R2=_array66,
                         T1=lambda v: _array(v, (6,)),
                         T2=lambda v: _array(v, (6,)),
@@ -269,9 +250,9 @@ class Element(object):
                         EApertures=lambda v: _array(v, (2,)),
                         KickAngle=lambda v: _array(v, (2,)),
                         PolynomB=_array, PolynomA=_array,
-                        BendingAngle=_float,
-                        MaxOrder=_int, NumIntSteps=lambda v: _int(v, vmin=0),
-                        Energy=_float,
+                        BendingAngle=float,
+                        MaxOrder=int, NumIntSteps=int,
+                        Energy=float,
                         )
 
     _entrance_fields = ['T1', 'R1']
@@ -293,35 +274,27 @@ class Element(object):
 
     def __setattr__(self, key, value):
         try:
-            value = self._conversions.get(key, _nop)(value)
+            super(Element, self).__setattr__(
+                key, self._conversions.get(key, _nop)(value))
         except Exception as exc:
             exc.args = ('In element {0}, parameter {1}: {2}'.format(
                 self.FamName, key, exc),)
             raise
-        else:
-            super(Element, self).__setattr__(key, value)
 
     def __str__(self):
-        first3 = ["FamName", "Length", "PassMethod"]
-        # Get values and parameter objects
         attrs = dict(self.items())
-        keywords = [f"\t{k} : {attrs.pop(k)!s}" for k in first3]
-        keywords += [f"\t{k} : {v!s}" for k, v in attrs.items()]
-        return "\n".join((type(self).__name__ + ":", "\n".join(keywords)))
+        return "\n".join(
+            [self.__class__.__name__ + ":"]
+            + [f"{k:>14}: {attrs.pop(k)!s}" for k in ["FamName", "Length", "PassMethod"]]
+            + [f"{k:>14}: {v!s}" for k, v in attrs.items()]
+        )
 
     def __repr__(self):
-        # Get values only, even for parameters
-        attrs = dict((k, getattr(self, k)) for k, v in self.items())
-        arguments = [attrs.pop(k) for k in self._BUILD_ATTRIBUTES]
-        defelem = self.__class__(*arguments)
-        keywords = [f"{v!r}" for v in arguments]
-        keywords += [
-            f"{k}={v!r}"
-            for k, v in sorted(attrs.items())
-            if not numpy.array_equal(v, getattr(defelem, k, None))
-        ]
+        clsname, args, kwargs = self.definition
+        keywords = [f"{arg!r}" for arg in args]
+        keywords += [f"{k}={v!r}" for k, v in kwargs.items()]
         args = re.sub(r"\n\s*", " ", ", ".join(keywords))
-        return "{0}({1})".format(self.__class__.__name__, args)
+        return f"{clsname}({args})"
 
     def equals(self, other) -> bool:
         """Whether an element is equivalent to another.
@@ -352,12 +325,10 @@ class Element(object):
 
     def swap_faces(self, copy=False):
         """Swap the faces of an element, alignment errors are ignored"""
-
         def swapattr(element, attro, attri):
             val = getattr(element, attri)
             delattr(element, attri)
             return attro, val
-
         if copy:
             el = self.copy()
         else:
@@ -388,7 +359,7 @@ class Element(object):
         Update the element attributes with the given arguments
         """
         attrs = dict(*args, **kwargs)
-        for key, value in attrs.items():
+        for (key, value) in attrs.items():
             setattr(self, key, value)
 
     def copy(self) -> Element:
@@ -399,10 +370,23 @@ class Element(object):
         """Return a deep copy of the element"""
         return deepcopy(self)
 
+    @property
+    def definition(self) -> tuple[str, tuple, dict]:
+        """tuple (class_name, args, kwargs) defining the element"""
+        attrs = dict(self.items())
+        arguments = tuple(attrs.pop(k, getattr(self, k)) for k in self._BUILD_ATTRIBUTES)
+        defelem = self.__class__(*arguments)
+        keywords = dict(
+            (k, v)
+            for k, v in sorted(attrs.items())
+            if not numpy.array_equal(v, getattr(defelem, k, None))
+        )
+        return self.__class__.__name__, arguments, keywords
+
     def items(self) -> Generator[tuple[str, Any], None, None]:
         """Iterates through the data members"""
-        # Properties may be added by overloading this method
-        yield from vars(self).items()
+        for k, v in vars(self).items():
+            yield k, v
 
     def is_compatible(self, other: Element) -> bool:
         """Checks if another :py:class:`Element` can be merged"""
@@ -412,7 +396,8 @@ class Element(object):
         """Merge another element"""
         if not self.is_compatible(other):
             badname = getattr(other, 'FamName', type(other))
-            raise TypeError("Cannot merge {0} and {1}".format(self.FamName, badname))
+            raise TypeError('Cannot merge {0} and {1}'.format(self.FamName,
+                                                              badname))
 
     # noinspection PyMethodMayBeStatic
     def _get_longt_motion(self):
@@ -434,8 +419,8 @@ class Element(object):
 
 
 class LongElement(Element):
-    """Base class for long elements"""
-
+    """Base class for long elements
+    """
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ['Length']
 
     def __init__(self, family_name: str, length: float, *args, **kwargs):
@@ -469,7 +454,8 @@ class LongElement(Element):
         # Remove entrance and exit attributes
         fin = dict(popattr(el, key) for key in vars(self) if
                    key in self._entrance_fields)
-        fout = dict(popattr(el, key) for key in vars(self) if key in self._exit_fields)
+        fout = dict(popattr(el, key) for key in vars(self) if
+                    key in self._exit_fields)
         # Split element
         element_list = [el._part(f, numpy.sum(frac)) for f in frac]
         # Restore entrance and exit attributes
@@ -480,22 +466,8 @@ class LongElement(Element):
         return element_list
 
     def is_compatible(self, other) -> bool:
-        def compatible_field(fieldname):
-            f1 = getattr(self, fieldname, None)
-            f2 = getattr(other, fieldname, None)
-            if f1 is None and f2 is None:  # no such field
-                return True
-            elif f1 is None or f2 is None:  # only one
-                return False
-            else:  # both
-                return numpy.all(f1 == f2)
-
-        if not (type(other) is type(self) and self.PassMethod == other.PassMethod):
-            return False
-        for fname in ("RApertures", "EApertures"):
-            if not compatible_field(fname):
-                return False
-        return True
+        return type(other) is type(self) and \
+               self.PassMethod == other.PassMethod
 
     def merge(self, other) -> None:
         super().merge(other)
@@ -542,7 +514,6 @@ class BeamMoments(Element):
 
 class SliceMoments(Element):
     """Element to compute slices mean and std"""
-
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ['nslice']
     _conversions = dict(Element._conversions, nslice=int)
 
@@ -561,7 +532,8 @@ class SliceMoments(Element):
         kwargs.setdefault('PassMethod', 'SliceMomentsPass')
         self._startturn = kwargs.pop('startturn', 0)
         self._endturn = kwargs.pop('endturn', 1)
-        super(SliceMoments, self).__init__(family_name, nslice=nslice, **kwargs)
+        super(SliceMoments, self).__init__(family_name, nslice=nslice,
+                                           **kwargs)
         self._nbunch = 1
         self.startturn = self._startturn
         self.endturn = self._endturn
@@ -576,33 +548,45 @@ class SliceMoments(Element):
         self.endturn = min(self.endturn, nturns)
         self._dturns = self.endturn - self.startturn
         self._nbunch = nbunch
-        self._stds = numpy.zeros((3, nbunch*self.nslice, self._dturns), order="F")
-        self._means = numpy.zeros((3, nbunch*self.nslice, self._dturns), order="F")
-        self._spos = numpy.zeros((nbunch*self.nslice, self._dturns), order="F")
-        self._weights = numpy.zeros((nbunch*self.nslice, self._dturns), order="F")
+        self._stds = numpy.zeros((3, nbunch*self.nslice, self._dturns),
+                                 order='F')
+        self._means = numpy.zeros((3, nbunch*self.nslice, self._dturns),
+                                  order='F')
+        self._spos = numpy.zeros((nbunch*self.nslice, self._dturns),
+                                 order='F')
+        self._weights = numpy.zeros((nbunch*self.nslice, self._dturns),
+                                    order='F')
 
     @property
     def stds(self):
         """Slices x,y,dp standard deviation"""
-        return self._stds.reshape((3, self._nbunch, self.nslice, self._dturns))
+        return self._stds.reshape((3, self._nbunch,
+                                   self.nslice,
+                                   self._dturns))
 
     @property
     def means(self):
         """Slices x,y,dp center of mass"""
-        return self._means.reshape((3, self._nbunch, self.nslice, self._dturns))
+        return self._means.reshape((3, self._nbunch,
+                                    self.nslice,
+                                    self._dturns))
 
     @property
     def spos(self):
         """Slices s position"""
-        return self._spos.reshape((self._nbunch, self.nslice, self._dturns))
+        return self._spos.reshape((self._nbunch,
+                                   self.nslice,
+                                   self._dturns))
 
     @property
     def weights(self):
         """Slices weights in mA if beam current >0,
-        otherwise fraction of total number of
-        particles in the bunch
+           otherwise fraction of total number of
+           particles in the bunch
         """
-        return self._weights.reshape((self._nbunch, self.nslice, self._dturns))
+        return self._weights.reshape((self._nbunch,
+                                      self.nslice,
+                                      self._dturns))
 
     @property
     def startturn(self):
@@ -633,7 +617,6 @@ class SliceMoments(Element):
 
 class Aperture(Element):
     """Aperture element"""
-
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ['Limits']
     _conversions = dict(Element._conversions, Limits=lambda v: _array(v, (4,)))
 
@@ -712,7 +695,6 @@ class Drift(LongElement):
 
 class Collimator(Drift):
     """Collimator element"""
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['RApertures']
 
     def __init__(self, family_name: str, length: float, limits, **kwargs):
@@ -731,8 +713,8 @@ class Collimator(Drift):
 
 class ThinMultipole(Element):
     """Thin multipole element"""
-
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["PolynomA", "PolynomB"]
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ['PolynomA',
+                                                     'PolynomB']
 
     def __init__(self, family_name: str, poly_a, poly_b, **kwargs):
         """
@@ -760,13 +742,10 @@ class ThinMultipole(Element):
             else:
                 return poly
 
-        # PolynomA and PolynomB and convert to ParamArray
-        prmpola = self._conversions["PolynomA"](kwargs.pop("PolynomA", poly_a))
-        prmpolb = self._conversions["PolynomB"](kwargs.pop("PolynomB", poly_b))
-        poly_a, len_a, ord_a = getpol(prmpola)
-        poly_b, len_b, ord_b = getpol(prmpolb)
+        # Remove MaxOrder, PolynomA and PolynomB
+        poly_a, len_a, ord_a = getpol(_array(kwargs.pop('PolynomA', poly_a)))
+        poly_b, len_b, ord_b = getpol(_array(kwargs.pop('PolynomB', poly_b)))
         deforder = max(getattr(self, 'DefaultOrder', 0), ord_a, ord_b)
-        # Remove MaxOrder
         maxorder = kwargs.pop('MaxOrder', deforder)
         kwargs.setdefault('PassMethod', 'ThinMPolePass')
         super(ThinMultipole, self).__init__(family_name, **kwargs)
@@ -774,32 +753,36 @@ class ThinMultipole(Element):
         super(ThinMultipole, self).__setattr__('MaxOrder', maxorder)
         # Adjust polynom lengths and set them
         len_ab = max(self.MaxOrder + 1, len_a, len_b)
-        self.PolynomA = lengthen(prmpola, len_ab - len_a)
-        self.PolynomB = lengthen(prmpolb, len_ab - len_b)
+        self.PolynomA = lengthen(poly_a, len_ab - len_a)
+        self.PolynomB = lengthen(poly_b, len_ab - len_b)
 
     def __setattr__(self, key, value):
         """Check the compatibility of MaxOrder, PolynomA and PolynomB"""
         polys = ('PolynomA', 'PolynomB')
         if key in polys:
-            lmin = self.MaxOrder
+            value = _array(value)
+            lmin = getattr(self, 'MaxOrder')
             if not len(value) > lmin:
                 raise ValueError(
                     'Length of {0} must be larger than {1}'.format(key, lmin))
         elif key == 'MaxOrder':
-            intval = int(value)
+            value = int(value)
             lmax = min(len(getattr(self, k)) for k in polys)
-            if not intval < lmax:
-                raise ValueError("MaxOrder must be smaller than {0}".format(lmax))
+            if not value < lmax:
+                raise ValueError(
+                    'MaxOrder must be smaller than {0}'.format(lmax))
+
         super(ThinMultipole, self).__setattr__(key, value)
 
 
 class Multipole(_Radiative, LongElement, ThinMultipole):
     """Multipole element"""
-
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["PolynomA", "PolynomB"]
+    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['PolynomA',
+                                                         'PolynomB']
     _conversions = dict(ThinMultipole._conversions, K=float, H=float)
 
-    def __init__(self, family_name: str, length: float, poly_a, poly_b, **kwargs):
+    def __init__(self, family_name: str, length: float, poly_a, poly_b,
+                 **kwargs):
         """
         Args:
             family_name:    Name of the element
@@ -819,10 +802,12 @@ class Multipole(_Radiative, LongElement, ThinMultipole):
         """
         kwargs.setdefault('PassMethod', 'StrMPoleSymplectic4Pass')
         kwargs.setdefault('NumIntSteps', 10)
-        super(Multipole, self).__init__(family_name, length, poly_a, poly_b, **kwargs)
+        super(Multipole, self).__init__(family_name, length,
+                                        poly_a, poly_b, **kwargs)
 
     def is_compatible(self, other) -> bool:
-        if super().is_compatible(other) and self.MaxOrder == other.MaxOrder:
+        if super().is_compatible(other) and \
+                self.MaxOrder == other.MaxOrder:
             for i in range(self.MaxOrder + 1):
                 if self.PolynomB[i] != other.PolynomB[i]:
                     return False
@@ -836,8 +821,7 @@ class Multipole(_Radiative, LongElement, ThinMultipole):
     @property
     def K(self) -> float:
         """Focusing strength [mˆ-2]"""
-        arr = self.PolynomB
-        return 0.0 if len(arr) < 2 else arr[1]
+        return 0.0 if len(self.PolynomB) < 2 else self.PolynomB[1]
 
     # noinspection PyPep8Naming
     @K.setter
@@ -848,8 +832,7 @@ class Multipole(_Radiative, LongElement, ThinMultipole):
     @property
     def H(self) -> float:
         """Sextupolar strength [mˆ-3]"""
-        arr = self.PolynomB
-        return 0.0 if len(arr) < 3 else arr[2]
+        return 0.0 if len(self.PolynomB) < 3 else self.PolynomB[2]
 
     # noinspection PyPep8Naming
     @H.setter
@@ -922,15 +905,16 @@ class Dipole(Radiative, Multipole):
 
         Default PassMethod: :ref:`BndMPoleSymplectic4Pass`
         """
+        poly_b = kwargs.pop('PolynomB', numpy.array([0, k]))
         kwargs.setdefault('BendingAngle', bending_angle)
         kwargs.setdefault('EntranceAngle', 0.0)
         kwargs.setdefault('ExitAngle', 0.0)
         kwargs.setdefault('PassMethod', 'BndMPoleSymplectic4Pass')
-        super(Dipole, self).__init__(family_name, length, [], [0.0, k], **kwargs)
+        super(Dipole, self).__init__(family_name, length, [], poly_b, **kwargs)
 
-    def items(self) -> Generator[tuple[str, Any], None, None]:
+    def items(self) -> Generator[tuple, None, None]:
         yield from super().items()
-        yield "K", vars(self)["PolynomB"][1]
+        yield 'K', self.K
 
     def _part(self, fr, sumfr):
         pp = super(Dipole, self)._part(fr, sumfr)
@@ -943,9 +927,9 @@ class Dipole(Radiative, Multipole):
         def invrho(dip: Dipole):
             return dip.BendingAngle / dip.Length
 
-        return (super().is_compatible(other)
-                and self.ExitAngle == -other.EntranceAngle
-                and abs(invrho(self) - invrho(other)) <= 1.e-6)
+        return (super().is_compatible(other) and
+                self.ExitAngle == -other.EntranceAngle and
+                abs(invrho(self) - invrho(other)) <= 1.e-6)
 
     def merge(self, other) -> None:
         super().merge(other)
@@ -960,7 +944,6 @@ Bend = Dipole
 
 class Quadrupole(Radiative, Multipole):
     """Quadrupole element"""
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['K']
     _conversions = dict(Multipole._conversions, FringeQuadEntrance=int,
                         FringeQuadExit=int)
@@ -998,17 +981,18 @@ class Quadrupole(Radiative, Multipole):
 
         Default PassMethod: ``StrMPoleSymplectic4Pass``
         """
-        kwargs.setdefault("PassMethod", "StrMPoleSymplectic4Pass")
-        super(Quadrupole, self).__init__(family_name, length, [], [0.0, k], **kwargs)
+        poly_b = kwargs.pop('PolynomB', numpy.array([0, k]))
+        kwargs.setdefault('PassMethod', 'StrMPoleSymplectic4Pass')
+        super(Quadrupole, self).__init__(family_name, length, [], poly_b,
+                                         **kwargs)
 
-    def items(self) -> Generator[tuple[str, Any], None, None]:
+    def items(self) -> Generator[tuple, None, None]:
         yield from super().items()
-        yield "K", vars(self)["PolynomB"][1]
+        yield 'K', self.K
 
 
 class Sextupole(Multipole):
     """Sextupole element"""
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['H']
 
     DefaultOrder = 2
@@ -1032,18 +1016,14 @@ class Sextupole(Multipole):
 
         Default PassMethod: ``StrMPoleSymplectic4Pass``
         """
-        kwargs.setdefault("PassMethod", "StrMPoleSymplectic4Pass")
-        super(Sextupole, self).__init__(family_name, length, [], [0.0, 0.0, h],
+        poly_b = kwargs.pop('PolynomB', [0, 0, h])
+        kwargs.setdefault('PassMethod', 'StrMPoleSymplectic4Pass')
+        super(Sextupole, self).__init__(family_name, length, [], poly_b,
                                         **kwargs)
-
-    def items(self) -> Generator[tuple[str, Any], None, None]:
-        yield from super().items()
-        yield "H", vars(self)["PolynomB"][2]
 
 
 class Octupole(Multipole):
     """Octupole element, with no changes from multipole at present"""
-
     _BUILD_ATTRIBUTES = Multipole._BUILD_ATTRIBUTES
 
     DefaultOrder = 3
@@ -1051,7 +1031,6 @@ class Octupole(Multipole):
 
 class RFCavity(LongtMotion, LongElement):
     """RF cavity element"""
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['Voltage',
                                                          'Frequency',
                                                          'HarmNumber',
@@ -1092,9 +1071,9 @@ class RFCavity(LongtMotion, LongElement):
         return pp
 
     def is_compatible(self, other) -> bool:
-        return (super().is_compatible(other)
-                and self.Frequency == other.Frequency
-                and self.TimeLag == other.TimeLag)
+        return (super().is_compatible(other) and
+                self.Frequency == other.Frequency and
+                self.TimeLag == other.TimeLag)
 
     def merge(self, other) -> None:
         super().merge(other)
@@ -1113,7 +1092,6 @@ class RFCavity(LongtMotion, LongElement):
 
 class M66(Element):
     """Linear (6, 6) transfer matrix"""
-
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["M66"]
     _conversions = dict(Element._conversions, M66=_array66)
 
@@ -1124,7 +1102,7 @@ class M66(Element):
             m66:            Transfer matrix. Default: Identity matrix
 
         Default PassMethod: ``Matrix66Pass``
-        """
+       """
         if m66 is None:
             m66 = numpy.identity(6)
         kwargs.setdefault('PassMethod', 'Matrix66Pass')
@@ -1140,7 +1118,6 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
     Note: The damping times are needed to compute the correct
     kick for the emittance. Radiation damping is NOT applied.
     """
-
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     default_pass = {False: 'IdentityPass', True: 'SimpleQuantDiffPass'}
 
@@ -1165,8 +1142,8 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
             tauz:          Longitudinal damping time [turns]
 
         Default PassMethod: ``SimpleQuantDiffPass``
-        """
-        kwargs.setdefault("PassMethod", self.default_pass[True])
+       """
+        kwargs.setdefault('PassMethod', self.default_pass[True])
 
         assert taux >= 0.0, 'taux must be greater than or equal to 0'
         self.taux = taux
@@ -1199,7 +1176,6 @@ class SimpleQuantDiff(_DictLongtMotion, Element):
 
 class SimpleRadiation(_DictLongtMotion, Radiative, Element):
     """Simple radiation damping and energy loss"""
-
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     _conversions = dict(Element._conversions, U0=float,
                         damp_mat_diag=lambda v: _array(v, shape=(6,)))
@@ -1221,7 +1197,7 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
             U0:            Energy loss per turn [eV]
 
         Default PassMethod: ``SimpleRadiationPass``
-        """
+       """
         assert taux >= 0.0, 'taux must be greater than or equal to 0'
         if taux == 0.0:
             dampx = 1
@@ -1250,7 +1226,6 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
 
 class Corrector(LongElement):
     """Corrector element"""
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['KickAngle']
 
     def __init__(self, family_name: str, length: float, kick_angle, **kwargs):
@@ -1276,7 +1251,6 @@ class Wiggler(Radiative, LongElement):
 
     See atwiggler.m
     """
-
     _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['Lw', 'Bmax',
                                                          'Energy']
     _conversions = dict(Element._conversions, Lw=float, Bmax=float,
@@ -1319,12 +1293,14 @@ class Wiggler(Radiative, LongElement):
         for i, b in enumerate(self.By.T):
             dk = abs(b[3] ** 2 - b[4] ** 2 - b[2] ** 2) / abs(b[4])
             if dk > 1e-6:
-                raise ValueError("Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = {0}".format(i))
+                raise ValueError("Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = "
+                                 "{0}".format(i))
 
         for i, b in enumerate(self.Bx.T):
             dk = abs(b[2] ** 2 - b[4] ** 2 - b[3] ** 2) / abs(b[4])
             if dk > 1e-6:
-                raise ValueError("Wiggler(V): ky^2 + kz^2 -kx^2 !=0, i = {0}".format(i))
+                raise ValueError("Wiggler(V): ky^2 + kz^2 -kx^2 !=0, i = "
+                                 "{0}".format(i))
 
         self.NHharm = self.By.shape[1]
         self.NVharm = self.Bx.shape[1]

--- a/pyat/at/load/__init__.py
+++ b/pyat/at/load/__init__.py
@@ -8,3 +8,4 @@ from .matfile import *
 from .reprfile import *
 from .tracy import *
 from .elegant import *
+from .json import *

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -3,12 +3,14 @@ determined by the file extension
 """
 
 from __future__ import annotations
-import os.path
-from typing import Optional
-from collections.abc import Callable
-from at.lattice import Lattice
 
 __all__ = ["load_lattice", "save_lattice", "register_format"]
+
+import os.path
+from collections.abc import Callable
+from typing import Optional
+
+from at.lattice import Lattice
 
 _load_extension = {}
 _save_extension = {}

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -1,10 +1,14 @@
 """Generic function to save and load python AT lattices. The format is
 determined by the file extension
 """
+
+from __future__ import annotations
 import os.path
+from typing import Optional
+from collections.abc import Callable
 from at.lattice import Lattice
 
-__all__ = ['load_lattice', 'save_lattice', 'register_format']
+__all__ = ["load_lattice", "save_lattice", "register_format"]
 
 _load_extension = {}
 _save_extension = {}
@@ -13,31 +17,31 @@ _save_extension = {}
 def load_lattice(filepath: str, **kwargs) -> Lattice:
     """Load a Lattice object from a file
 
-The file format is indicated by the filepath extension. The file name is stored in
-the *in_file* Lattice attribute. The selected variable, if relevant, is stored
-in the *use* Lattice attribute.
+    The file format is indicated by the filepath extension. The file name is stored in
+    the *in_file* Lattice attribute. The selected variable, if relevant, is stored
+    in the *use* Lattice attribute.
 
-Parameters:
-    filepath:           Name of the file
+    Parameters:
+        filepath:           Name of the file
 
-Keyword Args:
-    use (str):          Name of the variable containing the desired lattice.
-      Default: if there is a single variable, use it, otherwise select ``"RING"``
-    name (str):         Name of the lattice.
-      Default: taken from the file, or ``""``
-    energy (float):     Energy of the lattice
-      (default: taken from the file)
-    periodicity (int):  Number of periods
-      (default: taken from the file, or 1)
-    *:                  All other keywords will be set as :py:class:`.Lattice`
-      attributes
+    Keyword Args:
+        use (str):          Name of the variable containing the desired lattice.
+          Default: if there is a single variable, use it, otherwise select ``"RING"``
+        name (str):         Name of the lattice.
+          Default: taken from the file, or ``""``
+        energy (float):     Energy of the lattice
+          (default: taken from the file)
+        periodicity (int):  Number of periods
+          (default: taken from the file, or 1)
+        *:                  All other keywords will be set as :py:class:`.Lattice`
+          attributes
 
-Check the format-specific function for specific keyword arguments.
+    Returns:
+        lattice (Lattice):          New :py:class:`.Lattice` object
 
-Returns:
-    lattice (Lattice):          New :py:class:`.Lattice` object
+    Check the format-specific function for specific keyword arguments:
 
-.. Admonition:: Known extensions are:
+    .. Admonition:: Known extensions are:
     """
     _, ext = os.path.splitext(filepath)
     try:
@@ -48,25 +52,18 @@ Returns:
         return load_func(filepath, **kwargs)
 
 
-def save_lattice(ring: Lattice, filepath: str, **kwargs):
+def save_lattice(ring: Lattice, filepath: str, **kwargs) -> None:
     """Save a Lattice object
 
-The file format is indicated by the filepath extension.
+    The file format is indicated by the filepath extension.
 
-Parameters:
-    ring:               Lattice description
-    filepath:           Name of the file
+    Parameters:
+        ring:               Lattice description
+        filepath:           Name of the file
 
-Specific keywords for .mat files
+    Check the format-specific function for specific keyword arguments:
 
-Keyword Args:
-    mat_key (str):      Name of the Matlab variable containing the lattice.
-      Default: ``'RING'``
-
-See Also:
-    :py:func:`.save_mat`, :py:func:`.save_m`, :py:func:`.save_repr`
-
-.. Admonition:: Known extensions are:
+    .. Admonition:: Known extensions are:
     """
     _, ext = os.path.splitext(filepath)
     try:
@@ -77,24 +74,26 @@ See Also:
         return save_func(ring, filepath, **kwargs)
 
 
-def register_format(extension: str, load_func=None, save_func=None,
-                    descr: str = ''):
+def register_format(
+    extension: str,
+    load_func: Optional[Callable[..., Lattice]] = None,
+    save_func: Optional[Callable[..., None]] = None,
+    descr: str = "",
+):
     """Register format-specific processing functions
 
     Parameters:
         extension:      File extension string.
-        load_func:      load function. Default: :py:obj:`None`
-        save_func:      save_lattice function Default: :py:obj:`None`
-        descr:          File type description
+        load_func:      load function.
+        save_func:      save function.
+        descr:          File type description.
     """
     if load_func is not None:
         _load_extension[extension] = load_func
-        load_lattice.__doc__ += '\n    {0:<10}'\
-                                '\n        {1}\n'.format(extension, descr)
+        load_lattice.__doc__ += f"\n        {extension:<10}\n            {descr}\n"
     if save_func is not None:
         _save_extension[extension] = save_func
-        save_lattice.__doc__ += '\n    {0:<10}'\
-                                '\n        {1}\n'.format(extension, descr)
+        save_lattice.__doc__ += f"\n        {extension:<10}\n            {descr}\n"
 
 
 Lattice.load = staticmethod(load_lattice)

--- a/pyat/at/load/allfiles.py
+++ b/pyat/at/load/allfiles.py
@@ -13,39 +13,29 @@ _save_extension = {}
 def load_lattice(filepath: str, **kwargs) -> Lattice:
     """Load a Lattice object from a file
 
-The file format is indicated by the filepath extension.
+The file format is indicated by the filepath extension. The file name is stored in
+the *in_file* Lattice attribute. The selected variable, if relevant, is stored
+in the *use* Lattice attribute.
 
 Parameters:
     filepath:           Name of the file
 
 Keyword Args:
+    use (str):          Name of the variable containing the desired lattice.
+      Default: if there is a single variable, use it, otherwise select ``"RING"``
     name (str):         Name of the lattice.
-      Default: taken from the file, or ``''``
+      Default: taken from the file, or ``""``
     energy (float):     Energy of the lattice
       (default: taken from the file)
-    periodicity (int]): Number of periods
+    periodicity (int):  Number of periods
       (default: taken from the file, or 1)
     *:                  All other keywords will be set as :py:class:`.Lattice`
       attributes
 
-Specific keywords for .mat files
-
-Keyword Args:
-    mat_key (str):      Name of the Matlab variable containing
-      the lattice. Default: Matlab variable name if there is only one,
-      otherwise ``'RING'``
-    check (bool):       Run coherence tests. Default: :py:obj:`True`
-    quiet (bool):       Suppress the warning for non-standard classes.
-      Default: :py:obj:`False`
-    keep_all (bool):    Keep Matlab RingParam elements as Markers.
-      Default: :py:obj:`False`
+Check the format-specific function for specific keyword arguments.
 
 Returns:
     lattice (Lattice):          New :py:class:`.Lattice` object
-
-See Also:
-    :py:func:`.load_mat`, :py:func:`.load_m`, :py:func:`.load_repr`,
-    :py:func:`.load_elegant`, :py:func:`.load_tracy`
 
 .. Admonition:: Known extensions are:
     """

--- a/pyat/at/load/elegant.py
+++ b/pyat/at/load/elegant.py
@@ -337,10 +337,8 @@ def load_elegant(filename: str, **kwargs) -> Lattice:
         name (str):         Name of the lattice. Default: taken from
           the file.
         energy (float):     Energy of the lattice [eV]
-        periodicity(int):   Number of periods. Default: taken from the
-          elements, or 1
-        *:                  All other keywords will be set as Lattice
-          attributes
+        periodicity(int):   Number of periods. Default: taken from the elements, or 1
+        *:                  All other keywords will be set as Lattice attributes
 
     Returns:
         lattice (Lattice):  New :py:class:`.Lattice` object
@@ -354,7 +352,7 @@ def load_elegant(filename: str, **kwargs) -> Lattice:
         harmonic_number = kwargs.pop("harmonic_number")
 
         def elem_iterator(params, elegant_file):
-            with open(params.setdefault("elegant_file", elegant_file)) as f:
+            with open(params.setdefault("in_file", elegant_file)) as f:
                 contents = f.read()
                 element_lines = expand_elegant(
                     contents, lattice_key, energy, harmonic_number
@@ -370,4 +368,5 @@ def load_elegant(filename: str, **kwargs) -> Lattice:
                          'lattice {}: {}'.format(filename, e))
 
 
-register_format(".lte", load_elegant, descr="Elegant format")
+register_format(
+    ".lte", load_elegant, descr="Elegant format. See :py:func:`.load_elegant`.")

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -31,24 +31,29 @@ class _AtEncoder(json.JSONEncoder):
             return super().default(obj)
 
 
-def save_json(ring: Lattice, filename: Optional[str] = None) -> None:
+def save_json(
+    ring: Lattice, filename: Optional[str] = None, compact: bool = False
+) -> None:
     """Save a :py:class:`.Lattice` as a JSON file
 
     Parameters:
         ring:           Lattice description
         filename:       Name of the JSON file. Default: outputs on
           :py:obj:`sys.stdout`
+        compact:        If :py:obj:`False` (default), the JSON file is pretty-printed
+          with line feeds and indentation. Otherwise, the output is a single line.
 
     See Also:
         :py:func:`.save_lattice` for a generic lattice-saving function.
         :py:meth:`.Lattice.save` for a generic lattice-saving method.
     """
+    indent = None if compact else 2
     data = dict(elements=list(save_filter(ring)), properties=ring.attrs)
     if filename is None:
-        print(json.dumps(data, cls=_AtEncoder, indent=2))
+        print(json.dumps(data, cls=_AtEncoder, indent=indent))
     else:
         with open(filename, "wt") as jsonfile:
-            json.dump(data, jsonfile, cls=_AtEncoder, indent=2)
+            json.dump(data, jsonfile, cls=_AtEncoder, indent=indent)
 
 
 def load_json(filename: str, **kwargs) -> Lattice:

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -48,7 +48,9 @@ def save_json(
         :py:meth:`.Lattice.save` for a generic lattice-saving method.
     """
     indent = None if compact else 2
-    data = dict(elements=list(keep_elements(ring)), properties=keep_attributes(ring))
+    data = dict(
+        atjson=1, elements=list(keep_elements(ring)), properties=keep_attributes(ring)
+    )
     if filename is None:
         print(json.dumps(data, cls=_AtEncoder, indent=indent))
     else:
@@ -76,13 +78,21 @@ def load_json(filename: str, **kwargs) -> Lattice:
 
         with open(params.setdefault("in_file", fn), "rt") as jsonfile:
             data = json.load(jsonfile)
+        # Check the file signature - For later use
+        try:
+            atjson = data["atjson"]  # noqa F841
+        except KeyError:
+            atjson = 1  # noqa F841
+        # Get elements
         elements = data["elements"]
+        # Get lattice properties
         try:
             properties = data["properties"]
         except KeyError:
             properties = {}
         particle_dict = properties.pop("particle", {})
         params.setdefault("particle", Particle(**particle_dict))
+
         for k, v in properties.items():
             params.setdefault(k, v)
         for idx, elem_dict in enumerate(elements):

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -13,7 +13,7 @@ from typing import Optional, Any
 import numpy as np
 
 from .allfiles import register_format
-from .utils import element_to_dict, element_from_dict, save_filter
+from .utils import element_to_dict, element_from_dict, keep_elements, keep_attributes
 from ..lattice import Element, Lattice, Particle
 
 
@@ -48,7 +48,7 @@ def save_json(
         :py:meth:`.Lattice.save` for a generic lattice-saving method.
     """
     indent = None if compact else 2
-    data = dict(elements=list(save_filter(ring)), properties=ring.attrs)
+    data = dict(elements=list(keep_elements(ring)), properties=keep_attributes(ring))
     if filename is None:
         print(json.dumps(data, cls=_AtEncoder, indent=indent))
     else:
@@ -74,7 +74,7 @@ def load_json(filename: str, **kwargs) -> Lattice:
 
     def json_generator(params: dict[str, Any], fn):
 
-        with open(params.setdefault("json_file", fn), "rt") as jsonfile:
+        with open(params.setdefault("in_file", fn), "rt") as jsonfile:
             data = json.load(jsonfile)
         elements = data["elements"]
         try:

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -13,7 +13,7 @@ from typing import Optional, Any
 import numpy as np
 
 from .allfiles import register_format
-from .utils import element_to_dict, element_from_dict, keep_elements, keep_attributes
+from .utils import element_from_dict, keep_elements, keep_attributes
 from ..lattice import Element, Lattice, Particle
 
 
@@ -22,7 +22,7 @@ class _AtEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, Element):
-            return element_to_dict(obj)
+            return obj.to_dict()
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         elif isinstance(obj, Particle):

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -13,7 +13,7 @@ from typing import Optional, Any
 import numpy as np
 
 from .allfiles import register_format
-from .utils import element_from_dict, keep_elements, keep_attributes
+from .utils import keep_elements, keep_attributes
 from ..lattice import Element, Lattice, Particle
 
 
@@ -86,7 +86,7 @@ def load_json(filename: str, **kwargs) -> Lattice:
         for k, v in properties.items():
             params.setdefault(k, v)
         for idx, elem_dict in enumerate(elements):
-            yield element_from_dict(elem_dict, index=idx, check=False)
+            yield Element.from_dict(elem_dict, index=idx, check=False)
 
     return Lattice(abspath(filename), iterator=json_generator, **kwargs)
 

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from typing import Optional, Any
+
+import numpy as np
+
+from . import register_format
+from ..lattice import Element, Lattice, Particle, get_class_map
+
+_CLASS_MAP = get_class_map()
+
+
+def elemstr(self):
+    attrs = dict(self.items())
+    return "\n".join(
+        [self.__class__.__name__ + ":"]
+        + [f"{k:>14}: {attrs.pop(k)!s}" for k in ["FamName", "Length", "PassMethod"]]
+        + [f"{k:>14}: {v!s}" for k, v in attrs.items()]
+    )
+
+
+class _AtEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Element):
+            return obj.definition
+        elif isinstance(obj, Particle):
+            return obj.to_dict()
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        else:
+            return super().default(obj)
+
+
+def save_json(ring: Lattice, filename: Optional[str] = None) -> None:
+    """Save a :py:class:`.Lattice` as a JSON file
+
+    Parameters:
+        ring:           Lattice description
+        filename:       Name of the JSON file. Default: outputs on
+          :py:obj:`sys.stdout`
+
+    See Also:
+        :py:func:`.save_lattice` for a generic lattice-saving function.
+        :py:meth:`.Lattice.save` for a generic lattice-saving method.
+    """
+    if filename is None:
+        json.dumps(("Lattice", ring, ring.attrs), cls=_AtEncoder)
+    else:
+        with open(filename, "wt") as jsonfile:
+            json.dump(("Lattice", ring, ring.attrs), jsonfile, cls=_AtEncoder)
+
+
+def load_json(filename: str, **kwargs) -> Lattice:
+    """Create a :py:class:`.Lattice`  from a JSON file
+
+    Parameters:
+        filename:           Name of a JSON file
+
+    Keyword Args:
+        name (str):         Name of the lattice. Default: taken from
+          the lattice
+        energy (float):     Energy of the lattice [eV]. Default: taken
+          from the lattice elements
+        periodicity(int):   Number of periods. Default: taken from the
+          elements, or 1
+        *:                  All other keywords will be set as Lattice
+          attributes
+
+    Returns:
+        lattice (Lattice):          New :py:class:`.Lattice` object
+
+    See Also:
+        :py:meth:`.Lattice.load` for a generic lattice-loading method.
+    """
+
+    def json_generator(params: dict[str, Any], elem_list):
+        particle_dict = params.pop("particle", {})
+        params["particle"] = Particle(**particle_dict)
+        for clname, args, keys in elem_list:
+            cls = _CLASS_MAP[clname]
+            yield cls(*args, **keys)
+
+    with open(filename, "rt") as jsonfile:
+        data = json.load(jsonfile)
+
+    try:
+        code, elems, prms = data
+    except ValueError:
+        raise TypeError("Not a Lattice")
+    if not (
+        isinstance(code, str)
+        and isinstance(elems, list)
+        and isinstance(prms, dict)
+        and (code == "Lattice")
+    ):
+        raise TypeError("Not a lattice")
+
+    prms.update(kwargs)
+    return Lattice(elems, iterator=json_generator, **prms)
+
+
+register_format(
+    ".json",
+    load_json,
+    save_json,
+    descr="JSON representation of a python AT Lattice",
+)

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -95,5 +95,5 @@ register_format(
     ".json",
     load_json,
     save_json,
-    descr="JSON representation of a python AT Lattice",
+    descr="JSON representation of a python AT Lattice. See :py:func:`.load_json`.",
 )

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -11,16 +11,8 @@ from ..lattice import Element, Lattice, Particle, get_class_map
 _CLASS_MAP = get_class_map()
 
 
-def elemstr(self):
-    attrs = dict(self.items())
-    return "\n".join(
-        [self.__class__.__name__ + ":"]
-        + [f"{k:>14}: {attrs.pop(k)!s}" for k in ["FamName", "Length", "PassMethod"]]
-        + [f"{k:>14}: {v!s}" for k, v in attrs.items()]
-    )
-
-
 class _AtEncoder(json.JSONEncoder):
+    """JSON encoder for specific AT types"""
     def default(self, obj):
         if isinstance(obj, Element):
             return obj.definition
@@ -45,7 +37,7 @@ def save_json(ring: Lattice, filename: Optional[str] = None) -> None:
         :py:meth:`.Lattice.save` for a generic lattice-saving method.
     """
     if filename is None:
-        json.dumps(("Lattice", ring, ring.attrs), cls=_AtEncoder)
+        print(json.dumps(("Lattice", ring, ring.attrs), cls=_AtEncoder))
     else:
         with open(filename, "wt") as jsonfile:
             json.dump(("Lattice", ring, ring.attrs), jsonfile, cls=_AtEncoder)

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -163,9 +163,9 @@ def load_mat(filename: str, **kwargs) -> Lattice:
 
     Keyword Args:
         use (str):          Name of the Matlab variable containing
-          the lattice. Default: Matlab variable name if there is only one,
-          otherwise 'RING'
-        mat_key (str):      alias for *use*
+          the lattice. Default: it there is a single variable, use it, otherwise
+          select 'RING'
+        mat_key (str):      deprecated alias for *use*
         check (bool):       Run the coherence tests. Default:
           :py:obj:`True`
         quiet (bool):       Suppress the warning for non-standard
@@ -479,7 +479,7 @@ def save_m(ring: Lattice, filename: Optional[str] = None) -> None:
 
 # Simulates the deprecated "mat_file" and "mat_key" attributes
 def _mat_file(ring):
-    """.mat input file. Deprecated, use 'in_file' instead."""
+    """.mat input file. Deprecated, use *in_file* instead."""
     try:
         in_file = ring.in_file
     except AttributeError:
@@ -492,7 +492,7 @@ def _mat_file(ring):
 
 
 def _mat_key(ring):
-    """selected Matlab variable. Deprecated, use 'use' instead."""
+    """selected Matlab variable. Deprecated, use *use* instead."""
     try:
         mat_key = ring.use
     except AttributeError:
@@ -500,8 +500,18 @@ def _mat_key(ring):
     return mat_key
 
 
-register_format(".mat", load_mat, save_mat, descr="Matlab binary mat-file")
-register_format(".m", load_m, save_m, descr="Matlab text m-file")
+register_format(
+    ".mat",
+    load_mat,
+    save_mat,
+    descr="Matlab binary mat-file. See :py:func:`.load_mat`.",
+),
+register_format(
+    ".m",
+    load_m,
+    save_m,
+    descr="Matlab text m-file. See :py:func:`.load_m`."
+),
 
 Lattice.mat_file = property(_mat_file, None, None)
 Lattice.mat_key = property(_mat_key, None, None)

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -21,7 +21,6 @@ from numpy import array, uint8, NaN  # noqa: F401
 
 from .allfiles import register_format
 from .utils import split_ignoring_parentheses, RingParam, keep_elements
-from .utils import element_from_dict
 from .utils import _drop_attrs, _CLASS_MAP
 from ..lattice import Element, Lattice, Particle, Filter
 from ..lattice import elements, AtWarning, params_filter, AtError
@@ -98,7 +97,7 @@ def _matfile_generator(
     for index, mat_elem in enumerate(cell_array):
         elem = mat_elem[0, 0]
         kwargs = {f: mclean(elem[f]) for f in elem.dtype.fields}
-        yield element_from_dict(kwargs, index=index, check=check, quiet=quiet)
+        yield Element.from_dict(kwargs, index=index, check=check, quiet=quiet)
 
 
 def ringparam_filter(
@@ -344,7 +343,7 @@ def load_var(matlat: Sequence[dict], **kwargs) -> Lattice:
     # noinspection PyUnusedLocal
     def var_generator(params, latt):
         for elem in latt:
-            yield element_from_dict(elem)
+            yield Element.from_dict(elem)
 
     return Lattice(
         ringparam_filter, var_generator, matlat, iterator=params_filter, **kwargs

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -331,12 +331,8 @@ def save_mat(ring: Lattice, filename: str, mat_key: str = "RING") -> None:
     See Also:
         :py:func:`.save_lattice` for a generic lattice-saving function.
     """
-#   lring = tuple(element_to_dict(el, encoder=_mat_encoder) for el in matlab_ring(ring))
-#   Ensure the lattice is a Matlab column vector
-    lring = np.array(
-        [element_to_dict(el, encoder=_mat_encoder) for el in matlab_ring(ring)]
-    ).reshape(-1, 1)
-    # noinspection PyUnresolvedReferences
+    # Ensure the lattice is a Matlab column vector: list(list)
+    lring = [[element_to_dict(el, encoder=_mat_encoder)] for el in matlab_ring(ring)]
     scipy.io.savemat(filename, {mat_key: lring}, long_field_names=True)
 
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -190,7 +190,7 @@ def load_mat(filename: str, **kwargs) -> Lattice:
     if "key" in kwargs:  # process the deprecated 'key' keyword
         kwargs.setdefault("use", kwargs.pop("key"))
     if "mat_key" in kwargs:  # process the deprecated 'mat_key' keyword
-        kwargs.setdefault("use", kwargs.pop("key"))
+        kwargs.setdefault("use", kwargs.pop("mat_key"))
     return Lattice(
         ringparam_filter,
         _matfile_generator,

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -331,7 +331,11 @@ def save_mat(ring: Lattice, filename: str, mat_key: str = "RING") -> None:
     See Also:
         :py:func:`.save_lattice` for a generic lattice-saving function.
     """
-    lring = tuple(element_to_dict(el, encoder=_mat_encoder) for el in matlab_ring(ring))
+#   lring = tuple(element_to_dict(el, encoder=_mat_encoder) for el in matlab_ring(ring))
+#   Ensure the lattice is a Matlab column vector
+    lring = np.array(
+        [element_to_dict(el, encoder=_mat_encoder) for el in matlab_ring(ring)]
+    ).reshape(-1, 1)
     # noinspection PyUnresolvedReferences
     scipy.io.savemat(filename, {mat_key: lring}, long_field_names=True)
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -374,21 +374,25 @@ def matlab_ring(ring: Lattice) -> Generator[Element, None, None]:
     yield from keep_elements(ring)
 
 
-def save_mat(ring: Lattice, filename: str, mat_key: str = "RING") -> None:
+def save_mat(ring: Lattice, filename: str, **kwargs) -> None:
     """Save a :py:class:`.Lattice` as a Matlab mat-file
 
     Parameters:
-        ring:           Lattice description
-        filename:       Name of the '.mat' file
-        mat_key (str):  Name of the Matlab variable containing
-          the lattice. Default: ``'RING'``
+        ring:       Lattice description
+        filename:   Name of the '.mat' file
+
+    Keyword Args:
+        use (str):  Name of the Matlab variable containing the lattice, Default: "RING"
+        mat_key (str): Deprecated, alias for *use*
 
     See Also:
         :py:func:`.save_lattice` for a generic lattice-saving function.
     """
     # Ensure the lattice is a Matlab column vector: list(list)
+    use = kwargs.pop("mat_key", "RING")  # For backward compatibility
+    use = kwargs.pop("use", use)
     lring = [[el.to_dict(encoder=_mat_encoder)] for el in matlab_ring(ring)]
-    scipy.io.savemat(filename, {mat_key: lring}, long_field_names=True)
+    scipy.io.savemat(filename, {use: lring}, long_field_names=True)
 
 
 def _element_to_m(elem: Element) -> str:

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -211,7 +211,7 @@ def _element_from_m(line: str) -> Element:
     """
 
     def argsplit(value):
-        return [a.strip() for a in split_ignoring_parentheses(value, ",")]
+        return [a.strip() for a in split_ignoring_parentheses(value)]
 
     def makedir(mat_struct):
         """Build directory from Matlab struct arguments"""
@@ -505,13 +505,14 @@ register_format(
     load_mat,
     save_mat,
     descr="Matlab binary mat-file. See :py:func:`.load_mat`.",
-),
+)
+
 register_format(
     ".m",
     load_m,
     save_m,
-    descr="Matlab text m-file. See :py:func:`.load_m`."
-),
+    descr="Matlab text m-file. See :py:func:`.load_m`.",
+)
 
 Lattice.mat_file = property(_mat_file, None, None)
 Lattice.mat_key = property(_mat_key, None, None)

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -21,17 +21,19 @@ from .utils import element_to_dict, element_to_m
 from ..lattice import Element, Lattice, Particle, Filter
 from ..lattice import elements, AtWarning, params_filter, AtError
 
+# Translation of RingParam attributes
 _m2p = {
     "FamName": "name",
     "Energy": "energy",
     "Periodicity": "periodicity",
     "Particle": "particle",
     "cell_harmnumber": "cell_harmnumber",
+    "beam_current": "beam_current",
+    "PassMethod": None,
+    "Length": None,
+    "cavpts": None,
 }
-_param_ignore = {"PassMethod", "Length", "cavpts"}
-
-# Python to Matlab
-_p2m = {"name", "energy", "periodicity", "particle", "cell_harmnumber", "beam_current"}
+_p2m = dict((v, k) for k, v in _m2p.items() if v is not None)
 
 # Python to Matlab type translation
 _mattype_map = {
@@ -144,8 +146,9 @@ def ringparam_filter(
         if isinstance(elem, RingParam):
             ringparams.append(elem)
             for k, v in elem.items():
-                if k not in _param_ignore:
-                    params.setdefault(_m2p.get(k, k), v)
+                k2 = _m2p.get(k, k)
+                if k2 is not None:
+                    params.setdefault(k2, v)
             if keep_all:
                 pars = vars(elem).copy()
                 name = pars.pop("FamName")
@@ -300,14 +303,14 @@ def matlab_ring(ring: Lattice) -> Generator[Element, None, None]:
         # Public lattice attributes
         params = dict((k, v) for k, v in vars(rng).items() if not k.startswith("_"))
         # Output the required attributes/properties
-        for k in _p2m:
+        for kp, km in _p2m.items():
             try:
-                v = getattr(rng, k)
+                v = getattr(rng, kp)
             except AttributeError:
                 pass
             else:
-                params.pop(k, None)
-                yield k, v
+                params.pop(kp, None)
+                yield km, v
         # Output the remaining attributes
         yield from params.items()
 

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -103,5 +103,5 @@ register_format(
     load_repr,
     save_repr,
     descr=("Text representation of a python AT Lattice. "
-           "See also :py:func:`.load_repr`."),
+           "See :py:func:`.load_repr`."),
 )

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -1,18 +1,23 @@
 """Text representation of a python AT lattice with each element represented by
 its :py:func:`repr` string
 """
+
 from __future__ import print_function
+
+__all__ = ["load_repr", "save_repr"]
+
 import sys
 from os.path import abspath
 from typing import Optional
+
 import numpy
+
 from at.lattice import Lattice
-from at.load import register_format
-from at.load.utils import element_from_string
+
 # imports necessary in' globals()' for 'eval'
 from at.lattice import Particle  # noqa: F401
-
-__all__ = ['load_repr', 'save_repr']
+from at.load import register_format
+from at.load.utils import element_from_string
 
 
 def load_repr(filename: str, **kwargs) -> Lattice:
@@ -37,8 +42,9 @@ def load_repr(filename: str, **kwargs) -> Lattice:
     See Also:
         :py:func:`.load_lattice` for a generic lattice-loading function.
     """
+
     def elem_iterator(params, repr_file):
-        with open(params.setdefault('repr_file', repr_file), 'rt') as file:
+        with open(params.setdefault("repr_file", repr_file), "rt") as file:
             # the 1st line is the dictionary of saved lattice parameters
             for k, v in eval(next(file)).items():
                 params.setdefault(k, v)
@@ -59,25 +65,21 @@ def save_repr(ring: Lattice, filename: Optional[str] = None) -> None:
     See Also:
         :py:func:`.save_lattice` for a generic lattice-saving function.
     """
+
     def save(file):
-        # print(repr(dict((k, v) for k, v in vars(ring).items()
-        #                 if not k.startswith('_'))), file=file)
         print(repr(ring.attrs), file=file)
         for elem in ring:
             print(repr(elem), file=file)
 
-    # Save the current options
-    opts = numpy.get_printoptions()
     # Set options to print the full representation of float variables
-    numpy.set_printoptions(formatter={'float_kind': repr})
-    if filename is None:
-        save(sys.stdout)
-    else:
-        with open(filename, 'wt') as reprfile:
-            save(reprfile)
-    # Restore the current options
-    numpy.set_printoptions(**opts)
+    with numpy.printoptions(formatter={"float_kind": repr}):
+        if filename is None:
+            save(sys.stdout)
+        else:
+            with open(filename, "wt") as reprfile:
+                save(reprfile)
 
 
-register_format('.repr', load_repr, save_repr,
-                descr='Text representation of a python AT Lattice')
+register_format(
+    ".repr", load_repr, save_repr, descr="Text representation of a python AT Lattice"
+)

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -17,7 +17,7 @@ from at.lattice import Lattice
 # imports necessary in' globals()' for 'eval'
 from at.lattice import Particle  # noqa: F401
 from at.load import register_format
-from at.load.utils import element_from_string
+from at.load.utils import element_from_string, keep_attributes, keep_elements
 
 
 def load_repr(filename: str, **kwargs) -> Lattice:
@@ -44,7 +44,7 @@ def load_repr(filename: str, **kwargs) -> Lattice:
     """
 
     def elem_iterator(params, repr_file):
-        with open(params.setdefault("repr_file", repr_file), "rt") as file:
+        with open(params.setdefault("in_file", repr_file), "rt") as file:
             # the 1st line is the dictionary of saved lattice parameters
             for k, v in eval(next(file)).items():
                 params.setdefault(k, v)
@@ -67,8 +67,8 @@ def save_repr(ring: Lattice, filename: Optional[str] = None) -> None:
     """
 
     def save(file):
-        print(repr(ring.attrs), file=file)
-        for elem in ring:
+        print(repr(keep_attributes(ring)), file=file)
+        for elem in keep_elements(ring):
             print(repr(elem), file=file)
 
     # Set options to print the full representation of float variables

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -2,7 +2,7 @@
 its :py:func:`repr` string
 """
 
-from __future__ import print_function
+from __future__ import annotations
 
 __all__ = ["load_repr", "save_repr"]
 

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -378,7 +378,11 @@ def element_to_dict(elem: Element, encoder: Callable[[Any], Any] = _no_encoder) 
     return dct
 
 
-def split_ignoring_parentheses(string, delimiter):
+def split_ignoring_parentheses(string: str, delimiter: str = ",") -> list[str]:
+    """Split a string while keeping parenthesized expressions intact
+
+    Example: "l=0,hom(4,0.0,0)" -> ["l=0", "hom(4,0.0,0)"]
+    """
     placeholder = "placeholder"
     substituted = string[:]
     matches = collections.deque(re.finditer("\\(.*?\\)", string))

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -5,11 +5,9 @@ Conversion utilities for creating pyat elements
 from __future__ import annotations
 
 __all__ = [
+    "element_classes",
     "element_from_dict",
     "element_to_dict",
-    "element_from_m",
-    "element_to_m",
-    "element_from_string",
     "find_class",
     "keep_elements",
     "keep_attributes",
@@ -27,12 +25,9 @@ from collections.abc import Callable, Generator
 
 import numpy as np
 
-# imports necessary in 'globals()' for 'eval'
-from numpy import array, uint8, NaN  # noqa: F401
-
 from at import integrators
 from at.lattice import AtWarning
-from at.lattice import get_class_map, elements as elt
+from at.lattice import elements as elt
 from at.lattice import Lattice, Particle, Element, Marker
 from at.lattice import idtable_element
 
@@ -60,6 +55,20 @@ def _warn(index: int, message: str, elem_dict: dict) -> None:
     location = f'"{name}":\n' if index is None else f'{index} ("{name}"):\n'
     warning = "".join(("In element ", location, message, f"\n{elem_dict}\n"))
     warn(AtWarning(warning), stacklevel=2)
+
+
+def element_classes() -> frozenset[type[Element]]:
+    """Build a set of all Element subclasses"""
+
+    # Misses class aliases (Bend, Matrix66)
+    def subclasses_recursive(cl):
+        direct = cl.__subclasses__()
+        indirect = []
+        for subclass in direct:
+            indirect.extend(subclasses_recursive(subclass))
+        return frozenset([cl] + direct + indirect)
+
+    return subclasses_recursive(Element)
 
 
 class RingParam(elt.Element):
@@ -102,15 +111,14 @@ _alias_map = {
     "ap": elt.Aperture,
     "ringparam": RingParam,
     "wig": elt.Wiggler,
-    "insertiondevicekickmap": idtable_element.InsertionDeviceKickMap,
     "matrix66": elt.M66,
 }
 
-
-# Matlab to Python class translation
-_CLASS_MAP = dict((k.lower(), v) for k, v in get_class_map().items())
+# Map class names to Element classes
+_CLASS_MAP = dict((cls.__name__.lower(), cls) for cls in element_classes())
 _CLASS_MAP.update(_alias_map)
 
+# Maps passmethods to Element classes
 _PASS_MAP = {
     "BendLinearPass": elt.Dipole,
     "BndMPoleSymplectic4RadPass": elt.Dipole,
@@ -128,22 +136,17 @@ _PASS_MAP = {
     "GWigSymplecticPass": elt.Wiggler,
 }
 
-# Python to Matlab class translation
+# Maps python class name to Matlab class
 # Default: element_class.__name__
 _mat_class = {
     "Dipole": "Bend",
     "M66": "Matrix66",
 }
-# Matlab constructor function
-# Default: "".join(("at", element_class.__name__.lower()))
-_mat_constructor = {
-    "Dipole": "atsbend",
-    "M66": "atM66",
-}
 
 # Lattice attributes which must be dropped when writing a file
 _drop_attrs = {
     "in_file": None,
+    "use": None,
     "mat_key": None,
     "mat_file": None,  # Not used anymore...
     "m_file": None,
@@ -185,10 +188,65 @@ def keep_elements(ring: Lattice) -> Generator[Element, None, None]:
             yield elem
 
 
+def _from_contents(elem: dict) -> type[Element]:
+    """Deduce the element class from its contents"""
+
+    def low_order(key):
+        polynom = np.array(elem[key], dtype=np.float64).reshape(-1)
+        try:
+            low = np.where(polynom != 0.0)[0][0]
+        except IndexError:
+            low = -1
+        return low
+
+    length = float(elem.get("Length", 0.0))
+    pass_method = elem.get("PassMethod", "")
+    if _hasattrs(
+        elem, "FullGap", "FringeInt1", "FringeInt2", "gK", "EntranceAngle", "ExitAngle"
+    ):
+        return elt.Dipole
+    elif _hasattrs(elem, "Voltage", "Frequency", "HarmNumber", "PhaseLag", "TimeLag"):
+        return elt.RFCavity
+    elif _hasattrs(elem, "Periodicity"):
+        # noinspection PyProtectedMember
+        return RingParam
+    elif _hasattrs(elem, "Limits"):
+        return elt.Aperture
+    elif _hasattrs(elem, "M66"):
+        return elt.M66
+    elif _hasattrs(elem, "K"):
+        return elt.Quadrupole
+    elif _hasattrs(elem, "PolynomB", "PolynomA"):
+        loworder = low_order("PolynomB")
+        if loworder == 1:
+            return elt.Quadrupole
+        elif loworder == 2:
+            return elt.Sextupole
+        elif loworder == 3:
+            return elt.Octupole
+        elif pass_method.startswith("StrMPoleSymplectic4") or (length > 0):
+            return elt.Multipole
+        else:
+            return elt.ThinMultipole
+    elif _hasattrs(elem, "KickAngle"):
+        return elt.Corrector
+    elif length > 0.0:
+        return elt.Drift
+    elif _hasattrs(elem, "GCR"):
+        return elt.Monitor
+    elif pass_method == "IdentityPass":
+        return elt.Marker
+    else:
+        return elt.Element
+
+
 def find_class(
     elem_dict: dict, quiet: bool = False, index: Optional[int] = None
 ) -> type(Element):
-    """Identify the class of an element from its attributes
+    """Deduce the class of an element from its attributes
+
+    `find_class` looks first at the "Class" field, if existing. It then tries to deduce
+    the class from "FamName", from "PassMethod", and finally form the element contents.
 
     Args:
         elem_dict:      The dictionary of keyword arguments passed to the
@@ -200,88 +258,40 @@ def find_class(
         element_class:  The guessed Class name
     """
 
-    def low_order(key):
-        polynom = np.array(elem_dict[key], dtype=np.float64).reshape(-1)
-        try:
-            low = np.where(polynom != 0.0)[0][0]
-        except IndexError:
-            low = -1
-        return low
+    def check_class(clname):
+        if clname:
+            _warn(index, f"Class '{clname}' does not exist.", elem_dict)
 
-    class_name = elem_dict.pop("Class", "")
-    try:
-        return _CLASS_MAP[class_name.lower()]
-    except KeyError:
-        if not quiet and class_name:
-            _warn(index, f"Class '{class_name}' does not exist.", elem_dict)
-        fam_name = elem_dict.get("FamName", "")
-        try:
-            return _CLASS_MAP[fam_name.lower()]
-        except KeyError:
-            pass_method = elem_dict.get("PassMethod", "")
-            if not quiet and not pass_method:
-                _warn(index, "No PassMethod provided.", elem_dict)
-            elif not quiet and not pass_method.endswith("Pass"):
-                message = (
-                    f"Invalid PassMethod '{pass_method}', "
-                    "provided pass methods should end in 'Pass'."
-                )
-                _warn(index, message, elem_dict)
-            class_from_pass = _PASS_MAP.get(pass_method)
-            if class_from_pass is not None:
-                return class_from_pass
-            else:
-                length = float(elem_dict.get("Length", 0.0))
-                if _hasattrs(
-                    elem_dict,
-                    "FullGap",
-                    "FringeInt1",
-                    "FringeInt2",
-                    "gK",
-                    "EntranceAngle",
-                    "ExitAngle",
-                ):
-                    return elt.Dipole
-                elif _hasattrs(
-                    elem_dict,
-                    "Voltage",
-                    "Frequency",
-                    "HarmNumber",
-                    "PhaseLag",
-                    "TimeLag",
-                ):
-                    return elt.RFCavity
-                elif _hasattrs(elem_dict, "Periodicity"):
-                    # noinspection PyProtectedMember
-                    return RingParam
-                elif _hasattrs(elem_dict, "Limits"):
-                    return elt.Aperture
-                elif _hasattrs(elem_dict, "M66"):
-                    return elt.M66
-                elif _hasattrs(elem_dict, "K"):
-                    return elt.Quadrupole
-                elif _hasattrs(elem_dict, "PolynomB", "PolynomA"):
-                    loworder = low_order("PolynomB")
-                    if loworder == 1:
-                        return elt.Quadrupole
-                    elif loworder == 2:
-                        return elt.Sextupole
-                    elif loworder == 3:
-                        return elt.Octupole
-                    elif pass_method.startswith("StrMPoleSymplectic4") or (length > 0):
-                        return elt.Multipole
-                    else:
-                        return elt.ThinMultipole
-                elif _hasattrs(elem_dict, "KickAngle"):
-                    return elt.Corrector
-                elif length > 0.0:
-                    return elt.Drift
-                elif _hasattrs(elem_dict, "GCR"):
-                    return elt.Monitor
-                elif pass_method == "IdentityPass":
-                    return elt.Marker
-                else:
-                    return elt.Element
+    def check_pass(passm):
+        if not passm:
+            _warn(index, "No PassMethod provided.", elem_dict)
+        elif not passm.endswith("Pass"):
+            message = (
+                f"Invalid PassMethod '{passm}': "
+                "provided pass methods should end in 'Pass'."
+            )
+            _warn(index, message, elem_dict)
+
+    class_name = elem_dict.pop("Class", "")  # try from class name
+    cls = _CLASS_MAP.get(class_name.lower(), None)
+    if cls is not None:
+        return cls
+    elif not quiet:
+        check_class(class_name)
+
+    elname = elem_dict.get("FamName", "")  # try from element name
+    cls = _CLASS_MAP.get(elname.lower(), None)
+    if cls is not None:
+        return cls
+
+    pass_method = elem_dict.get("PassMethod", "")  # try from passmethod
+    cls = _PASS_MAP.get(pass_method, None)
+    if cls is not None:
+        return cls
+    elif not quiet:
+        check_pass(pass_method)
+
+    return _from_contents(elem_dict)  # look for contents
 
 
 def element_from_dict(
@@ -352,83 +362,6 @@ def element_from_dict(
     return element
 
 
-def element_from_string(elem_string: str) -> Element:
-    """Builds an :py:class:`.Element` from its python :py:func:`repr` string
-
-    Parameters:
-        elem_string:    String representation of an :py:class:`.Element`
-
-    Returns:
-        elem (Element): new :py:class:`.Element`
-    """
-    return eval(elem_string, globals(), get_class_map())
-
-
-def element_from_m(line: str) -> Element:
-    """Builds an :py:class:`.Element` from a line in an m-file
-
-    Parameters:
-        line:           Matlab string representation of an :py:class:`.Element`
-
-    Returns:
-        elem (Element): new :py:class:`.Element`
-    """
-
-    def argsplit(value):
-        return [a.strip() for a in split_ignoring_parentheses(value, ",")]
-
-    def makedir(mat_struct):
-        """Build directory from Matlab struct arguments"""
-
-        def pairs(it):
-            while True:
-                try:
-                    a = next(it)
-                except StopIteration:
-                    break
-                yield eval(a), convert(next(it))
-
-        return dict(pairs(iter(mat_struct)))
-
-    def makearray(mat_arr):
-        """Build numpy array for Matlab array syntax"""
-
-        def arraystr(arr):
-            lns = arr.split(";")
-            rr = [arraystr(v) for v in lns] if len(lns) > 1 else lns[0].split()
-            return "[{0}]".format(", ".join(rr))
-
-        return eval("array({0})".format(arraystr(mat_arr)))
-
-    def convert(value):
-        """convert Matlab syntax to numpy syntax"""
-        if value.startswith("["):
-            result = makearray(value[1:-1])
-        elif value.startswith("struct"):
-            result = makedir(argsplit(value[7:-1]))
-        else:
-            result = eval(value)
-        return result
-
-    left = line.index("(")
-    right = line.rindex(")")
-    matcls = line[:left].strip()[2:]
-    cls = _CLASS_MAP[matcls]
-    arguments = argsplit(line[left + 1 : right])
-    ll = len(cls._BUILD_ATTRIBUTES)
-    if ll < len(arguments) and arguments[ll].endswith("Pass'"):
-        arguments.insert(ll, "'PassMethod'")
-    args = [convert(v) for v in arguments[:ll]]
-    kwargs = makedir(arguments[ll:])
-    if matcls == "rbend":
-        # the Matlab 'rbend' has no equivalent in PyAT. This adds parameters
-        # necessary for using the python sector bend
-        halfangle = 0.5 * args[2]
-        kwargs.setdefault("EntranceAngle", halfangle)
-        kwargs.setdefault("ExitAngle", halfangle)
-    return cls(*args, **kwargs)
-
-
 def element_to_dict(elem: Element, encoder: Callable[[Any], Any] = _no_encoder) -> dict:
     """Builds the Matlab structure of an :py:class:`.Element`
 
@@ -443,64 +376,6 @@ def element_to_dict(elem: Element, encoder: Callable[[Any], Any] = _no_encoder) 
     class_name = elem.__class__.__name__
     dct["Class"] = _mat_class.get(class_name, class_name)
     return dct
-
-
-def element_to_m(elem: Element) -> str:
-    """Builds the Matlab-evaluable string for an :py:class:`.Element`
-
-    Parameters:
-        elem:           :py:class:`.Element`
-
-    Returns:
-        mstr (str):     Matlab string representation of the
-          :py:class:`.Element` attributes
-    """
-
-    def convert(arg):
-        def convert_dict(pdir):
-            def scan(d):
-                for k, v in d.items():
-                    yield convert(k)
-                    yield convert(v)
-
-            return "struct({0})".format(", ".join(scan(pdir)))
-
-        def convert_array(arr):
-            if arr.ndim > 1:
-                lns = (str(list(ln)).replace(",", "")[1:-1] for ln in arr)
-                return "".join(("[", "; ".join(lns), "]"))
-            elif arr.ndim > 0:
-                return str(list(arr)).replace(",", "")
-            else:
-                return str(arr)
-
-        if isinstance(arg, np.ndarray):
-            return convert_array(arg)
-        elif isinstance(arg, dict):
-            return convert_dict(arg)
-        elif isinstance(arg, Particle):
-            return convert_dict(arg.to_dict())
-        else:
-            return repr(arg)
-
-    def m_name(elclass):
-        classname = elclass.__name__
-        return _mat_constructor.get(classname, "".join(("at", classname.lower())))
-
-    attrs = dict(elem.items())
-    # noinspection PyProtectedMember
-    args = [attrs.pop(k, getattr(elem, k)) for k in elem._BUILD_ATTRIBUTES]
-    defelem = elem.__class__(*args)
-    kwds = dict(
-        (k, v)
-        for k, v in attrs.items()
-        if not np.array_equal(v, getattr(defelem, k, None))
-    )
-    argstrs = [convert(arg) for arg in args]
-    if "PassMethod" in kwds:
-        argstrs.append(convert(kwds.pop("PassMethod")))
-    argstrs += [", ".join((repr(k), convert(v))) for k, v in kwds.items()]
-    return "{0:>15}({1});...".format(m_name(elem.__class__), ", ".join(argstrs))
 
 
 def split_ignoring_parentheses(string, delimiter):
@@ -519,3 +394,6 @@ def split_ignoring_parentheses(string, delimiter):
     assert not matches
 
     return replaced_parts
+
+
+Element.to_dict = element_to_dict

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -11,7 +11,8 @@ __all__ = [
     "element_to_m",
     "element_from_string",
     "find_class",
-    "save_filter",
+    "keep_elements",
+    "keep_attributes",
     "split_ignoring_parentheses",
     "RingParam",
 ]
@@ -140,6 +141,15 @@ _mat_constructor = {
     "M66": "atM66",
 }
 
+# Lattice attributes which must be dropped when writing a file
+_drop_attrs = {
+    "in_file": None,
+    "mat_key": None,
+    "mat_file": None,  # Not used anymore...
+    "m_file": None,
+    "repr_file": None,
+}
+
 
 def _hasattrs(kwargs: dict, *attributes) -> bool:
     """Checks the presence of keys in a :py:class:`dict`
@@ -161,7 +171,15 @@ def _hasattrs(kwargs: dict, *attributes) -> bool:
     return False
 
 
-def save_filter(ring: Lattice) -> Generator[Element, None, None]:
+def keep_attributes(ring: Lattice):
+    """Remove Lattice attributes which must not be saved on file"""
+    return dict(
+        (k, v) for k, v in ring.attrs.items() if _drop_attrs.get(k, k) is not None
+    )
+
+
+def keep_elements(ring: Lattice) -> Generator[Element, None, None]:
+    """Remove the 'RingParam' Marker"""
     for elem in ring:
         if not (isinstance(elem, Marker) and getattr(elem, "tag", None) == "RingParam"):
             yield elem

--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -363,7 +363,7 @@ def element_from_dict(
 
 
 def element_to_dict(elem: Element, encoder: Callable[[Any], Any] = _no_encoder) -> dict:
-    """Builds the Matlab structure of an :py:class:`.Element`
+    """Convert a :py:class:`.Element` to a :py:class:`dict`
 
     Parameters:
         elem:           :py:class:`.Element`
@@ -396,4 +396,5 @@ def split_ignoring_parentheses(string, delimiter):
     return replaced_parts
 
 
+Element.from_dict = staticmethod(element_from_dict)
 Element.to_dict = element_to_dict

--- a/pyat/test/test_basic_elements.py
+++ b/pyat/test/test_basic_elements.py
@@ -15,8 +15,8 @@ def test_data_checks():
 
 def test_element_string_ordering():
     d = elements.Drift('D0', 1, attr=numpy.array(0))
-    assert d.__str__() == ("Drift:\n\tFamName : D0\n\tLength : 1.0\n"
-                           "\tPassMethod : DriftPass\n\tattr : 0")
+    assert d.__str__() == ("Drift:\n       FamName: D0\n        Length: 1.0\n"
+                           "    PassMethod: DriftPass\n          attr: 0")
     assert d.__repr__() == "Drift('D0', 1.0, attr=array(0))"
 
 

--- a/pyat/test/test_load_save.py
+++ b/pyat/test/test_load_save.py
@@ -1,0 +1,36 @@
+import os
+from tempfile import mktemp
+
+import pytest
+from numpy.testing import assert_equal
+
+from at.lattice import Lattice
+
+
+@pytest.mark.parametrize("lattice", ["dba_lattice", "hmba_lattice"])
+@pytest.mark.parametrize(
+    "suffix, options",
+    [
+        (".m", {}),
+        (".repr", {}),
+        (".mat", {"use": "abcd"}),
+        (".json", {}),
+    ],
+)
+def test_m(request, lattice, suffix, options):
+    ring0 = request.getfixturevalue(lattice)
+    fname = mktemp(suffix=suffix)
+
+    # Create a new .m or .repr file
+    ring0.save(fname, **options)
+
+    # load the new file
+    ring1 = Lattice.load(fname, **options)
+
+    # Check that we get back the original lattice
+    el1, rg1, _ = ring0.linopt6()
+    el2, rg2, _ = ring1.linopt6()
+    assert_equal(rg1.tune, rg2.tune)
+    assert_equal(rg1.chromaticity, rg2.chromaticity)
+
+    os.unlink(fname)

--- a/pyat/test/test_load_utils.py
+++ b/pyat/test/test_load_utils.py
@@ -5,8 +5,10 @@ import warnings
 from at import AtWarning
 from at.lattice import Lattice, elements, params_filter, no_filter
 from at.load.utils import find_class, element_from_dict
+# noinspection PyProtectedMember
 from at.load.utils import _CLASS_MAP, _PASS_MAP
 from at.load.utils import RingParam, split_ignoring_parentheses
+# noinspection PyProtectedMember
 from at.load.matfile import ringparam_filter
 
 
@@ -66,8 +68,8 @@ def test_inconsistent_energy_values_warns_correctly():
 
 
 def test_more_than_one_RingParam_in_ring_raises_warning():
-    p1 = RingParam('rp1', 5.e+6)
-    p2 = RingParam('rp2', 3.e+6)
+    p1 = RingParam('rp1', 5.e+6, 1)
+    p2 = RingParam('rp2', 3.e+6, 1)
     with pytest.warns(AtWarning):
         params = _matlab_scanner([p1, p2])
         assert params['_energy'] == 5.e+6


### PR DESCRIPTION
With this PR, AT can save and load lattices in JSON format. JSON is a text-based format with the following properties:
- JSON is a widely used format for storing structured data (ex.: Jupyter .ipynb files),
- JSON is natively supported by both Matlab and python,
- JSON files can be manipulated by external editors and viewers,
- AT files in JSON format can be used for exchanging lattices between Matlab and python, as an alternative to the proprietary `.mat` format.

In addition, a few modifications have been made to the global load/save package to prepare future formats:
- for file formats possibly containing several lattices (.mat, Elegant files), a specific keyword allows to select  the desired lattice. A unique keyword `use=lattice_name` is now used for all formats, while the specific keywords (`matkey=`, `lattice_key=` etc.) are still understood for compatibility,
- similarly, in the lattice attributes, the specific attribute `mat_file`, `elegant_file`... which records the input file name is replaced by a single one: `in_file`. This avoids the accumulation of different attributes, with the consequence that the last loaded file could not be identified. The file name extension is enough to know which kind of file was loaded.

Finally, the file loading structure is improved to allow an easier addition of new formats.
