### PR TITLE
check len(refpts) > 2 after removing zero length elements in get_lifetime()

### DIFF
--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -385,7 +385,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
     double omr = TWOPI*freq;
-    double complex vbeamc = vbeam[0]*cexp(_Complex_I*vbeam[1]);
+    double complex vbeamc = vbeam[0]*cexp(I*vbeam[1]);
     double complex vbeamkc = 0.0;
     double kloss = rshunt*omr/(2*qfactor);
     double bc = beta*C0;
@@ -416,7 +416,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
             /* This is dt between each slice*/
             dt = (turnhistoryZ[i]-turnhistoryZ[i-1])/bc;
         }
-        vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
+        vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
         /*vbeamkc is average kick i.e. average vbeam*/   
         vbeamkc += (vbeamc+selfkick)*wi;
         totalW += wi;
@@ -430,7 +430,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     /*This takes the vbeam backwards in time to effectively store the
     final slice position */
     dt = -turnhistoryZ[sliceperturn*nturns-1]/bc;    
-    vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
+    vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
 
     vbeam[0] = cabs(vbeamc);
     vbeam[1] = carg(vbeamc);

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -8,7 +8,6 @@
 #include <mpi4py/mpi4py.h>
 #endif
 
-#define _I _Complex_I
 
 int binarySearch(double *array,double value,int upper,int lower,int nStep){
     int pivot = (int)(lower+upper)/2;

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -385,7 +385,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
     double omr = TWOPI*freq;
-    double complex vbeamc = vbeam[0]*cexp(I*vbeam[1]);
+    double complex vbeamc = vbeam[0]*cexp(_Complex_I*vbeam[1]);
     double complex vbeamkc = 0.0;
     double kloss = rshunt*omr/(2*qfactor);
     double bc = beta*C0;
@@ -416,7 +416,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
             /* This is dt between each slice*/
             dt = (turnhistoryZ[i]-turnhistoryZ[i-1])/bc;
         }
-        vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+        vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
         /*vbeamkc is average kick i.e. average vbeam*/   
         vbeamkc += (vbeamc+selfkick)*wi;
         totalW += wi;
@@ -430,7 +430,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     /*This takes the vbeam backwards in time to effectively store the
     final slice position */
     dt = -turnhistoryZ[sliceperturn*nturns-1]/bc;    
-    vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+    vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
 
     vbeam[0] = cabs(vbeamc);
     vbeam[1] = carg(vbeamc);

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -8,6 +8,8 @@
 #include <mpi4py/mpi4py.h>
 #endif
 
+#define _I _Complex_I
+
 int binarySearch(double *array,double value,int upper,int lower,int nStep){
     int pivot = (int)(lower+upper)/2;
     if ((upper-lower)<=1){
@@ -297,7 +299,7 @@ static void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turn
 
     int rank=0;
     int size=1;
-    int i,ii,ib,loopstart,loopend;
+    int i,ii,ib;
     double ds,wi,wii;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
@@ -375,7 +377,8 @@ static void compute_kicks_longres(int nslice,int nbunch,int nturns, double *turn
 static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *turnhistory,
                           double normfact, double *kz,double freq, double qfactor,
                           double rshunt, double *vbeam, double circumference,
-                          double energy, double beta, double *vbeamk, double *vbunch){  
+                          double energy, double beta, double *vbeamk, double *vbunch){ 
+                          
     #ifndef _MSC_VER  
     int i,ib,is;
     double wi;
@@ -416,7 +419,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
             /* This is dt between each slice*/
             dt = (turnhistoryZ[i]-turnhistoryZ[i-1])/bc;
         }
-        vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+        vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
         /*vbeamkc is average kick i.e. average vbeam*/   
         vbeamkc += (vbeamc+selfkick)*wi;
         totalW += wi;
@@ -430,7 +433,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     /*This takes the vbeam backwards in time to effectively store the
     final slice position */
     dt = -turnhistoryZ[sliceperturn*nturns-1]/bc;    
-    vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+    vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
 
     vbeam[0] = cabs(vbeamc);
     vbeam[1] = carg(vbeamc);

--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -181,6 +181,8 @@ def _init_ma_rp(ring, refpts=None, offset=None, momap=None,
         zerolength_warning = ('zero-length elements removed '
                               'from lifetime calculation')
         warnings.warn(AtWarning(zerolength_warning))
+        assert len(refpts[mask]) > 2, \
+            'After removing zero-length elements: len(refpts)<2'
 
     refpts = refpts[mask]
     if offset is not None:


### PR DESCRIPTION
This answers #796 : when `len(refpts) < 2` after removing the zero length elements in the `get_lifetime()` function and error message is issued.