### PR TITLE
BugFix: memory error incollective effects circular buffers

### DIFF
--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -42,7 +42,9 @@ struct elem
 
 
 void write_buffer(double *data, double *buffer, int datasize, int buffersize){
-    memmove(buffer, buffer + datasize, datasize*buffersize*sizeof(double));
+    if(buffersize>1){
+        memmove(buffer, buffer + datasize, datasize*buffersize*sizeof(double));
+    }
     memcpy(buffer + datasize*(buffersize-1), data, datasize*sizeof(double));
 }
    

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -38,11 +38,13 @@ static double getTableWake(double *waketable,double *waketableT,double distance,
 };
 
 static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
-    memmove(turnhistory, turnhistory + nslice, 4*nslice*nturns*sizeof(double));
-    double *z = turnhistory+nslice*nturns*2;
     int i;
-    for(i=0; i<nslice*nturns; i++){
-        z[i] += -circumference;
+    if(nturns > 1){
+        memmove(turnhistory, turnhistory + nslice, 4*nslice*nturns*sizeof(double));
+        double *z = turnhistory+nslice*nturns*2;
+        for(i=0; i<nslice*nturns; i++){
+            z[i] += -circumference;
+        }
     }
     double *x0 = turnhistory + (nturns-1)*nslice;
     double *y0 = turnhistory + (2*nturns-1)*nslice;


### PR DESCRIPTION
This PR fixes a bug in the collective effects implementation. Circular buffers are used to store the slice information and some parameters history. These buffers where shifted even when their size was equal to 1.
In the new implementation, when the size of these buffers is equal to 1 they are simply overwritten.