### PR TITLE
Fix bug reading atM66 elements from matlab lattice

### DIFF
--- a/pyat/at/load/utils.py
+++ b/pyat/at/load/utils.py
@@ -112,6 +112,7 @@ _alias_map = {
     "ringparam": RingParam,
     "wig": elt.Wiggler,
     "matrix66": elt.M66,
+    "M66": elt.M66,
 }
 
 # Map class names to Element classes


### PR DESCRIPTION
Dear all, 

when loading a lattice in python from a matlab ".m" file all class names are converted to lower case.
As almost all matlab element creation functions are lower case this works, with the exception of atM66.
Therefore a lattice with an atM66 element raises a warning and the element is not included in the python lattice.

This pull requests adds "M66" with an upper case M to the alias map in at/load/utils.py to correctly read this element.