### PR TITLE
use _Complex_I instead of I

### DIFF
--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -385,7 +385,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
     double omr = TWOPI*freq;
-    double complex vbeamc = vbeam[0]*cexp(I*vbeam[1]);
+    double complex vbeamc = vbeam[0]*cexp(_Complex_I*vbeam[1]);
     double complex vbeamkc = 0.0;
     double kloss = rshunt*omr/(2*qfactor);
     double bc = beta*C0;
@@ -416,7 +416,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
             /* This is dt between each slice*/
             dt = (turnhistoryZ[i]-turnhistoryZ[i-1])/bc;
         }
-        vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+        vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
         /*vbeamkc is average kick i.e. average vbeam*/   
         vbeamkc += (vbeamc+selfkick)*wi;
         totalW += wi;
@@ -430,7 +430,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     /*This takes the vbeam backwards in time to effectively store the
     final slice position */
     dt = -turnhistoryZ[sliceperturn*nturns-1]/bc;    
-    vbeamc *= cexp((I*omr-omr/(2*qfactor))*dt);
+    vbeamc *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
 
     vbeam[0] = cabs(vbeamc);
     vbeam[1] = carg(vbeamc);


### PR DESCRIPTION
This PR is a workaround regarding issue #800. Following compilation issues, the I macro is replaced with _Complex_I in `atimplib.c`.
This is a **temporary** fix that will need to be looked at in more details as it is for the moment not understood and could be a symptom for more severe problems.