### PR TITLE
Adapted the get_mcf() function

### DIFF
--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -12,7 +12,10 @@ __all__ = ['get_mcf', 'get_slip_factor', 'get_revolution_frequency',
 
 @check_6d(False)
 def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
-            keep_lattice: bool = False, **kwargs) -> float:
+            keep_lattice: bool = False,
+            fit_order: Optional[int] = 1,
+            n_step: Optional[int] = 2,
+            **kwargs) -> float:
     r"""Compute the momentum compaction factor :math:`\alpha`
 
     Parameters:
@@ -21,24 +24,33 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         dp:             Momentum deviation. Defaults to :py:obj:`None`
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: :py:obj:`False`
+        fit_order:      Maximum momentum compaction factor to be fitted.
+          Defaults to :py:obj:`None`
+        n_step:         Number of different calculated momentum deviations to be fitted
+          with a polynomial.
+          Defaults to :py:obj:`None`
 
     Keyword Args:
         DPStep (Optional[float]):       Momentum step size.
           Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     Returns:
-        mcf (float):    Momentum compaction factor :math:`\alpha`
+        mcf (array):    Momentum compaction factor :math:`\alpha`
+          up to the order fit_order
     """
+    if n_step < 2*fit_order:
+        print('Low nunber of steps, it is advised to have n_step >= 2*fit_order'+
+        ' for a better fit.')
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
-    fp_a, _ = find_orbit4(ring, dp=dp - 0.5*dp_step, keep_lattice=keep_lattice)
-    fp_b, _ = find_orbit4(ring, dp=dp + 0.5*dp_step, keep_lattice=True)
-    fp = numpy.stack((fp_a, fp_b),
-                     axis=0).T  # generate a Fortran contiguous array
+    dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)
+    fp_i = tuple(at.physics.find_orbit4(ring_py, dp=dp + dp_i, keep_lattice=True)[0] \
+       for dp_i in dp_samples)
+    fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
     b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
     ring_length = get_s_pos(ring, len(ring))
-    alphac = (b[5, 1] - b[5, 0]) / dp_step / ring_length[0]
+    p = numpy.polynomial.Polynomial.fit(b[4], b[5], deg=fit_order).convert().coef
+    alphac = p[1:] / ring_length[0]
     return alphac
-
 
 def get_slip_factor(ring: Lattice, **kwargs) -> float:
     r"""Compute the slip factor :math:`\eta`

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -44,10 +44,10 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         ' for a better fit.')
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)
-    fp_i = tuple(find_orbit4(ring, dp=dp + dp_i, keep_lattice=True)[0] \
+    fp_i = tuple(find_orbit4(ring, dp=dp + dp_i, keep_lattice=keep_lattice)[0] \
        for dp_i in dp_samples)
     fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
-    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
+    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=keep_lattice), axis=(2, 3))
     ring_length = get_s_pos(ring, len(ring))
     p = numpy.polynomial.Polynomial.fit(b[4], b[5], deg=fit_order).convert().coef
     alphac = p[1:] / ring_length[0]

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -44,7 +44,7 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         ' for a better fit.')
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)
-    fp_i = tuple(find_orbit4(ring_py, dp=dp + dp_i, keep_lattice=True)[0] \
+    fp_i = tuple(find_orbit4(ring, dp=dp + dp_i, keep_lattice=True)[0] \
        for dp_i in dp_samples)
     fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
     b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -25,10 +25,10 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: :py:obj:`False`
         fit_order:      Maximum momentum compaction factor order to be fitted.
-          Defaults to 1, corresponding to the first-order momentum compaction factor.
+          Default to 1, corresponding to the first-order momentum compaction factor.
         n_step:         Number of different calculated momentum deviations to be fitted
           with a polynomial.
-          Defaults to 2.
+          Default to 2.
 
     Keyword Args:
         DPStep (Optional[float]):       Momentum step size.

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -44,7 +44,7 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         ' for a better fit.')
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)
-    fp_i = tuple(at.physics.find_orbit4(ring_py, dp=dp + dp_i, keep_lattice=True)[0] \
+    fp_i = tuple(find_orbit4(ring_py, dp=dp + dp_i, keep_lattice=True)[0] \
        for dp_i in dp_samples)
     fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
     b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -47,7 +47,7 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
     fp_i = tuple(find_orbit4(ring, dp=dp + dp_i, keep_lattice=keep_lattice)[0] \
        for dp_i in dp_samples)
     fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
-    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=keep_lattice), axis=(2, 3))
+    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
     ring_length = get_s_pos(ring, len(ring))
     p = numpy.polynomial.Polynomial.fit(b[4], b[5], deg=fit_order).convert().coef
     alphac = p[1:] / ring_length[0]

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -25,10 +25,10 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: :py:obj:`False`
         fit_order:      Maximum momentum compaction factor order to be fitted.
-          Defaults to :py:obj:`None`
+          Defaults to 1, corresponding to the first-order momentum compaction factor.
         n_step:         Number of different calculated momentum deviations to be fitted
           with a polynomial.
-          Defaults to :py:obj:`None`
+          Defaults to 2.
 
     Keyword Args:
         DPStep (Optional[float]):       Momentum step size.

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -12,9 +12,37 @@ __all__ = ['get_mcf', 'get_slip_factor', 'get_revolution_frequency',
 
 @check_6d(False)
 def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
+            keep_lattice: bool = False, **kwargs) -> float:
+    r"""Compute the momentum compaction factor :math:`\alpha`
+
+    Parameters:
+        ring:           Lattice description (:pycode:`ring.is_6d` must be
+          :py:obj:`False`)
+        dp:             Momentum deviation. Defaults to :py:obj:`None`
+        keep_lattice:   Assume no lattice change since the previous tracking.
+          Default: :py:obj:`False`
+
+    Keyword Args:
+        DPStep (Optional[float]):       Momentum step size.
+          Default: :py:data:`DConstant.DPStep <.DConstant>`
+
+    Returns:
+        mcf (float):    Momentum compaction factor :math:`\alpha`
+    """
+    dp_step = kwargs.pop('DPStep', DConstant.DPStep)
+    fp_a, _ = find_orbit4(ring, dp=dp - 0.5*dp_step, keep_lattice=keep_lattice)
+    fp_b, _ = find_orbit4(ring, dp=dp + 0.5*dp_step, keep_lattice=True)
+    fp = numpy.stack((fp_a, fp_b),
+                     axis=0).T  # generate a Fortran contiguous array
+    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
+    ring_length = get_s_pos(ring, len(ring))
+    alphac = (b[5, 1] - b[5, 0]) / dp_step / ring_length[0]
+    return alphac
+
+def get_momentum_compaction_factor_array(ring: Lattice, dp: Optional[float] = 0.0,
             keep_lattice: bool = False,
-            fit_order: Optional[int] = 1,
-            n_step: Optional[int] = 2,
+            fit_order: Optional[int] = 2,
+            n_step: Optional[int] = 10,
             **kwargs) -> float:
     r"""Compute the momentum compaction factor :math:`\alpha`
 
@@ -24,10 +52,10 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
         dp:             Momentum deviation. Defaults to :py:obj:`None`
         keep_lattice:   Assume no lattice change since the previous tracking.
           Default: :py:obj:`False`
-        fit_order:      Maximum momentum compaction factor to be fitted.
+        fit_order:      Maximum momentum compaction factor order to be fitted. 
           Defaults to :py:obj:`None`
         n_step:         Number of different calculated momentum deviations to be fitted
-          with a polynomial.
+          with a polynomial. 
           Defaults to :py:obj:`None`
 
     Keyword Args:
@@ -39,7 +67,7 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
           up to the order fit_order
     """
     if n_step < 2*fit_order:
-        print('Low nunber of steps, it is advised to have n_step >= 2*fit_order'+
+        raise ValueError('Low nunber of steps, it is advised to have n_step >= 2*fit_order'+
         ' for a better fit.')
     dp_step = kwargs.pop('DPStep', DConstant.DPStep)
     dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)


### PR DESCRIPTION
Adapted version of the get_mcf() function to calculate higher-orders of the momentum compaction factor using a polynomial fit. Default behaviour is identical to the original version.