### PR TITLE
Regression bug from PR #774: beam_current lattice attribute not propagated correctly

### DIFF
--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -43,7 +43,7 @@ struct elem
 
 void write_buffer(double *data, double *buffer, int datasize, int buffersize){
     if(buffersize>1){
-        memmove(buffer, buffer + datasize, datasize*buffersize*sizeof(double));
+        memmove(buffer, buffer + datasize, datasize*(buffersize-1)*sizeof(double));
     }
     memcpy(buffer + datasize*(buffersize-1), data, datasize*sizeof(double));
 }

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -39,24 +39,34 @@ static double getTableWake(double *waketable,double *waketableT,double distance,
 
 static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
 
-    int i;
-    double *z;
-    if(nturns>1){
-        memmove(turnhistory, turnhistory + nslice, 4*nslice*(nturns-1)*sizeof(double));
-        z = turnhistory + nslice*nturns*2;
-        for(i=0; i<nslice*nturns; i++){
-            z[i] -= circumference;
+    double *xtmp,*xtmp0;
+    double *ytmp,*ytmp0;
+    double *ztmp,*ztmp0;
+    double *wtmp,*wtmp0;
+    double *t0;
+    int i, ii;    
+    for (i=0;i<nturns-1;i++){
+        xtmp0 = turnhistory + i*nslice;
+        xtmp = turnhistory + (i+1)*nslice;
+        ytmp0 = turnhistory + (i+nturns)*nslice;
+        ytmp = turnhistory + (i+nturns+1)*nslice;
+        ztmp0 = turnhistory + (i+2*nturns)*nslice;
+        ztmp = turnhistory + (i+2*nturns+1)*nslice;
+        wtmp0 = turnhistory + (i+3*nturns)*nslice;
+        wtmp = turnhistory + (i+3*nturns+1)*nslice;
+        for(ii=0;ii<nslice;ii++){
+            xtmp0[ii]=xtmp[ii];
+            ytmp0[ii]=ytmp[ii];
+            ztmp0[ii]=ztmp[ii]-circumference;
+            wtmp0[ii]=wtmp[ii];
         }
     }
-    double *x0 = turnhistory + (nturns-1)*nslice;
-    double *y0 = turnhistory + (2*nturns-1)*nslice;
-    double *z0 = turnhistory + (3*nturns-1)*nslice;
-    double *w0 = turnhistory + (4*nturns-1)*nslice;
-    for(i=0; i<nslice; i++){
-        x0[i] = 0.0;
-        y0[i] = 0.0;
-        z0[i] = 0.0;
-        w0[i] = 0.0;
+    
+    for(ii=1;ii<5; ii++){ 
+        t0 = turnhistory + (ii*nturns-1)*nslice;
+        for(i=0; i<nslice; i++){
+            t0[i] = 0.0;
+        }
     }
 };
 

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -39,35 +39,15 @@ static double getTableWake(double *waketable,double *waketableT,double distance,
 
 static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
 
-    double *xtmp,*xtmp0;
-    double *ytmp,*ytmp0;
-    double *ztmp,*ztmp0;
-    double *wtmp,*wtmp0;
-    int i, ii;    
-    for (i=0;i<nturns-1;i++){
-        xtmp0 = turnhistory + i*nslice;
-        xtmp = turnhistory + (i+1)*nslice;
-        ytmp0 = turnhistory + (i+nturns)*nslice;
-        ytmp = turnhistory + (i+nturns+1)*nslice;
-        ztmp0 = turnhistory + (i+2*nturns)*nslice;
-        ztmp = turnhistory + (i+2*nturns+1)*nslice;
-        wtmp0 = turnhistory + (i+3*nturns)*nslice;
-        wtmp = turnhistory + (i+3*nturns+1)*nslice;
-        for(ii=0;ii<nslice;ii++){
-            xtmp0[ii]=xtmp[ii];
-            ytmp0[ii]=ytmp[ii];
-            ztmp0[ii]=ztmp[ii]-circumference;
-            wtmp0[ii]=wtmp[ii];
-        }
-    }
-
-
-    /*int i;
-    if(nturns > 1){
-        memmove(turnhistory, turnhistory + nslice, 4*nslice*nturns*sizeof(double));
-        double *z = turnhistory+nslice*nturns*2;
-        for(i=0; i<nslice*nturns; i++){
-            z[i] += -circumference;
+    int i, ii;
+    double *z;
+    if(nturns>1){
+        memmove(turnhistory, turnhistory + nslice, 4*nslice*(nturns-1)*sizeof(double));
+        for(i=0; i<nturns; i++){
+            z = turnhistory + nslice*(i+nturns*2);
+            for(ii=0; ii<nslice; ii++){
+                z[ii] -= circumference;
+            }
         }
     }
     double *x0 = turnhistory + (nturns-1)*nslice;
@@ -79,7 +59,7 @@ static void rotate_table_history(long nturns,long nslice,double *turnhistory,dou
         y0[i] = 0.0;
         z0[i] = 0.0;
         w0[i] = 0.0;
-    }*/
+    }
 };
 
 static void getbounds(double *r_in, int nbunch, int num_particles, double *smin,

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -38,7 +38,31 @@ static double getTableWake(double *waketable,double *waketableT,double distance,
 };
 
 static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
-    int i;
+
+    double *xtmp,*xtmp0;
+    double *ytmp,*ytmp0;
+    double *ztmp,*ztmp0;
+    double *wtmp,*wtmp0;
+    int i, ii;    
+    for (i=0;i<nturns-1;i++){
+        xtmp0 = turnhistory + i*nslice;
+        xtmp = turnhistory + (i+1)*nslice;
+        ytmp0 = turnhistory + (i+nturns)*nslice;
+        ytmp = turnhistory + (i+nturns+1)*nslice;
+        ztmp0 = turnhistory + (i+2*nturns)*nslice;
+        ztmp = turnhistory + (i+2*nturns+1)*nslice;
+        wtmp0 = turnhistory + (i+3*nturns)*nslice;
+        wtmp = turnhistory + (i+3*nturns+1)*nslice;
+        for(ii=0;ii<nslice;ii++){
+            xtmp0[ii]=xtmp[ii];
+            ytmp0[ii]=ytmp[ii];
+            ztmp0[ii]=ztmp[ii]-circumference;
+            wtmp0[ii]=wtmp[ii];
+        }
+    }
+
+
+    /*int i;
     if(nturns > 1){
         memmove(turnhistory, turnhistory + nslice, 4*nslice*nturns*sizeof(double));
         double *z = turnhistory+nslice*nturns*2;
@@ -55,7 +79,7 @@ static void rotate_table_history(long nturns,long nslice,double *turnhistory,dou
         y0[i] = 0.0;
         z0[i] = 0.0;
         w0[i] = 0.0;
-    }
+    }*/
 };
 
 static void getbounds(double *r_in, int nbunch, int num_particles, double *smin,

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -39,15 +39,13 @@ static double getTableWake(double *waketable,double *waketableT,double distance,
 
 static void rotate_table_history(long nturns,long nslice,double *turnhistory,double circumference){
 
-    int i, ii;
+    int i;
     double *z;
     if(nturns>1){
         memmove(turnhistory, turnhistory + nslice, 4*nslice*(nturns-1)*sizeof(double));
-        for(i=0; i<nturns; i++){
-            z = turnhistory + nslice*(i+nturns*2);
-            for(ii=0; ii<nslice; ii++){
-                z[ii] -= circumference;
-            }
+        z = turnhistory + nslice*nturns*2;
+        for(i=0; i<nslice*nturns; i++){
+            z[i] -= circumference;
         }
     }
     double *x0 = turnhistory + (nturns-1)*nslice;

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -128,9 +128,9 @@ def _get_vals(ring, rp, ma, emity, bunch_curr, emitx=None,
     bs = bxy2/sigb2*(1-(sigh2*(dt2/sigb2).T).T)
     bg2i = 1/(2*beta2*gamma2)
     B1 = bg2i*numpy.sum(bs, axis=1)
-    B2sq = (bg2i*bg2i*numpy.diff(bs, axis=1).T**2 +
-            sigh2*sigh2*numpy.prod(bxy2*dt2, axis=1) /
-            numpy.prod(sigb2*sigb2, axis=1))
+    B2sq = bg2i*bg2i*(numpy.diff(bs, axis=1).T**2 +
+                      4*sigh2*sigh2*numpy.prod(bxy2*dt2, axis=1) /
+                      numpy.prod(sigb2*sigb2, axis=1))
     B2 = numpy.squeeze(numpy.sqrt(B2sq))
 
     val = numpy.zeros((2, len(rp)))

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -93,7 +93,7 @@ class Lattice(list):
     _excluded_attributes = ('nbunch', )
     # Attributes propagated in copies:
     _std_attributes = ('name', '_energy', '_particle', 'periodicity',
-                       '_cell_harmnumber', '_radiation', 'beam_current',
+                       '_cell_harmnumber', '_radiation', '_beam_current',
                        '_fillpattern')
 
     # noinspection PyUnusedLocal

--- a/pyat/examples/CollectiveEffects/BeamLoading.py
+++ b/pyat/examples/CollectiveEffects/BeamLoading.py
@@ -52,7 +52,7 @@ rank = comm.Get_rank()
 print(size, rank)
 
 ring = at.load_lattice('../../../machine_data/esrf.m')
-ring.radiation_on(cavity_pass='RFCavityPass')
+ring.enable_6d(cavity_pass='RFCavityPass')
 ring.set_rf_frequency()
 
 
@@ -74,7 +74,7 @@ fring.pop(-1)  # drop diffusion element
 
 # Here we specify whether we want to use PHASOR or WAKE
 # beam loading models.
-mode = 'PHASOR'
+mode = 'WAKE'
 if mode == 'WAKE':
     blm = BLMode.WAKE
 else:
@@ -107,6 +107,18 @@ if rank == 0:
 
     z_all = numpy.zeros((Nturns, Nbunches))
     dp_all = numpy.zeros((Nturns, Nbunches))
+
+
+# Here it should be considered that there are 2 ways to run
+# simulations in pyat. Either with ring.track(part, nturns=Nturns)
+# or with for i in np.arange(Nturns): ring.track(part, nturns=1).
+# With the former, you should use the BeamMoments element to acquire
+# the means and stds of each bunch turn by turn when using MPI.
+# However, when you want to kick after a certain turn, you have 1
+# of 2 choices. Either you use a BeamMoments element, and split the 
+# tracking into 2 (before and after). You can then concatenate the
+# the results. Or you can use the code below to gather all particles
+# yourself with the MPICOMM after each turn.
 
 for i in numpy.arange(Nturns):
     # Apply a kick to ensure the coherent tune is large

--- a/pyat/examples/CollectiveEffects/LCBI_run.py
+++ b/pyat/examples/CollectiveEffects/LCBI_run.py
@@ -48,11 +48,10 @@ def launch():
     ring.beam_current = current
     ring.set_rf_voltage(6e6)
 
-    ring.radiation_off(cavity_pass='RFCavityPass')
+    ring.disable_6d(cavity_pass='RFCavityPass')
     ring.set_fillpattern(Nbunches)
 
     ring.set_rf_frequency()
-    freqres = ring.rf_frequency
 
     qx, qy, qs = ring.get_tune()
     fs0 = qs * ring.revolution_frequency
@@ -77,7 +76,7 @@ def launch():
     fring.append(bmon)
 
     # Particle generation and tracking
-    sigm = at.sigma_matrix(ring.radiation_on(copy=True))
+    sigm = at.sigma_matrix(ring.enable_6d(copy=True))
     part = at.beam(Npart, sigm, orbit=ld0)
     part[4, :] = 0
     part[5, :] = 0

--- a/pyat/examples/CollectiveEffects/LongDistribution.py
+++ b/pyat/examples/CollectiveEffects/LongDistribution.py
@@ -13,7 +13,7 @@ freq = 10e9
 qfactor = 1
 Rs = 1e4
 current = 5e-4
-m = 50  # 30 is quite coarse, 70 or 80 is very fine. 50 is middle
+m = 60  # 30 is quite coarse, 70 or 80 is very fine. 50 is middle
 kmax = 8
 
 
@@ -60,7 +60,7 @@ Nbunches = 1
 ring.beam_current = current
 ring.set_fillpattern(Nbunches)
 
-ring.radiation_on()
+ring.enable_6d()
 ring.set_cavity_phase()
 _, fring = at.fast_ring(ring)
 fring.append(welem)

--- a/pyat/examples/CollectiveEffects/TRW_run.py
+++ b/pyat/examples/CollectiveEffects/TRW_run.py
@@ -36,7 +36,7 @@ def launch():
 
     # Set up the ring
     ring = at.load_m('../../../machine_data/esrf.m')
-    ring.radiation_off(cavity_pass='RFCavityPass')
+    ring.disable_6d(cavity_pass='RFCavityPass')
 
     current = 200e-3
     nturns = 10000
@@ -85,7 +85,7 @@ def launch():
     fring.append(bmon)
 
     # Particle generation and tracking
-    sigm = at.sigma_matrix(ring.radiation_on(copy=True))
+    sigm = at.sigma_matrix(ring.enable_6d(copy=True))
     part = at.beam(Npart, sigm)
     part[0, :] = 1e-6
     part[1, :] = 0

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -169,6 +169,10 @@ def test_buffers(hmba_lattice):
     for i in numpy.arange(1, nturns):
         dth = numpy.sum(th[i-1,(nturns-i)*ns:]
                         -th[i,(nturns-i-1)*ns:(nturns-1)*ns]) - i*ls  
-        dvbh = numpy.sum(dvbh[i-1,(nturns-i)*2:]
-                         -dvbh[i,(nturns-i-1)*ns:(nturns-1)*2])     
-    assert_allclose([dthm dvbh], 0.0, atol = 1e-9)
+        dvbh = numpy.sum(vbh[i-1, :, (nturns-i):]
+                         -vbh[i, :, (nturns-i-1):(nturns-1)])  
+        dvgh = numpy.sum(vgh[i-1, :,(nturns-i):]
+                         -vgh[i, :,(nturns-i-1):(nturns-1)]) 
+        dvbbh = numpy.sum(vbbh[i-1, :,(nturns-i):]
+                         -vbbh[i, :,(nturns-i-1):(nturns-1)])           
+    assert_close([dth, dvbh, dvgh, dvbbh], numpy.zeros(4), atol = 1e-9)

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -151,7 +151,7 @@ def test_buffers(hmba_lattice):
     ns = nbunch*nslice
     ls = ns*ring.circumference/ring.periodicity
     add_beamloading(ring, 44e3, 400, Nturns=nturns, Nslice=nslice,
-                    buffersize=nturns, blmode=BLMode.PHASOR)
+                    buffersize=nturns, blmode=BLMode.WAKE)
     ring.set_fillpattern(nbunch)
     ring.beam_current = 0.2
     rin = numpy.zeros((6, nbunch)) + 1.0e-6

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -14,7 +14,7 @@ _issorted = lambda a: numpy.all(a[:-1] <= a[1:])
 
 
 def test_fillpattern(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     nbunch = 16
     current = 0.2
     ring.set_fillpattern(nbunch)
@@ -56,7 +56,7 @@ def test_wake_object():
     
     
 def test_wake_element(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     srange = Wake.build_srange(0.0, 0.36, 1.0e-5, 1.0e-2, 844, 844) 
     long_res =  Wake.long_resonator(srange, 1.0e9, 1.0, 1.0e3, 1.0) 
     welem = WakeElement('WELEM', ring, long_res)
@@ -69,7 +69,7 @@ def test_wake_element(hmba_lattice):
     
     
 def test_resonator_element(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     srange = Wake.build_srange(0.0, 0.36, 1.0e-5, 1.0e-2, 844, 844)
     welem = ResonatorElement('WELEM', ring, srange, WakeComponent.Z, 1.0e9, 1.0, 1.0e3)  
     assert welem.ResFrequency == 1.0e9
@@ -81,7 +81,7 @@ def test_resonator_element(hmba_lattice):
     
     
 def test_resistive_wall_element(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     srange = Wake.build_srange(0.0, 0.36, 1.0e-5, 1.0e-2, 844, 844)
     welem = ResWallElement('WELEM', ring, srange, WakeComponent.DX, 1.0, 1.0e-2, 1.0e6)  
     assert welem.RWLength == 1.0
@@ -92,7 +92,7 @@ def test_resistive_wall_element(hmba_lattice):
     
     
 def test_beamloading(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     with pytest.raises(Exception):
         add_beamloading(ring, 44e3, 400, cavpts=range(len(ring)))
     add_beamloading(ring, 44e3, 400)
@@ -116,7 +116,7 @@ def test_beamloading(hmba_lattice):
 
 @pytest.mark.parametrize('func', (lattice_track, lattice_pass))
 def test_track_beamloading(hmba_lattice, func):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     rin0 = numpy.zeros(6)
     func(ring, rin0, refpts=[])
     add_beamloading(ring, 44e3, 400, blmode=BLMode.WAKE)
@@ -140,7 +140,7 @@ def test_track_beamloading(hmba_lattice, func):
  
 
 def test_buffers(hmba_lattice):
-    ring = hmba_lattice.radiation_on(copy=True)
+    ring = hmba_lattice.enable_6d(copy=True)
     ring.periodicity = 1
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -167,12 +167,12 @@ def test_buffers(hmba_lattice):
         vgh[i] = bl_elem.Vgen_buffer
         vbbh[i] = bl_elem.Vbunch_buffer
     for i in numpy.arange(1, nturns):
-        dth = numpy.sum(th[i-1,(nturns-i)*ns:]
-                        -th[i,(nturns-i-1)*ns:(nturns-1)*ns]) - i*ls  
+        dth = numpy.sum(th[i-1, (nturns-i)*ns:]
+                        - th[i, (nturns-i-1)*ns:(nturns-1)*ns]) - i*ls
         dvbh = numpy.sum(vbh[i-1, :, (nturns-i):]
-                         -vbh[i, :, (nturns-i-1):(nturns-1)])  
-        dvgh = numpy.sum(vgh[i-1, :,(nturns-i):]
-                         -vgh[i, :,(nturns-i-1):(nturns-1)]) 
-        dvbbh = numpy.sum(vbbh[i-1, :,(nturns-i):]
-                         -vbbh[i, :,(nturns-i-1):(nturns-1)])           
-    assert_close([dth, dvbh, dvgh, dvbbh], numpy.zeros(4), atol = 1e-9)
+                         - vbh[i, :, (nturns-i-1):(nturns-1)])
+        dvgh = numpy.sum(vgh[i-1, :, (nturns-i):]
+                         - vgh[i, :, (nturns-i-1):(nturns-1)])
+        dvbbh = numpy.sum(vbbh[i-1, :, (nturns-i):]
+                          - vbbh[i, :, (nturns-i-1):(nturns-1)])
+    assert_close([dth, dvbh, dvgh, dvbbh], numpy.zeros(4), atol=1e-9)

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -74,7 +74,6 @@ def test_resonator_element(hmba_lattice):
     assert welem.ResFrequency == 1.0e9
     assert welem.Qfactor == 1
     assert welem.Rshunt == 1.0e3
-    print(welem.WakeZ[[0,1]])
     assert_close(welem.WakeZ[[0,1]], [3.14159265e+12, 6.28318531e+12], rtol = 1e-8)
     welem.ResFrequency += 100
     assert welem.ResFrequency == 1.0e9 + 100
@@ -86,7 +85,6 @@ def test_resistive_wall_element(hmba_lattice):
     welem = ResWallElement('WELEM', ring, srange, WakeComponent.DX, 1.0, 1.0e-2, 1.0e6)  
     assert welem.RWLength == 1.0
     assert welem.Conductivity == 1.0e6
-    print(welem.WakeDX[[0,1]])
     assert_close(welem.WakeDX[[0,1]], [ 0.0000000e+00, -1.0449877e+24], rtol = 1e-8)
     welem.Conductivity += 100
     assert welem.Conductivity == 1.0e6 + 100
@@ -138,4 +136,32 @@ def test_track_beamloading(hmba_lattice, func):
                                         0.000000e+00,  0.000000e+00,
                                         -1.313306e-05, -1.443748e-08]
                                         ), atol=5e-10)
-    
+ 
+
+def test_buffers(hmba_lattice):
+    ring = hmba_lattice.radiation_on(copy=True)
+    nturns = 11
+    nbunch = 16
+    nslice = 51
+    ns = nbunch*nslice
+    ls = ns*ring.circumference/ring.periodicity
+    add_beamloading(ring, 44e3, 400, Nturns=nturns, Nslice=nslice,
+                    buffersize=nturns, blmode=BLMode.PHASOR)
+    ring.set_fillpattern(nbunch)
+    ring.beam_current = 0.2
+    rin = numpy.zeros((6, nbunch)) + 1.0e-6
+    bl_elem = ring.get_elements('*_BL')[0]
+    th = numpy.zeros((nturns, ) + bl_elem.TurnHistory.shape)
+    vbh = numpy.zeros((nturns, ) + bl_elem.Vbeam_buffer.shape)
+    vgh = numpy.zeros((nturns, ) + bl_elem.Vgen_buffer.shape)
+    vbbh = numpy.zeros((nturns, ) + bl_elem.Vbunch_buffer.shape)
+    for i in numpy.arange(nturns):
+        ring.track(rin, nturns=1, refpts=None, in_place=True)
+        th[i] = bl_elem.TurnHistory
+        vbh[i] = bl_elem.Vbeam_buffer
+        vgh[i] = bl_elem.Vgen_buffer
+        vbbh[i] = bl_elem.Vbunch_buffer
+    for i in numpy.arange(1, nturns):
+        dth = numpy.sum(th[i-1,(nturns-i)*ns:]
+                        -th[i,(nturns-i-1)*ns:(nturns-1)*ns]) - i*ls      
+    assert_close(dth, 0.0, atol = 1e-9)

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -168,5 +168,7 @@ def test_buffers(hmba_lattice):
         vbbh[i] = bl_elem.Vbunch_buffer
     for i in numpy.arange(1, nturns):
         dth = numpy.sum(th[i-1,(nturns-i)*ns:]
-                        -th[i,(nturns-i-1)*ns:(nturns-1)*ns]) - i*ls      
-    assert_close(dth, 0.0, atol = 1e-9)
+                        -th[i,(nturns-i-1)*ns:(nturns-1)*ns]) - i*ls  
+        dvbh = numpy.sum(dvbh[i-1,(nturns-i)*2:]
+                         -dvbh[i,(nturns-i-1)*ns:(nturns-1)*2])     
+    assert_allclose([dthm dvbh], 0.0, atol = 1e-9)

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -1,6 +1,7 @@
 import at
 import numpy
 import pytest
+import warnings
 from numpy.testing import assert_allclose as assert_close
 from at.collective import Wake, WakeElement, ResonatorElement
 from at.collective import WakeComponent, ResWallElement
@@ -140,8 +141,12 @@ def test_track_beamloading(hmba_lattice, func):
 
 def test_buffers(hmba_lattice):
     ring = hmba_lattice.radiation_on(copy=True)
+    ring.periodicity = 1
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ring.harmonic_number = 32
     nturns = 11
-    nbunch = 16
+    nbunch = 4
     nslice = 51
     ns = nbunch*nslice
     ls = ns*ring.circumference/ring.periodicity


### PR DESCRIPTION
This PR fixes a regression bug from #744. Modification in the `lattice_object` initialization resulted in wrong propagation of the `_beam_current` attribute.
This was discovered when performing consecutive `add_beamloading()` calls on the same lattice.
The `_std_attribtues` were modifed to propagate the attribute correctly, the specific case that was failing before is now working properly.