### PR TITLE
numpy 2.0 support

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,16 +22,11 @@ jobs:
           # see: https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
 
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.19.1
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -54,7 +54,7 @@ jobs:
         run: python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tar.gz
           path: ./dist/*.tar.gz

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -26,19 +26,19 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Set up python 3.9
+    - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         cache: pip
 
     - name: Set up MATLAB
-      uses: matlab-actions/setup-matlab@v1
+      uses: matlab-actions/setup-matlab@v2
       with:
-        release: R2022a
+        release: R2023a
 
     - name: Atmexall
-      uses: matlab-actions/run-command@v1
+      uses: matlab-actions/run-command@v2
       with:
         command: run('atmat/atpath');githubsetup();
 

--- a/atmat/attests/githubrun.m
+++ b/atmat/attests/githubrun.m
@@ -7,5 +7,8 @@ tsuite=fullfile(atroot,'attests');
 % else
 %     v=assertSuccess(run(testsuite(tsuite,'Tag','GitHub')));
 % end
+if ~(ispc || ismac)
+    py.sys.setdlopenflags(int32(bitor(int64(py.os.RTLD_LAZY), int64(py.os.RTLD_DEEPBIND))));
+end
 v=assertSuccess(run(testsuite(tsuite)));
 disp(table(v));

--- a/atmat/attests/githubrun.m
+++ b/atmat/attests/githubrun.m
@@ -2,9 +2,10 @@
 % normally no reason to run it in a user workflow.
 
 tsuite=fullfile(atroot,'attests');
-if ispc || ismac
-    v=assertSuccess(run(testsuite(tsuite)));
-else
-    v=assertSuccess(run(testsuite(tsuite,'Tag','GitHub')));
-end
+% if ispc || ismac
+%     v=assertSuccess(run(testsuite(tsuite)));
+% else
+%     v=assertSuccess(run(testsuite(tsuite,'Tag','GitHub')));
+% end
+v=assertSuccess(run(testsuite(tsuite)));
 disp(table(v));

--- a/atmat/attests/githubrun.m
+++ b/atmat/attests/githubrun.m
@@ -2,12 +2,11 @@
 % normally no reason to run it in a user workflow.
 
 tsuite=fullfile(atroot,'attests');
-% if ispc || ismac
-%     v=assertSuccess(run(testsuite(tsuite)));
-% else
-%     v=assertSuccess(run(testsuite(tsuite,'Tag','GitHub')));
-% end
 if ~(ispc || ismac)
+    % Solution for
+    % "Intel MKL ERROR: Parameter 11 was incorrect on entry to DSBEVD."
+    % found there:
+    % https://fr.mathworks.com/matlabcentral/answers/1983899-intel-mkl-error-when-callying-scipy-from-matlab
     py.sys.setdlopenflags(int32(bitor(int64(py.os.RTLD_LAZY), int64(py.os.RTLD_DEEPBIND))));
 end
 v=assertSuccess(run(testsuite(tsuite)));

--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -15,7 +15,7 @@ elseif ismac
     execmode='InProcess';
 else
     execfile=fullfile(getenv('pythonLocation'),'bin','python');
-    execmode='OutOfProcess';
+    execmode='InProcess';
 end
 pyenv("Version", execfile,'ExecutionMode', execmode);
 disp(pyenv);

--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -9,14 +9,9 @@ savepath('pathdef.m');
 atmexall -fail
 if ispc
     execfile=fullfile(getenv('pythonLocation'),'pythonw.exe');
-    execmode='InProcess';
-elseif ismac
-    execfile=fullfile(getenv('pythonLocation'),'bin','python');
-    execmode='InProcess';
 else
     execfile=fullfile(getenv('pythonLocation'),'bin','python');
-    execmode='InProcess';
 end
-pyenv("Version", execfile,'ExecutionMode', execmode);
+pyenv("Version", execfile,'ExecutionMode', 'InProcess');
 disp(pyenv);
 end

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -18,7 +18,9 @@
 #include <float.h>
 #include <atrandom.c>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define atPrintf(...) PySys_WriteStdout(__VA_ARGS__)
+
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <numpy/ndarrayobject.h>
 
 #define NUMPY_IMPORT_ARRAY_RETVAL NULL
@@ -306,11 +308,11 @@ void set_energy_particle(PyObject *lattice, PyObject *energy,
 void set_current_fillpattern(PyArrayObject *bspos, PyArrayObject *bcurrents,
                              struct parameters *param){ 
     if(bcurrents != NULL){
-        PyObject *bcurrentsum = PyArray_Sum(bcurrents, NPY_MAXDIMS, 
+        PyObject *bcurrentsum = PyArray_Sum(bcurrents, NPY_RAVEL_AXIS,
                                             PyArray_DESCR(bcurrents)->type_num,
-                                            NULL); 
+                                            NULL);
         param->beam_current = PyFloat_AsDouble(bcurrentsum);
-        Py_DECREF(bcurrentsum);    
+        Py_DECREF(bcurrentsum);
         param->nbunch = PyArray_SIZE(bspos);
         param->bunch_spos = PyArray_DATA(bspos);
         param->bunch_currents = PyArray_DATA(bcurrents); 
@@ -319,7 +321,7 @@ void set_current_fillpattern(PyArrayObject *bspos, PyArrayObject *bcurrents,
         param->nbunch=1;
         param->bunch_spos = (double[1]){0.0};
         param->bunch_currents = (double[1]){0.0};
-    }   
+    }
 }
 
 /*
@@ -415,7 +417,7 @@ static PyObject *at_atpass(PyObject *self, PyObject *args, PyObject *kwargs) {
     else
         param.nturn = counter;
 
-    set_energy_particle(lattice, energy, particle, &param);   
+    set_energy_particle(lattice, energy, particle, &param);
     set_current_fillpattern(bspos, bcurrents, &param);
 
     num_particles = (PyArray_SIZE(rin)/6);

--- a/pyat/at.c
+++ b/pyat/at.c
@@ -20,11 +20,11 @@
 
 #define atPrintf(...) PySys_WriteStdout(__VA_ARGS__)
 
-#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>
-
-#define NUMPY_IMPORT_ARRAY_RETVAL NULL
-#define NUMPY_IMPORT_ARRAY_TYPE void *
+#if NPY_ABI_VERSION < 0x02000000
+    #define NPY_RAVEL_AXIS 32
+#endif
 
 typedef PyObject atElem;
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -17,7 +17,7 @@ import numpy as np
 import scipy.io
 
 # imports necessary in 'globals()' for 'eval'
-from numpy import array, uint8, NaN  # noqa: F401
+from numpy import array, uint8, nan as NaN  # noqa: F401
 
 from .allfiles import register_format
 from .utils import split_ignoring_parentheses, RingParam, keep_elements

--- a/pyat/at/load/reprfile.py
+++ b/pyat/at/load/reprfile.py
@@ -13,7 +13,7 @@ from typing import Optional
 import numpy as np
 
 # imports necessary in 'globals()' for 'eval'
-from numpy import array, uint8, NaN  # noqa: F401
+from numpy import array, uint8, nan as NaN  # noqa: F401
 
 from at.lattice import Lattice, Element
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,6 @@ build-verbosity = "1"
 # "build" frontend fails on windows
 # build-frontend = "build"
 
-[tool.cibuildwheel.macos]
-archs = "native"
-
 #[tool.cibuildwheel.linux]
 ## Pass the detected PyAT version to the linux docker containers
 #environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ build-verbosity = "1"
 # build-frontend = "build"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = "native"
 
 #[tool.cibuildwheel.linux]
 ## Pass the detected PyAT version to the linux docker containers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "setuptools >= 64",
     "setuptools_scm >= 7",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version <= '3.8'",
+    "numpy >= 2.0; python_version >= '3.9'",
     "wheel",
 ]
 # build-backend = "setuptools.build_meta"
@@ -36,7 +37,8 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "importlib-resources;python_version<'3.9'",
-    "numpy >=1.16.6, <2.0",
+    "numpy >=1.16.6, <2.0; python_version <= '3.8'",
+    "numpy >= 1.23.5; python_version >= '3.9'",
     "scipy>=1.4.0"
 ]
 


### PR DESCRIPTION
Numpy 2.0 was released a few days ago. This new major version breaks the compatibility for both API and ABI. This resulted in crashes when loading AT. A fast fix was brought immediately by restricting AT to numpy < 2.0. This PR brings a longer term solution by fully supporting both numpy 1.x and numpy 2.0.

Both python code and C code are updated in a compatible way to support both versions. However numpy 2.0 is available only for python >= 3.9. So the build process is now different depending on the python version:

- for python 3.7 and python 3.8, the build process is unchanged, requiring the "oldest-supported-numpy" package to ensure that the binaries are compatible with all following versions,
- for python >= 3.9, we follow the new rule defined [here](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice): we build with numpy 2.0, which ensured that the binary is compatible back to version 1.23. So the run-time spec for python >= 3.9 has been increased from 1.16.6 to 1.23.5

It also appeared that the action for building wheels was also failing. It has been upgraded

And finally, a workaround is implemented for a library bug on linux, allowing to run the full Matlab tests on the 3 platforms