### PR TITLE
Always attempt to import at.plot

### DIFF
--- a/docs/m/index.rst
+++ b/docs/m/index.rst
@@ -33,3 +33,4 @@ higher-level functions to provide physics results.
    releases/r2.3
    releases/r2.4
    releases/r2.5
+   releases/r2.6

--- a/docs/p/howto/Installation.rst
+++ b/docs/p/howto/Installation.rst
@@ -22,9 +22,41 @@ PyPI maintains PyAT versions for Linux, MacOS and Windows, and python versions:
 - CPython 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
 - PyPI does not support PyPy, because of the missing numpy and scipy libraries
 
-Install accelerator-toolbox from PyPI::
+*Installation with minimal dependencies:*
+.........................................
+
+::
 
    $ pip install accelerator-toolbox
+
+This minimal installation disables all plotting functions. Note that the plotting
+functions can be enabled later by simply installing `matplotlib <https://matplotlib.org>`_.
+
+*Standard installation:*
+........................
+
+::
+
+   $ pip install accelerator-toolbox[plot]
+
+This installs in addition the `matplotlib <https://matplotlib.org>`_ package and its dependencies, and enables all
+plotting functions.
+
+*Optional dependencies:*
+........................
+
+In addition to ``[plot]``, other modifiers are available for specific purposes:
+
+``accelerator-toolbox[dev]``
+    Installs the test framework: `pytest <https://docs.pytest.org/en/stable/>`_,
+    `pytest-cov <https://pypi.org/project/pytest-cov/>`_ and
+    `flake8 <https://flake8.pycqa.org/en/latest/>`_. This allows to run locally
+    the test sequence executed on GitHub.
+
+``accelerator-toolbox[doc]``
+    Installs `Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ and its
+    utilities, allowing the generate locally the HTML documentation.
+
 
 From conda-forge
 ~~~~~~~~~~~~~~~~

--- a/docs/p/howto/Installation.rst
+++ b/docs/p/howto/Installation.rst
@@ -37,26 +37,27 @@ functions can be enabled later by simply installing `matplotlib <https://matplot
 
 ::
 
-   $ pip install accelerator-toolbox[plot]
+   $ pip install "accelerator-toolbox[plot]"
 
-This installs in addition the `matplotlib <https://matplotlib.org>`_ package and its dependencies, and enables all
-plotting functions.
+This installs in addition the `matplotlib <https://matplotlib.org>`_ package and its
+dependencies, which enables all plotting functions.
 
 *Optional dependencies:*
 ........................
 
 In addition to ``[plot]``, other modifiers are available for specific purposes:
 
-``accelerator-toolbox[dev]``
+``"accelerator-toolbox[dev]"``
     Installs the test framework: `pytest <https://docs.pytest.org/en/stable/>`_,
     `pytest-cov <https://pypi.org/project/pytest-cov/>`_ and
     `flake8 <https://flake8.pycqa.org/en/latest/>`_. This allows to run locally
     the test sequence executed on GitHub.
 
-``accelerator-toolbox[doc]``
+``"accelerator-toolbox[doc]"``
     Installs `Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ and its
     utilities, allowing the generate locally the HTML documentation.
 
+These modifiers may be combined. Example: ``pip install "accelerator-toolbox[plot,dev]"``
 
 From conda-forge
 ~~~~~~~~~~~~~~~~

--- a/docs/p/howto/Primer.rst
+++ b/docs/p/howto/Primer.rst
@@ -49,14 +49,14 @@ the function **Quadrupole**
 .. parsed-literal::
 
     Quadrupole:
-    	FamName : QF
-    	Length : 0.5
-    	PassMethod : StrMPoleSymplectic4Pass
-    	NumIntSteps : 10
-    	MaxOrder : 1
-    	PolynomA : [0. 0.]
-    	PolynomB : [0.  1.2]
-    	K : 1.2
+        FamName : QF
+        Length : 0.5
+        PassMethod : StrMPoleSymplectic4Pass
+        NumIntSteps : 10
+        MaxOrder : 1
+        PolynomA : [0. 0.]
+        PolynomB : [0.  1.2]
+        K : 1.2
 
 
 We note that the family name of this quadrupole is ’QF’ and the pass
@@ -248,23 +248,23 @@ selected elements:
 .. parsed-literal::
 
     Quadrupole:
-    	FamName : QF
-    	Length : 0.5
-    	PassMethod : StrMPoleSymplectic4Pass
-    	NumIntSteps : 10
-    	MaxOrder : 1
-    	PolynomA : [0. 0.]
-    	PolynomB : [0.  1.2]
-    	K : 1.2
+        FamName : QF
+        Length : 0.5
+        PassMethod : StrMPoleSymplectic4Pass
+        NumIntSteps : 10
+        MaxOrder : 1
+        PolynomA : [0. 0.]
+        PolynomB : [0.  1.2]
+        K : 1.2
     Quadrupole:
-    	FamName : QD
-    	Length : 0.5
-    	PassMethod : StrMPoleSymplectic4Pass
-    	NumIntSteps : 10
-    	MaxOrder : 1
-    	PolynomA : [0. 0.]
-    	PolynomB : [ 0.  -1.2]
-    	K : -1.2
+        FamName : QD
+        Length : 0.5
+        PassMethod : StrMPoleSymplectic4Pass
+        NumIntSteps : 10
+        MaxOrder : 1
+        PolynomA : [0. 0.]
+        PolynomB : [ 0.  -1.2]
+        K : -1.2
 
 
 Extracting attribute values
@@ -753,14 +753,14 @@ the function **set_cavity** as follows
 .. parsed-literal::
 
     RFCavity:
-    	FamName : RFC
-    	Length : 0.0
-    	PassMethod : IdentityPass
-    	Voltage : 500000.0
-    	Frequency : 299792457.9999997
-    	HarmNumber : 1
-    	Energy : 1000000000.0
-    	TimeLag : 0.0
+        FamName : RFC
+        Length : 0.0
+        PassMethod : IdentityPass
+        Voltage : 500000.0
+        Frequency : 299792457.9999997
+        HarmNumber : 1
+        Energy : 1000000000.0
+        TimeLag : 0.0
 
 
 which says that the each of the 20 RF cavities has a voltage of 25 kV.

--- a/pyat/at/__init__.py
+++ b/pyat/at/__init__.py
@@ -1,6 +1,7 @@
 """Python port of the Accelerator Toolbox"""
 
 from ._version import __version__, __version_tuple__
+
 # Make all functions visible in the at namespace:
 from .lattice import *
 from .tracking import *
@@ -10,3 +11,4 @@ from .load import *
 from .matching import *
 from .acceptance import *
 from .collective import *
+from .plot import *

--- a/pyat/at/plot/__init__.py
+++ b/pyat/at/plot/__init__.py
@@ -11,3 +11,4 @@ else:
     from .generic import *
     from .specific import *
     from .standalone import *
+    from .resonances import *

--- a/pyat/at/plot/__init__.py
+++ b/pyat/at/plot/__init__.py
@@ -1,12 +1,13 @@
 """AT plotting functions"""
+
 try:
     # noinspection PyPackageRequirements
     import matplotlib
+except (ImportError, RuntimeError) as exc:
+    print("matplotlib is unavailable => plotting is disabled.")
+    print("To enable plotting functions, run \"pip install matplotlib\".")
+else:
     from .synopt import *
     from .generic import *
     from .specific import *
     from .standalone import *
-    from .resonances import *
-except (ImportError, RuntimeError) as exc:
-    print(exc)
-    print('Plotting is disabled')


### PR DESCRIPTION
As discussed [here](https://github.com/atcollab/at/pull/809#issuecomment-2268502581), `at.plot` had to be explicitly imported to access plotting functions and methods. 

Now `at.plot` will be recursively imported when importing `at`. It is still possible to run at without matplotlib: in such a case, an explicit message will be printed on importing `at`:

_matplotlib is unavailable => plotting is disabled.
To enable plotting functions, run "pip install matplotlib"._

The installation instructions are updated to describe the optional dependencies.