### PR TITLE
Urgent: require numpy < 2.0

### DIFF
--- a/pyat/at/matching/matching.py
+++ b/pyat/at/matching/matching.py
@@ -66,7 +66,7 @@ class Variable(object):
         return '\n{:>12s}{:>13s}{:>16s}{:>16s}\n'.format(
             'Name', 'Initial', 'Final ', 'Variation')
 
-    def status(self, ring: Lattice, vini=np.NaN):
+    def status(self, ring: Lattice, vini=np.nan):
         vnow = self.get(ring)
         return '{:>12s}{: 16e}{: 16e}{: 16e}'.format(
             self.name, vini, vnow, (vnow - vini))
@@ -235,7 +235,7 @@ class Constraints(object):
     def status(self, ring: Lattice, initial=None):
         """Return a string giving the actual state of constraints"""
         if initial is None:
-            initial = repeat(np.NaN)
+            initial = repeat(np.nan)
         strs = []
         for name, ini, now, target in zip(self.name, initial,
                                           self.values(ring), self.target):

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -109,7 +109,7 @@ def _closure(m22):
         beta = m22[0, 1] / sinmu
         return alpha, beta, cosmu + sinmu*1j
     except ValueError:          # Unstable motion
-        return numpy.NaN, numpy.NaN, numpy.NaN
+        return numpy.nan, numpy.nan, numpy.nan
 
 
 # noinspection PyShadowingNames,PyPep8Naming
@@ -127,7 +127,7 @@ def _tunes(ring, **kwargs):
     except AtError:
         warnings.warn(AtWarning('Unstable ring'))
         tunes = numpy.empty(nd)
-        tunes[:] = numpy.NaN
+        tunes[:] = numpy.nan
     return tunes
 
 
@@ -509,7 +509,7 @@ def _linopt(ring: Lattice, analyze, refpts=None, dp=None, dct=None, df=None,
                          ('s_pos', numpy.float64)]
         data0 = (d0, orb0, mt, get_s_pos(ring, len(ring))[0])
         datas = (ds, orbs, ms, spos)
-        damping_times = numpy.NaN
+        damping_times = numpy.nan
 
     if get_w:
         dtype = dtype + wtype
@@ -523,7 +523,7 @@ def _linopt(ring: Lattice, analyze, refpts=None, dp=None, dct=None, df=None,
         deltap = o0up[4] - o0dn[4]
         chrom = (tunesup - tunesdn) / deltap
     else:
-        chrom = numpy.NaN
+        chrom = numpy.nan
 
     beamdata = numpy.array((tunes, chrom, damping_times),
                            dtype=[('tune', numpy.float64, (dms,)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "importlib-resources;python_version<'3.9'",
-    "numpy>=1.16.6",
+    "numpy >=1.16.6, <2.0",
     "scipy>=1.4.0"
 ]
 


### PR DESCRIPTION
The release of numpy 2.0 breaks the compatibility with previous versions. In this PR, we react by:
1. correcting the python code to be compatible with both numpy 1.x and 2.0
2. since the C code is not yet adapted to numpy 2.0, adding the requirement `numpy<2.0` to `pyproject.toml`