### PR TITLE
New test of the average optics values

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -46,7 +46,7 @@ jobs:
       run: python -m pip install .
 
     - name: Run tests
-      uses: matlab-actions/run-command@v1
+      uses: matlab-actions/run-command@v2
       with:
         command: githubrun
 #

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -109,7 +109,5 @@ end
         avedisp(:,[2 4])=(disp0(:,[2 4]).*(sin(sqrt(K).*L)./sqrt(K))-...
             disp0(:,[1 3]).*(1-cos(sqrt(K).*L))+...
             ir.*(1-cos(sqrt(K).*L))./K)./L;
-        disp([disp0 ir K L]);
-        disp(avedisp);
     end
 end

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -82,7 +82,7 @@ if any(long)
         kfoc = K(foc);
         irhofoc = irho(foc);
         K2 = [kfoc+irhofoc.*irhofoc -kfoc];
-        irho2 = [irhofoc irhofoc];
+        irho2 = [irhofoc zeros(size(irhofoc))];
         % Apply formulas
         avebeta(rqp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
         avedisp(rqp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
@@ -104,10 +104,12 @@ end
     function avedisp=dispfoc(disp0,ir,K,L)
         avedisp=disp0;
         avedisp(:,[1 3])=(disp0(:,[1 3]).*(sin(sqrt(K).*L)./sqrt(K))+...
-            disp0(:,[2 4]).*(1-cos(sqrt(K).*L))./K)./L+...
-            ir.*(L-sin(sqrt(K).*L)./sqrt(K))./K./L;
-        avedisp(:,[2 4])=(disp0(:,[2 3]).*(sin(sqrt(K).*L)./sqrt(K))-...
-            disp0(:,[1 3]).*(1-cos(sqrt(K).*L)))./L+...
-            ir.*(L-cos(sqrt(K).*L))./K./L;
+            disp0(:,[2 4]).*(1-cos(sqrt(K).*L))./K+...
+            ir.*(L-sin(sqrt(K).*L)./sqrt(K))./K)./L;
+        avedisp(:,[2 4])=(disp0(:,[2 4]).*(sin(sqrt(K).*L)./sqrt(K))-...
+            disp0(:,[1 3]).*(1-cos(sqrt(K).*L))+...
+            ir.*(1-cos(sqrt(K).*L))./K)./L;
+        disp([disp0 ir K L]);
+        disp(avedisp);
     end
 end

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -61,31 +61,32 @@ if any(long)
     m=atgetfieldvalues(ringlong,'PolynomB',{3},'Default',0);
     R11=atgetfieldvalues(ringlong,'R2',{1,1},'Default',1);
     dx=(atgetfieldvalues(ringlong,'T2',{1},'Default',0)-atgetfieldvalues(ringlong,'T1',{1},'Default',0))/2;
-    ba=atgetfieldvalues(ringlong,'BendingAngle','Default',0);
-    irho=ba./L;
-    e1=atgetfieldvalues(ringlong,'EntranceAngle','Default',0);
-    Fint=atgetfieldvalues(ringlong,'Fint','Default',0);
-    gap=atgetfieldvalues(ringlong,'gap','Default',0);
     K = q.*R11 + 2*m.*(dx0-dx);
     foc = abs(K) > 1.e-7;
-    %Hard edge model on dipoles
-    % d_csi=ba.*gap.*Fint.*(1+sin(e1).^2)./cos(e1)./L;
-    % Cp=[ba.*tan(e1)./L -ba.*tan(e1-d_csi)./L];
-    % alpha0=alpha0-beta0.*Cp;
-    % for ii=1:2
-    %     disp0(:,2*ii)=disp0(:,2*ii)-disp0(:,2*ii-1).*Cp(:,ii);
-    % end
 
     if any(foc)
-        rqp=lg;
-        rqp(lg)=foc;
+        qp=lg;
+        qp(lg)=foc;
+        ringfoc=ringlong(foc);
+        ba=atgetfieldvalues(ringfoc,'BendingAngle','Default',0);
+        e1=atgetfieldvalues(ringfoc,'EntranceAngle','Default',0);
+        Fint=atgetfieldvalues(ringfoc,'Fint','Default',0);
+        gap=atgetfieldvalues(ringfoc,'gap','Default',0);
         kfoc = K(foc);
-        irhofoc = irho(foc);
-        K2 = [kfoc+irhofoc.*irhofoc -kfoc];
-        irho2 = [irhofoc zeros(size(irhofoc))];
+        lfoc = L(foc);
+        irho=ba./lfoc;
+        K2 = [kfoc+irho.*irho -kfoc];
+        irho2 = [irho zeros(size(irho))];
+        %Hard edge model on dipoles
+        d_csi=ba.*gap.*Fint.*(1+sin(e1).^2)./cos(e1)./lfoc;
+        Cp=[ba.*tan(e1)./L -ba.*tan(e1-d_csi)./lfoc];
+        alpha0(foc,:)=alpha0(foc,:)-beta0(foc,:).*Cp;
+        for ii=1:2
+            disp0(foc,2*ii)=disp0(foc,2*ii)-disp0(foc,2*ii-1).*Cp(:,ii);
+        end
         % Apply formulas
-        avebeta(rqp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
-        avedisp(rqp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
+        avebeta(qp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
+        avedisp(qp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
     end
     
 end

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -33,11 +33,12 @@ ClosedOrbit=cat(2,lindata.ClosedOrbit)'; %refpts
 
 
 if any(long)
+    ringlong = ring(long);
     initial=[long(needed(1:end-1));false]; %needed
     final=[false;initial(1:end-1)]; %needed
 
     lg=initial(refs(needed)); % refpts
-    L=atgetfieldvalues(ring(long),'Length'); %long
+    L=atgetfieldvalues(ringlong,'Length'); %long
     
     beta0=avebeta(lg,:); %long
     alpha0=cat(1,lind(initial).alpha); %long
@@ -48,49 +49,43 @@ if any(long)
     mu1=cat(1,lind(final).mu); %long
     disp1=cat(2,lind(final).Dispersion)'; %long
     ClosedOrbit1=cat(2,lind(final).ClosedOrbit)'; %long
+    dx0=(ClosedOrbit0(:,1)+ClosedOrbit1(:,1))/2;
     
     L2=[L L]; %long
     avebeta(lg,:)=betadrift(beta0,alpha0,L2);
     avemu(lg,:)=0.5*(mu0+mu1);
     avedisp(lg,[1 3])=(disp1(:,[1 3])+disp0(:,[1 3]))*0.5;
     avedisp(lg,[2 4])=(disp1(:,[1 3])-disp0(:,[1 3]))./L2;
-    foc=atgetcells(ring(long),'PolynomB',@(el,polb) ...
-        (el.MaxOrder>=1 && polb(2)~=0) ||(el.MaxOrder>=2 && polb(3)~=0)); %long
+    L=atgetfieldvalues(ringlong,'Length','Default',0);
+    q=atgetfieldvalues(ringlong,'PolynomB',{2},'Default',0);
+    m=atgetfieldvalues(ringlong,'PolynomB',{3},'Default',0);
+    R11=atgetfieldvalues(ringlong,'R2',{1,1},'Default',1);
+    dx=(atgetfieldvalues(ringlong,'T2',{1},'Default',0)-atgetfieldvalues(ringlong,'T1',{1},'Default',0))/2;
+    ba=atgetfieldvalues(ringlong,'BendingAngle','Default',0);
+    irho=ba./L;
+    e1=atgetfieldvalues(ringlong,'EntranceAngle','Default',0);
+    Fint=atgetfieldvalues(ringlong,'Fint','Default',0);
+    gap=atgetfieldvalues(ringlong,'gap','Default',0);
+    K = q.*R11 + 2*m.*(dx0-dx);
+    foc = abs(K) > 1.e-7;
+    %Hard edge model on dipoles
+    % d_csi=ba.*gap.*Fint.*(1+sin(e1).^2)./cos(e1)./L;
+    % Cp=[ba.*tan(e1)./L -ba.*tan(e1-d_csi)./L];
+    % alpha0=alpha0-beta0.*Cp;
+    % for ii=1:2
+    %     disp0(:,2*ii)=disp0(:,2*ii)-disp0(:,2*ii-1).*Cp(:,ii);
+    % end
+
     if any(foc)
-        qp=false(size(lg));
-        qp(lg)=foc;
-
-        %Extract element parameters
-        reng_selection=ring(refpts(qp));
-        L=atgetfieldvalues(reng_selection,'Length','Default',0);
-        q=eps()+atgetfieldvalues(reng_selection,'PolynomB',{2},'Default',0);
-        m=atgetfieldvalues(reng_selection,'PolynomB',{3},'Default',0);
-        R11=atgetfieldvalues(reng_selection,'R2',{1,1},'Default',1);
-        dx=(atgetfieldvalues(reng_selection,'T2',{1},'Default',0)-atgetfieldvalues(reng_selection,'T1',{1},'Default',0))/2;
-        ba=atgetfieldvalues(reng_selection,'BendingAngle','Default',0);
-        irho=ba./L;
-        e1=atgetfieldvalues(reng_selection,'EntranceAngle','Default',0);
-        Fint=atgetfieldvalues(reng_selection,'Fint','Default',0);
-        gap=atgetfieldvalues(reng_selection,'gap','Default',0);
-        
-        %Hard edge model on dipoles
-        d_csi=ba.*gap.*Fint.*(1+sin(e1).^2)./cos(e1)./L;
-        Cp=[ba.*tan(e1)./L -ba.*tan(e1-d_csi)./L];
-        for ii=1:2
-            alpha0(foc,ii)=alpha0(foc,ii)-beta0(foc,ii).*Cp(:,ii);
-            disp0(foc,2+(ii-1)*2)=disp0(foc,2+(ii-1)*2)-disp0(foc,1+(ii-1)*2).*Cp(:,ii);
-        end
-        
-        % Additional components
-        dx0=(ClosedOrbit0(foc,1)+ClosedOrbit1(foc,1))/2;
-        K=q.*R11+2*m.*(dx0-dx);
-        K2=[K -K]; %long
-        K2(:,1)=K2(:,1)+irho.^2;
-        irho2=[irho 0*irho];
-
+        rqp=lg;
+        rqp(lg)=foc;
+        kfoc = K(foc);
+        irhofoc = irho(foc);
+        K2 = [kfoc+irhofoc.*irhofoc -kfoc];
+        irho2 = [irhofoc irhofoc];
         % Apply formulas
-        avebeta(qp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
-        avedisp(qp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
+        avebeta(rqp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
+        avedisp(rqp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
     end
     
 end

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -21,75 +21,52 @@ else
     refs=false(lr,1); % lr
     refs(refpts)=true;
 end
+
 long=atgetcells(ring,'Length',@(elem,lg) lg>0) & refs(1:end-1); %lr-1
 needed=refs | [false;long]; %lr
-[lind,nu,xsi]=atlinopt(ring,dpp,find(needed),varargin{:}); %needed
+initial=[long(needed(1:end-1));false]; %needed
+final=[false;initial(1:end-1)]; %needed
+[lind,nu,xsi]=atlinopt(ring,dpp,needed,varargin{:}); %needed
 
 lindata=lind(refs(needed)); %refpts
 avebeta=cat(1,lindata.beta); %refpts
 avemu=cat(1,lindata.mu); %refpts
 avedisp=cat(2,lindata.Dispersion)'; %refpts
-ClosedOrbit=cat(2,lindata.ClosedOrbit)'; %refpts
 
+ringlong = ring(long);
+lin0 = lind(initial);
+lin1 = lind(final);
 
-if any(long)
-    ringlong = ring(long);
-    initial=[long(needed(1:end-1));false]; %needed
-    final=[false;initial(1:end-1)]; %needed
+lg=initial(refs(needed)); % refpts
 
-    lg=initial(refs(needed)); % refpts
-    L=atgetfieldvalues(ringlong,'Length'); %long
-    
-    beta0=avebeta(lg,:); %long
-    alpha0=cat(1,lind(initial).alpha); %long
-    mu0=avemu(lg,:); %long
-    disp0=avedisp(lg,:); %long
-    ClosedOrbit0=ClosedOrbit(lg,:); %long
-    
-    mu1=cat(1,lind(final).mu); %long
-    disp1=cat(2,lind(final).Dispersion)'; %long
-    ClosedOrbit1=cat(2,lind(final).ClosedOrbit)'; %long
-    dx0=(ClosedOrbit0(:,1)+ClosedOrbit1(:,1))/2;
-    
-    L2=[L L]; %long
-    avebeta(lg,:)=betadrift(beta0,alpha0,L2);
-    avemu(lg,:)=0.5*(mu0+mu1);
-    avedisp(lg,[1 3])=(disp1(:,[1 3])+disp0(:,[1 3]))*0.5;
-    avedisp(lg,[2 4])=(disp1(:,[1 3])-disp0(:,[1 3]))./L2;
-    L=atgetfieldvalues(ringlong,'Length','Default',0);
-    q=atgetfieldvalues(ringlong,'PolynomB',{2},'Default',0);
-    m=atgetfieldvalues(ringlong,'PolynomB',{3},'Default',0);
-    R11=atgetfieldvalues(ringlong,'R2',{1,1},'Default',1);
-    dx=(atgetfieldvalues(ringlong,'T2',{1},'Default',0)-atgetfieldvalues(ringlong,'T1',{1},'Default',0))/2;
-    K = q.*R11 + 2*m.*(dx0-dx);
-    foc = abs(K) > 1.e-7;
+beta0=avebeta(lg,:); %long
+alpha0=cat(1,lin0.alpha); %long
+mu0=avemu(lg);
+disp0=avedisp(lg,:); %long
 
-    if any(foc)
-        qp=lg;
-        qp(lg)=foc;
-        ringfoc=ringlong(foc);
-        ba=atgetfieldvalues(ringfoc,'BendingAngle','Default',0);
-        e1=atgetfieldvalues(ringfoc,'EntranceAngle','Default',0);
-        Fint=atgetfieldvalues(ringfoc,'Fint','Default',0);
-        gap=atgetfieldvalues(ringfoc,'gap','Default',0);
-        kfoc = K(foc);
-        lfoc = L(foc);
-        irho=ba./lfoc;
-        K2 = [kfoc+irho.*irho -kfoc];
-        irho2 = [irho zeros(size(irho))];
-        %Hard edge model on dipoles
-        d_csi=ba.*gap.*Fint.*(1+sin(e1).^2)./cos(e1)./lfoc;
-        Cp=[ba.*tan(e1)./L -ba.*tan(e1-d_csi)./lfoc];
-        alpha0(foc,:)=alpha0(foc,:)-beta0(foc,:).*Cp;
-        for ii=1:2
-            disp0(foc,2*ii)=disp0(foc,2*ii)-disp0(foc,2*ii-1).*Cp(:,ii);
-        end
-        % Apply formulas
-        avebeta(qp,:)=betafoc(beta0(foc,:),alpha0(foc,:),K2,L2(foc,:));
-        avedisp(qp,:)=dispfoc(disp0(foc,:),irho2,K2,L2(foc,:));
-    end
-    
-end
+mu1=cat(1,lin1.mu); %long
+ClosedOrbit0=cat(2,lin0.ClosedOrbit)'; %long
+ClosedOrbit1=cat(2,lin1.ClosedOrbit)'; %long
+dx0=(ClosedOrbit0(:,1)+ClosedOrbit1(:,1))/2;
+
+[L,q,m,ba,R11,dx] = getparams(ringlong, @longparams);
+irho=ba./L;
+K = q.*R11 + 2*m.*(dx0-dx);
+Kx = K+irho.*irho;
+Ky = -K;
+bend = (irho ~= 0.0);
+
+% Hard edge model on dipoles
+[e1,Fint,gap] = getparams(ringlong(bend), @focparams);
+d_csi=irho(bend).*gap.*Fint.*(1+sin(e1).^2)./cos(e1);
+Cp=[irho(bend).*tan(e1) -irho(bend).*tan(e1-d_csi)];
+alpha0(bend,:)=alpha0(bend,:)-beta0(bend,:).*Cp;
+disp0(bend,[2 4])=disp0(bend,[2 4])-disp0(bend,[1 3]).*Cp;
+
+avemu(lg,:)=0.5*(mu0+mu1);
+avebeta(lg,:) = betalong(beta0,alpha0,[Kx Ky],[L L]);
+avedisp(lg,1:2)=displong(disp0(:,1:2),irho,Kx,L);
+avedisp(lg,3:4)=displong(disp0(:,3:4),zeros(size(irho)),Ky,L);
 
     function avebeta=betadrift(beta0,alpha0,L)
         gamma0=(alpha0.*alpha0+1)./beta0;
@@ -102,13 +79,67 @@ end
             (cos(2.0*sqrt(K).*L)-1.0).*alpha0./K)./L/2.0;
     end
 
-    function avedisp=dispfoc(disp0,ir,K,L)
-        avedisp=disp0;
-        avedisp(:,[1 3])=(disp0(:,[1 3]).*(sin(sqrt(K).*L)./sqrt(K))+...
-            disp0(:,[2 4]).*(1-cos(sqrt(K).*L))./K+...
-            ir.*(L-sin(sqrt(K).*L)./sqrt(K))./K)./L;
-        avedisp(:,[2 4])=(disp0(:,[2 4]).*(sin(sqrt(K).*L)./sqrt(K))-...
-            disp0(:,[1 3]).*(1-cos(sqrt(K).*L))+...
-            ir.*(1-cos(sqrt(K).*L))./K)./L;
+    function avebeta=betalong(beta0,alpha0,K,L)
+        avebeta=zeros(size(beta0));
+        kp = abs(K) >= 1.0e-7;
+        k0 = ~kp;
+        avebeta(kp) = betafoc(beta0(kp),alpha0(kp),K(kp),L(kp));
+        avebeta(k0) = betadrift(beta0(k0),alpha0(k0),L(k0));
     end
+
+
+    function avedisp=dispfoc(disp0,ir,K,L)
+        eta=(disp0(:,1).*(sin(sqrt(K).*L)./sqrt(K))+...
+            disp0(:,2).*(1-cos(sqrt(K).*L))./K+...
+            ir.*(L-sin(sqrt(K).*L)./sqrt(K))./K)./L;
+        etap=(disp0(:,2).*(sin(sqrt(K).*L)./sqrt(K))-...
+            disp0(:,1).*(1-cos(sqrt(K).*L))+...
+            ir.*(1-cos(sqrt(K).*L))./K)./L;
+        avedisp=[eta etap];
+    end
+
+    function avedisp=dispdrift(disp0,ir,L)
+        eta=disp0(:,1)+disp0(:,2).*L/2+ir.*L.*L./6.0;
+        etap=disp0(:,2)+ir.*L/2.0;
+        avedisp=[eta etap];
+    end
+
+    function avedisp=displong(disp0,ir,K,L)
+        avedisp=zeros(size(disp0));
+        kp = abs(K) >= 1.0e-7;
+        k0 = ~kp;
+        avedisp(kp,:) = dispfoc(disp0(kp,:),ir(kp),K(kp),L(kp));
+        avedisp(k0,:) = dispdrift(disp0(k0,:),ir(k0),L(k0));
+    end
+
+    function [L,q,m,ba,R11,dx] = longparams(elem)
+        m = 0;
+        q = 0;
+        if isfield(elem, 'PolynomB')
+            pb = elem.PolynomB;
+            if length(pb) >= 3
+                m = pb(3);
+                q = pb(2);
+            elseif length(pb) >= 2
+                q = pb(2);
+            end
+        end
+        if isfield(elem, 'Length'), L = elem.Length; else, L = 0; end
+        if isfield(elem, 'BendingAngle'), ba = elem.BendingAngle; else, ba = 0; end
+        if isfield(elem, 'R2'), R11 = elem.R2(1,1); else, R11 = 1; end
+        if isfield(elem, 'T1'), x1 = elem.T1(1); else, x1 = 0; end
+        if isfield(elem, 'T2'), x2 = elem.T2(1); else, x2 = 0; end
+        dx = (x2 - x1)/2;
+    end
+
+    function [e1,Fint, gap] = focparams(elem)
+        if isfield(elem, 'EntranceAngle'), e1 = elem.EntranceAngle; else, e1 = 0; end
+        if isfield(elem, 'Fint'), Fint = elem.Fint; else, Fint = 0; end
+        if isfield(elem, 'gap'), gap = elem.gap; else, gap = 0; end
+    end
+
+    function varargout = getparams(ring, func)
+        [varargout{1:nargout}] = cellfun(func, ring);
+    end
+
 end

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -9,10 +9,9 @@ classdef pytests < matlab.unittest.TestCase
     
     properties(TestParameter)
         dp = {0., -0.01, 0.01};
-        lat = struct("hmba", "hmba","dba","dba","spear3","spear3");
         rad = struct("radoff","ring4","radon","ring6");
-        lat2 = struct("hmba", "hmba","spear3","spear3");
-        latx = {"hmba"};
+        lat = {"hmba","dba","spear3"};  % All lattices
+        lat2 = {"hmba","spear3"};       % lattices with cavities
     end
     
     properties
@@ -60,7 +59,7 @@ classdef pytests < matlab.unittest.TestCase
         % These tests may run in GitHub actions
 
         function lattice_pass(testCase,lat,rad)
-            % Test ob basic tracking
+            % Test of basic tracking
             lattice=testCase.(rad).(lat);
             rin=1.e-6*eye(6);
             pin=py.numpy.asfortranarray(rin);
@@ -205,8 +204,8 @@ classdef pytests < matlab.unittest.TestCase
             testCase.verifyEqual(mchrom,pchrom,AbsTol=2.E-5);
         end
 
-        function avlin1(testCase, latx, dp)
-            lattice=testCase.ring4.(latx);
+        function avlin1(testCase, lat, dp)
+            lattice=testCase.ring4.(lat);
             mrefs=true(1,length(lattice.m));
             prefs=py.numpy.array(mrefs);
             % python
@@ -217,7 +216,7 @@ classdef pytests < matlab.unittest.TestCase
             [~,mbeta,~,mdisp,~,~]=atavedata(lattice.m,dp,mrefs);
             % check
             testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-7,RelTol=1.e-7);
-            testCase.verifyEqual(mdisp(:,2),pdisp(:,2),AbsTol=1.E-8,RelTol=0);
+            testCase.verifyEqual(mdisp,pdisp,AbsTol=1.E-8,RelTol=0);
         end
 
         function radiation_integrals(testCase,lat)

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -12,6 +12,7 @@ classdef pytests < matlab.unittest.TestCase
         lat = struct("hmba", "hmba","dba","dba","spear3","spear3");
         rad = struct("radoff","ring4","radon","ring6");
         lat2 = struct("hmba", "hmba","spear3","spear3");
+        latx = {"hmba"};
     end
     
     properties
@@ -202,6 +203,21 @@ classdef pytests < matlab.unittest.TestCase
             testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-9,RelTol=1.e-9);
             testCase.verifyEqual(mtunes,ptunes,AbsTol=1.E-9);
             testCase.verifyEqual(mchrom,pchrom,AbsTol=2.E-5);
+        end
+
+        function avlin1(testCase, latx, dp)
+            lattice=testCase.ring4.(latx);
+            mrefs=true(1,length(lattice.m));
+            prefs=py.numpy.array(mrefs);
+            % python
+            a=cell(lattice.p.avlinopt(dp, prefs));
+            pbeta = double(a{2});
+            pdisp = double(a{4});
+            % Matlab
+            [~,mbeta,~,mdisp,~,~]=atavedata(lattice.m,dp,mrefs);
+            % check
+            testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-7,RelTol=1.e-7);
+            testCase.verifyEqual(mdisp,pdisp,AbsTol=1.E-8,RelTol=0);
         end
 
         function radiation_integrals(testCase,lat)

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -217,7 +217,7 @@ classdef pytests < matlab.unittest.TestCase
             [~,mbeta,~,mdisp,~,~]=atavedata(lattice.m,dp,mrefs);
             % check
             testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-7,RelTol=1.e-7);
-            testCase.verifyEqual(mdisp,pdisp,AbsTol=1.E-8,RelTol=0);
+            testCase.verifyEqual(mdisp(:,2),pdisp(:,2),AbsTol=1.E-8,RelTol=0);
         end
 
         function radiation_integrals(testCase,lat)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -3,6 +3,7 @@ Coupled or non-coupled 4x4 linear motion
 """
 from __future__ import annotations
 import numpy
+import numpy as np
 from math import sqrt, pi, sin, cos, atan2
 from collections.abc import Callable
 import warnings
@@ -1070,7 +1071,7 @@ def linopt(ring: Lattice, dp: float = 0.0, refpts: Refpts = None,
 
 # noinspection PyPep8Naming
 @check_6d(False)
-def avlinopt(ring, dp, refpts, **kwargs):
+def avlinopt(ring: Lattice, dp: float = 0.0, refpts: Refpts = None, **kwargs):
     r"""Linear analysis of a lattice with average values
 
     :py:func:`avlinopt` returns average beta, mu, dispersion over the lattice
@@ -1138,6 +1139,7 @@ def avlinopt(ring, dp, refpts, **kwargs):
     See also:
         :py:func:`linopt4`, :py:func:`get_optics`
     """
+
     def get_strength(elem):
         try:
             k = elem.PolynomB[1]
@@ -1161,7 +1163,7 @@ def avlinopt(ring, dp, refpts, **kwargs):
 
     def get_dx(elem):
         try:
-            k = (elem.T2[0]-elem.T1[0])/2.0
+            k = (elem.T2[0] - elem.T1[0]) / 2.0
         except (AttributeError, IndexError):
             k = 0.0
         return k
@@ -1169,133 +1171,136 @@ def avlinopt(ring, dp, refpts, **kwargs):
     def get_bendingangle(elem):
         try:
             k = elem.BendingAngle
-        except (AttributeError, IndexError):
+        except AttributeError:
             k = 0.0
         return k
 
     def get_e1(elem):
         try:
             k = elem.EntranceAngle
-        except (AttributeError, IndexError):
+        except AttributeError:
             k = 0.0
         return k
 
     def get_fint(elem):
         try:
             k = elem.FringeInt1
-        except (AttributeError, IndexError):
+        except AttributeError:
             k = 0.0
         return k
 
     def get_gap(elem):
         try:
             k = elem.FullGap
-        except (AttributeError, IndexError):
+        except AttributeError:
             k = 0.0
         return k
 
-    def sini(x, L):
-        r = x.copy()
-        xp = x >= 0
-        xm = x < 0
-        r[xp] = numpy.sin(numpy.sqrt(x[xp])*L[xp])/numpy.sqrt(x[xp])
-        r[xm] = numpy.sinh(numpy.sqrt(-x[xm])*L[xm])/numpy.sqrt(-x[xm])
-        return r
+    def foctrigo(k2, lg):
+        sqkl = np.sqrt(k2) * lg
+        return np.sin(sqkl) / sqkl, 1.0 - np.cos(sqkl)
 
-    def cosi(x, L):
-        r = x.copy()
-        xp = x >= 0
-        xm = x < 0
-        r[xp] = numpy.cos(numpy.sqrt(x[xp])*L[xp])
-        r[xm] = numpy.cosh(numpy.sqrt(-x[xm])*L[xm])
-        return r
+    def defoctrigo(k2, lg):
+        sqkl = np.sqrt(-k2) * lg
+        return np.sinh(sqkl) / sqkl, 1.0 - np.cosh(sqkl)
 
     def betadrift(beta0, alpha0, lg):
         gamma0 = (alpha0 * alpha0 + 1.0) / beta0
-        return beta0-alpha0*lg+gamma0*lg*lg/3
+        return beta0 - alpha0 * lg + gamma0 * lg * lg / 3
 
-    def betafoc(beta0, alpha0, kk, lg):
+    def betafoc(func, beta0, alpha0, k2, lg):
         gamma0 = (alpha0 * alpha0 + 1.0) / beta0
-        return ((beta0+gamma0/kk)*lg +
-                (beta0-gamma0/kk)*sini(kk, 2.0*lg)/2.0 +
-                (cosi(kk, 2.0*lg)-1.0)*alpha0/kk)/lg/2.0
+        sini, cosi = func(k2, 2.0 * lg)
+        return (
+            (beta0 + gamma0 / k2)
+            + (beta0 - gamma0 / k2) * sini
+            - cosi * alpha0 / k2 / lg
+        ) / 2.0
 
-    def dispfoc(disp0, ir, k2, lg):
-        avedisp = disp0.copy()
-        avedisp[:, 0::2] = (disp0[:, 0::2]*sini(k2, lg) +
-                            disp0[:, 1::2]*(1.0-cosi(k2, lg))/k2 +
-                            ir*(lg-sini(k2, lg))/k2)/lg
-        avedisp[:, 1::2] = (disp0[:, 1::2]*(sini(k2, lg)) -
-                            disp0[:, 0::2]*(1.0-cosi(k2, lg)) +
-                            ir*(1.0-cosi(k2, lg))/k2)/lg
-        return avedisp
+    def betalong(beta0, alpha0, k2, lg):
+        r = np.empty_like(beta0)
+        kp = k2 >= 1.0e-7
+        km = k2 <= -1.0e-7
+        k0 = np.logical_not(kp | km)
+        r[kp] = betafoc(foctrigo, beta0[kp], alpha0[kp], k2[kp], lg[kp])
+        r[km] = betafoc(defoctrigo, beta0[km], alpha0[km], k2[km], lg[km])
+        r[k0] = betadrift(beta0[k0], alpha0[k0], lg[k0])
+        return r
+
+    def dispfoc(func, disp0, ir, k2, lg):
+        sini, cosi = func(k2, lg)
+        eta = disp0[:, 0] * sini + disp0[:, 1] * cosi / k2 / lg + ir * (1.0 - sini) / k2
+        etap = disp0[:, 1] * sini - disp0[:, 0] * cosi / lg + ir * cosi / k2 / lg
+        return np.stack((eta, etap), axis=1)
+
+    def dispdrift(disp0, ir, lg):
+        eta = disp0[:, 0] + disp0[:, 1] * lg / 2.0 + lg * lg * ir / 6.0
+        etap = disp0[:, 1] + lg * ir / 2.0
+        return np.stack((eta, etap), axis=1)
+
+    def displong(disp0, ir, k2, lg):
+        r = np.empty_like(disp0)
+        kp = k2 >= 1.0e-7
+        km = k2 <= -1.0e-7
+        k0 = np.logical_not(kp | km)
+        r[kp] = dispfoc(foctrigo, disp0[kp], ir[kp], k2[kp], lg[kp])
+        r[km] = dispfoc(defoctrigo, disp0[km], ir[km], k2[km], lg[km])
+        r[k0] = dispdrift(disp0[k0], ir[k0], lg[k0])
+        return r
 
     # selected list
     boolrefs = get_bool_index(ring, refpts)
-    ring_selected = ring[refpts]
-    L = numpy.array([el.Length for el in ring_selected])
-    K = numpy.array([get_strength(el) for el in ring_selected])
-    sext_strength = numpy.array([get_sext_strength(el)
-                                 for el in ring_selected])
-    roll = numpy.array([get_roll(el) for el in ring_selected])
-    ba = numpy.array([get_bendingangle(el) for el in ring_selected])
-    e1 = numpy.array([get_e1(el) for el in ring_selected])
-    Fint = numpy.array([get_fint(el) for el in ring_selected])
-    gap = numpy.array([get_gap(el) for el in ring_selected])
-    dx = numpy.array([get_dx(el) for el in ring_selected])
-    irho = ba.copy()
-    d_csi = ba.copy()
+    L = np.array([el.Length for el in ring[boolrefs[:-1]]])
+    longelem = boolrefs[:-1].copy()
+    longelem[longelem] = L != 0.0
 
-    # whole ring list
-    longelem = get_bool_index(ring, None)
-    longelem[boolrefs] = (L != 0)
-
-    shorti_refpts = (~longelem) & boolrefs
-    longi_refpts = longelem & boolrefs
-    longf_refpts = numpy.roll(longi_refpts, 1)
-    all_refs = shorti_refpts | longi_refpts | longf_refpts
-    _, bd, d_all = linopt4(ring, refpts=all_refs, dp=dp,
-                           get_chrom=True, **kwargs)
-    lindata = d_all[boolrefs[all_refs]]
+    longi_refpts = np.append(longelem, [False])
+    longf_refpts = np.roll(longi_refpts, 1)
+    all_refs = boolrefs | longf_refpts
+    _, bd, d_all = linopt4(ring, refpts=all_refs, dp=dp, get_chrom=True, **kwargs)
+    lindata = d_all[boolrefs[all_refs]]  # Optics at entrance of selected elements
 
     avebeta = lindata.beta.copy()
     avemu = lindata.mu.copy()
     avedisp = lindata.dispersion.copy()
     aves = lindata.s_pos.copy()
-    ClosedOrbit = lindata.closed_orbit.copy()
-    dx0 = ClosedOrbit[:, 0]
 
-    di = d_all[longi_refpts[all_refs]]
-    df = d_all[longf_refpts[all_refs]]
+    # Long elements
+    b_long = longi_refpts[boolrefs]
+    ring_long = ring[longelem]
+    L = L[(L != 0.0)]
+    di = d_all[longi_refpts[all_refs]]  # Optics at entrance of long elements
+    df = d_all[longf_refpts[all_refs]]  # Optics at exit of long elements
 
-    b_long = (L != 0.0)
-    dx0[b_long] = (di.closed_orbit[:, 0]+df.closed_orbit[:, 0])/2
-    irho[b_long] = ba[b_long]/L[b_long]
-    K = K*roll + 2*sext_strength*(dx0-dx)
-    b_foc = (abs(K) > 1.0e-7)
-    b_foc_long = b_long & b_foc
-    b_drf = b_long & (~b_foc)
+    dx0 = (di.closed_orbit[:, 0] + df.closed_orbit[:, 0]) / 2
+    K = np.array([get_strength(el) for el in ring_long])
+    sext_strength = np.array([get_sext_strength(el) for el in ring_long])
+    roll = np.array([get_roll(el) for el in ring_long])
+    ba = np.array([get_bendingangle(el) for el in ring_long])
+    dx = np.array([get_dx(el) for el in ring_long])
+    irho = ba / L
+    K = K * roll + 2 * sext_strength * (dx0 - dx)
+    Kx = K + irho * irho
+    Ky = -K
+    Kxy = np.stack((Kx, Ky), axis=1)
+    Lxy = np.stack((L, L), axis=1)
 
-    K2 = numpy.stack((K[b_foc_long]+irho[b_foc_long]*irho[b_foc_long], -K[b_foc_long]), axis=1)
-    fff = b_foc_long[b_long]
-    d_csi[b_long] = ba[b_long]*(gap[b_long]*Fint[b_long] *
-                                (1.0 + numpy.sin(e1[b_long])**2) /
-                                numpy.cos(e1[b_long])/L[b_long])
-    L2 = numpy.stack((L[b_foc_long], L[b_foc_long]), axis=1)
-    irho2 = irho[b_foc_long]
-    irho2 = numpy.stack((irho2, numpy.zeros(irho2.shape)), axis=1)
-    L = L.reshape((-1, 1))
+    # Hard edge model on dipoles
+    bend = irho != 0.0
+    e1 = np.array([get_e1(el) for el in ring_long[bend]])
+    Fint = np.array([get_fint(el) for el in ring_long[bend]])
+    gap = np.array([get_gap(el) for el in ring_long[bend]])
+    d_csi = irho[bend] * gap * Fint * (1.0 + np.sin(e1) ** 2) / np.cos(e1)
+    Cp = np.stack((irho[bend] * np.tan(e1), -irho[bend] * np.tan(e1 - d_csi)), axis=1)
+    di.alpha[bend] -= di.beta[bend] * Cp
+    di.dispersion[np.ix_(bend, [1, 3])] -= di.dispersion[np.ix_(bend, [0, 2])] * Cp
 
     avemu[b_long] = 0.5 * (di.mu + df.mu)
     aves[b_long] = 0.5 * (df.s_pos + di.s_pos)
-    avebeta[b_drf] = betadrift(di.beta[~fff], di.alpha[~fff], L[b_drf])
-    avebeta[b_foc_long] = betafoc(di.beta[fff], di.alpha[fff], K2, L2)
-    avedisp[numpy.ix_(b_long, [1, 3])] = (df.dispersion[:, [0, 2]] -
-                                          di.dispersion[:, [0, 2]]) / L[b_long]
-    idx = numpy.ix_(~fff, [0, 2])
-    avedisp[numpy.ix_(b_drf, [0, 2])] = (di.dispersion[idx] +
-                                         df.dispersion[idx]) * 0.5
-    avedisp[b_foc_long, :] = dispfoc(di.dispersion[fff, :], irho2, K2, L2)
+    avebeta[b_long] = betalong(di.beta, di.alpha, Kxy, Lxy)
+    avedx = displong(di.dispersion[:, :2], irho, Kx, L)
+    avedy = displong(di.dispersion[:, 2:], np.zeros_like(irho), Ky, L)
+    avedisp[b_long] = np.concat((avedx, avedy), axis=1)
 
     return lindata, avebeta, avemu, avedisp, aves, bd.tune, bd.chromaticity
 

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -1228,8 +1228,6 @@ def avlinopt(ring, dp, refpts, **kwargs):
         avedisp[:, 1::2] = (disp0[:, 1::2]*(sini(k2, lg)) -
                             disp0[:, 0::2]*(1.0-cosi(k2, lg)) +
                             ir*(1.0-cosi(k2, lg))/k2)/lg
-        print(disp0, ir, k2, lg)
-        print(avedisp)
         return avedisp
 
     # selected list
@@ -1285,7 +1283,7 @@ def avlinopt(ring, dp, refpts, **kwargs):
                                 numpy.cos(e1[b_long])/L[b_long])
     L2 = numpy.stack((L[b_foc_long], L[b_foc_long]), axis=1)
     irho2 = irho[b_foc_long]
-    irho2 = numpy.stack(irho2, numpy.zeros(irho2.shape), axis=1)
+    irho2 = numpy.stack((irho2, numpy.zeros(irho2.shape)), axis=1)
     L = L.reshape((-1, 1))
 
     avemu[b_long] = 0.5 * (di.mu + df.mu)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -1222,12 +1222,14 @@ def avlinopt(ring, dp, refpts, **kwargs):
 
     def dispfoc(disp0, ir, k2, lg):
         avedisp = disp0.copy()
-        avedisp[:, 0::2] = (disp0[:, 0::2]*(sini(k2, lg)) +
+        avedisp[:, 0::2] = (disp0[:, 0::2]*sini(k2, lg) +
                             disp0[:, 1::2]*(1.0-cosi(k2, lg))/k2 +
                             ir*(lg-sini(k2, lg))/k2)/lg
-        avedisp[:, 1::2] = (disp0[:, 0::2]*(sini(k2, lg)) -
+        avedisp[:, 1::2] = (disp0[:, 1::2]*(sini(k2, lg)) -
                             disp0[:, 0::2]*(1.0-cosi(k2, lg)) +
-                            ir*(lg-cosi(k2, lg))/k2)/lg
+                            ir*(1.0-cosi(k2, lg))/k2)/lg
+        print(disp0, ir, k2, lg)
+        print(avedisp)
         return avedisp
 
     # selected list
@@ -1282,7 +1284,8 @@ def avlinopt(ring, dp, refpts, **kwargs):
                                 (1.0 + numpy.sin(e1[b_long])**2) /
                                 numpy.cos(e1[b_long])/L[b_long])
     L2 = numpy.stack((L[b_foc_long], L[b_foc_long]), axis=1)
-    irho = irho.reshape((-1, 1))
+    irho2 = irho[b_foc_long]
+    irho2 = numpy.stack(irho2, numpy.zeros(irho2.shape), axis=1)
     L = L.reshape((-1, 1))
 
     avemu[b_long] = 0.5 * (di.mu + df.mu)
@@ -1294,8 +1297,7 @@ def avlinopt(ring, dp, refpts, **kwargs):
     idx = numpy.ix_(~fff, [0, 2])
     avedisp[numpy.ix_(b_drf, [0, 2])] = (di.dispersion[idx] +
                                          df.dispersion[idx]) * 0.5
-    avedisp[b_foc_long, :] = dispfoc(di.dispersion[fff, :],
-                                     irho[b_foc_long], K2, L2)
+    avedisp[b_foc_long, :] = dispfoc(di.dispersion[fff, :], irho2, K2, L2)
 
     return lindata, avebeta, avemu, avedisp, aves, bd.tune, bd.chromaticity
 


### PR DESCRIPTION
This PR restores the comparative tests between python and Matlab in the `pyat/test_matlab` directory, which was failing for the average beta and dispersion checks.

Unfortunately, this test cannot be run in GitHub actions because a problem of Matlab license, so the problem was not immediately spotted. We introduce here a new test in the "Matlab tests" script, which is run on GitHub, to prevent any further problem.

The introduction of this new test revealed a number of residual errors in the computation of average values. Among others:
- dipoles without gradient were considered as drifts, ignoring the intrinsic horizontal focusing (1/&rho;<sup>2</sup> term). This has a small effect on &beta;<sub>x</sub>, but more on the dispersion,
- the inverse radius effect was applied for dispersion on both horizontal and vertical planes. This results in a wrong vertical dispersion term,
- the dispersion derivative &eta;’ term was wrong (index error),
- the entrance pole face angle in dipoles was ignored in python, but applied in Matlab,
- more important: since the last release, defocusing magnets were wrong: the `k < 1.e-7` test should be `abs(k) < 1.e-7` (my fault),
- other small bugs

However all these ended up in relatively small errors. But the making it completely correct implied rather large modifications: mainly because we cannot assume that we have either focusing in both planes, or no focusing at all. Planes must now be dissociated.

The main improvement here is that the average values will be automatically checked on each commit.

@ZeusMarti: in your 1st version, you showed a validation, mainly focused on quadrupoles (which were right). Maybe you could you check that this is still ok ?