### PR TITLE
Add feeddown polba

### DIFF
--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -17,3 +17,4 @@ from .ring_parameters import *
 from .nonlinear import *
 from .fastring import *
 from .frequency_maps import fmap_parallel_track
+from .magnet_tools import *

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -45,33 +45,32 @@ def feeddown_polynomba(
     # verify polynoms length
     maxorda = len(pola)
     maxordb = len(polb)
-    if maxorda == 0 and maxordb == 0:
-        verboseprint("Both polynoms are zero.")
-        return numpy.array([])
     maxord = max(maxorda, maxordb)
-
-    polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))
-    polapad = numpy.pad(pola, (0, maxord - maxorda), "constant", constant_values=(0, 0))
-
-    verboseprint(f"polb={polb},pola={pola}")
-    verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
     polasum = numpy.zeros(maxord - 1)
     polbsum = numpy.zeros(maxord - 1)
-    for ith in range(2, maxord + 1):
-        polbaux_b, polaaux_b = feeddown_from_nth_order(
-            ith, polbpad[ith - 1], xoffset, yoffset, poltype="B"
-        )
-        polbaux_a, polaaux_a = feeddown_from_nth_order(
-            ith, polapad[ith - 1], xoffset, yoffset, poltype="A"
-        )
-        polbshort = polbaux_b + polbaux_a
-        polashort = polaaux_b + polaaux_a
-        polbsum = polbsum + numpy.pad(
-            polbshort, (0, maxord - ith), "constant", constant_values=(0, 0)
-        )
-        polasum = polasum + numpy.pad(
-            polashort, (0, maxord - ith), "constant", constant_values=(0, 0)
-        )
+    if maxorda == 0 and maxordb == 0:
+        verboseprint("Both polynoms are zero.")
+    else:
+        polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))
+        polapad = numpy.pad(pola, (0, maxord - maxorda), "constant", constant_values=(0, 0))
+
+        verboseprint(f"polb={polb},pola={pola}")
+        verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
+        for ith in range(2, maxord + 1):
+            polbaux_b, polaaux_b = feeddown_from_nth_order(
+                ith, polbpad[ith - 1], xoffset, yoffset, poltype="B"
+            )
+            polbaux_a, polaaux_a = feeddown_from_nth_order(
+                ith, polapad[ith - 1], xoffset, yoffset, poltype="A"
+            )
+            polbshort = polbaux_b + polbaux_a
+            polashort = polaaux_b + polaaux_a
+            polbsum = polbsum + numpy.pad(
+                polbshort, (0, maxord - ith), "constant", constant_values=(0, 0)
+            )
+            polasum = polasum + numpy.pad(
+                polashort, (0, maxord - ith), "constant", constant_values=(0, 0)
+            )
     poldict = {"PolynomB": polbsum, "PolynomA": polasum}
     verboseprint(f"poldict={poldict}")
     return poldict

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -10,8 +10,34 @@ from scipy.special import comb
 __all__ = [
     "feeddown_polynomba",
     "feeddown_from_nth_order",
+    "feeddown_pol_from_element",
 ]
 
+
+def feeddown_pol_from_element(ele):
+    """
+    Return the feed down polynoms due to a transverse offset on an element.
+
+    Parameters:
+        element: a ring element.
+        polb: PolynomB.
+        pola: PolynomA.
+        xoffset: Default zero. Horizontal offset in meters.
+
+    Returns:
+        Dictionary with PolynomB and PolynomA feeddown components.
+
+    Note: Thin lengs approxiamtion, T2=-T1.
+          Bending angles are ignored.
+    """
+    # check verbose flags only once
+    verboseprint = print if verbose else lambda *a, **k: None
+    # handle cases where polynom a and b are not defined
+    # get polynoms
+    # check if element has T1 and T2. Use one.
+    # Return the polynoms
+
+    return 0
 
 def feeddown_polynomba(
     polb: Sequence[float],
@@ -36,7 +62,7 @@ def feeddown_polynomba(
     Note:
         If only one polynom is passed, it is assumed to be PolynomB.
     """
-    # check and verbose flags only once
+    # check verbose flags only once
     verboseprint = print if verbose else lambda *a, **k: None
 
     # verify polynoms length

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -160,26 +160,27 @@ def feeddown_from_nth_order(
     fakeimag = {0: 1, 1: 0, 2: -1, 3: 0}
     polbaux = numpy.zeros(nthorder - 1)
     polaaux = numpy.zeros(nthorder - 1)
-    for kterm in range(1, nthorder):
-        ichoosek = comb(nthorder - 1, kterm)
-        pascalsn = comb(kterm, numpy.arange(kterm + 1))
-        powk = numpy.arange(kterm + 1)
-        powkflip = numpy.arange(kterm, -1, -1)
-        recoefs = numpy.array([fakeimag[numpy.mod(idx, 4)] for idx in powk])
-        imcoefs = numpy.array([fakeimag[numpy.mod(idx + 3, 4)] for idx in powk])
-        commonfactor = nthpolcomp * ichoosek * (-1) ** kterm
-        repart = (
-            recoefs
-            * commonfactor
-            * (pascalsn * (xoffset**powkflip * yoffset**powk))
-        )
-        impart = (
-            imcoefs
-            * commonfactor
-            * (pascalsn * (xoffset**powkflip * yoffset**powk))
-        )
-        polbaux[nthorder - kterm - 1] = polbaux[nthorder - kterm - 1] + repart.sum()
-        polaaux[nthorder - kterm - 1] = polaaux[nthorder - kterm - 1] + impart.sum()
+    if nthpolcomp != 0:
+        for kterm in range(1, nthorder):
+            ichoosek = comb(nthorder - 1, kterm)
+            pascalsn = comb(kterm, numpy.arange(kterm + 1))
+            powk = numpy.arange(kterm + 1)
+            powkflip = numpy.arange(kterm, -1, -1)
+            recoefs = numpy.array([fakeimag[numpy.mod(idx, 4)] for idx in powk])
+            imcoefs = numpy.array([fakeimag[numpy.mod(idx + 3, 4)] for idx in powk])
+            commonfactor = nthpolcomp * ichoosek * (-1) ** kterm
+            repart = (
+                recoefs
+                * commonfactor
+                * (pascalsn * (xoffset**powkflip * yoffset**powk))
+            )
+            impart = (
+                imcoefs
+                * commonfactor
+                * (pascalsn * (xoffset**powkflip * yoffset**powk))
+            )
+            polbaux[nthorder - kterm - 1] = polbaux[nthorder - kterm - 1] + repart.sum()
+            polaaux[nthorder - kterm - 1] = polaaux[nthorder - kterm - 1] + impart.sum()
     verboseprint(f"polbaux={polbaux},polaaux={polaaux}")
     polbout, polaout = polbaux, polaaux
     # skew components swap the imaginary and real feed-down and change the sign

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -46,8 +46,8 @@ def feeddown_polynomba(
     maxorda = len(pola)
     maxordb = len(polb)
     maxord = max(maxorda, maxordb)
-    polasum = numpy.zeros(maxord - 1)
-    polbsum = numpy.zeros(maxord - 1)
+    polasum = numpy.zeros(max(0,maxord - 1))
+    polbsum = numpy.zeros(max(0,maxord - 1))
     if maxorda == 0 and maxordb == 0:
         verboseprint("Both polynoms are zero.")
     else:

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -59,7 +59,7 @@ def feeddown_pol_from_element(
             xoffset = -ele.T1[0]
             yoffset = -ele.T1[2]
         else:
-            verboseprint("Element has no T1 or T2.")
+            verboseprint(f"Element {ele.FamName} has no T1 or T2.")
     verboseprint(f"Using offsets xoffset={xoffset}, yoffset={yoffset}.")
     # Return the polynoms
     return feeddown_polynomba(polb=polb, pola=pola, xoffset=xoffset, yoffset=yoffset)

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -1,0 +1,399 @@
+"""
+Non-linear optics
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy
+from scipy.special import comb, factorial
+
+from ..lattice import Element, Lattice
+from ..tracking import internal_lpass
+from .harmonic_analysis import get_tunes_harmonic
+from .linear import get_chrom, get_tune, linopt6
+from .orbit import Orbit, find_orbit
+
+__all__ = [
+    "detuning",
+    "chromaticity",
+    "gen_detuning_elem",
+    "tunes_vs_amp",
+    "feeddown_polynomba",
+    "feeddown_from_nth_order",
+]
+
+
+def tunes_vs_amp(
+    ring: Lattice,
+    amp: Optional[Sequence[float]] = None,
+    dim: Optional[int] = 0,
+    nturns: Optional[int] = 512,
+    **kwargs,
+) -> numpy.ndarray:
+    r"""Generates a range of tunes for varying x, y, or z amplitudes
+
+    Parameters:
+        ring:               Lattice description
+        amp:                Oscillation amplitude. If amp is None the
+                            tunes are calculated from :py:func:`.linopt6`
+                            else tracking is used
+        dim:                Coordinate index of the oscillation
+        nturns:             Number of turns
+        method:             ``'laskar'`` or ``'fft'``. Default: ``'laskar'``
+        num_harmonics:      Number of harmonic components to compute (before
+                            mask applied)
+        fmin:               Lower bound for tune
+        fmax:               Upper bound for tune
+        hann:               Turn on Hanning window. Default: :py:obj:`False`
+
+    Returns:
+        tunes (ndarray):    Array of tunes qx, qy with shape (len(amp), 2)
+    """
+
+    def _gen_part(ring, amp, dim, orbit, ld, nturns):
+        invx = numpy.array(
+            [
+                [1 / numpy.sqrt(ld["beta"][0]), 0],
+                [ld["alpha"][0] / numpy.sqrt(ld["beta"][0]), numpy.sqrt(ld["beta"][0])],
+            ]
+        )
+
+        invy = numpy.array(
+            [
+                [1 / numpy.sqrt(ld["beta"][1]), 0],
+                [ld["alpha"][1] / numpy.sqrt(ld["beta"][1]), numpy.sqrt(ld["beta"][1])],
+            ]
+        )
+        part = (
+            numpy.array(
+                [
+                    orbit,
+                ]
+                * len(amp)
+            ).T
+            + 1.0e-6
+        )
+        part[dim, :] += amp
+        part = internal_lpass(ring, part, nturns=nturns)
+        sh = part.shape
+        partx = numpy.reshape(part[0, :], (sh[1], sh[3]))
+        partxp = numpy.reshape(part[1, :], (sh[1], sh[3]))
+        party = numpy.reshape(part[2, :], (sh[1], sh[3]))
+        partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
+        px = numpy.array(
+            [numpy.matmul(invx, [partx[i], partxp[i]]) for i in range(len(amp))]
+        )
+        py = numpy.array(
+            [numpy.matmul(invy, [party[i], partyp[i]]) for i in range(len(amp))]
+        )
+        return px[:, 0, :] - 1j * px[:, 1, :], py[:, 0, :] - 1j * py[:, 1, :]
+
+    l0, bd, _ = linopt6(ring)
+    orbit = l0["closed_orbit"]
+    tunes = bd["tune"]
+
+    if amp is not None:
+        partx, party = _gen_part(ring, amp, dim, orbit, l0, nturns)
+        qx = get_tunes_harmonic(partx, **kwargs)
+        qy = get_tunes_harmonic(party, **kwargs)
+        tunes = numpy.vstack((qx, qy)).T
+
+    return numpy.array(tunes)
+
+
+def detuning(
+    ring: Lattice,
+    xm: Optional[float] = 0.3e-4,
+    ym: Optional[float] = 0.3e-4,
+    npoints: Optional[int] = 3,
+    nturns: Optional[int] = 512,
+    **kwargs,
+):
+    """Computes the tunes for a sequence of amplitudes
+
+    This function uses :py:func:`tunes_vs_amp` to compute the tunes for
+    the specified amplitudes. Then it fits this data and returns
+    the detuning coefficiant dQx/dx, dQy/dx, dQx/dy, dQy/dy and the
+    qx, qy arrays versus x, y arrays
+
+    Parameters:
+        ring:       Lattice description
+        xm:         Maximum x amplitude
+        ym:         Maximum y amplitude
+        npoints:    Number of points in each plane
+        nturns:     Number of turns for tracking
+        method:     ``'laskar'`` or ``'fft'``. Default: ``'laskar'``
+        num_harmonics:  Number of harmonic components to compute
+                       (before mask applied)
+        fmin:       Lower bound for tune
+        fmax:       Upper bound for tune
+        hann:       Turn on Hanning window. Default: :py:obj:`False`
+
+    Returns:
+        q0 (ndarray): qx, qy from horizontal and vertical amplitude scans.
+                      Fit results with shape (2, 2)
+        q1 (ndarray): Amplitude detuning coefficients with shape (2, 2)
+                      ``[[dQx/dx, dQy/dx], [dQx/dy, dQy/dy]]``
+        x (ndarray): x amplitudes (npoints, )
+        q_dx (ndarray): qx, qy tunes as a function of x amplitude (npoints, 2)
+        y (ndarray): y amplitudes (npoints, )
+        q_dy (ndarray): qx, qy tunes as a function of y amplitude (npoints, 2)
+    """
+    lindata0, _, _ = linopt6(ring)
+    gamma = (1 + lindata0.alpha * lindata0.alpha) / lindata0.beta
+
+    x = numpy.linspace(-xm, xm, npoints)
+    y = numpy.linspace(-ym, ym, npoints)
+    x2 = x * x
+    y2 = y * y
+
+    q_dx = tunes_vs_amp(ring, amp=x, dim=0, nturns=nturns, **kwargs)
+    q_dy = tunes_vs_amp(ring, amp=y, dim=2, nturns=nturns, **kwargs)
+
+    idx = numpy.isfinite(q_dx[:, 0]) & numpy.isfinite(q_dx[:, 1])
+    idy = numpy.isfinite(q_dy[:, 0]) & numpy.isfinite(q_dy[:, 1])
+
+    fx = numpy.polyfit(x2[idx], q_dx[idx], 1)
+    fy = numpy.polyfit(y2[idy], q_dy[idy], 1)
+
+    q0 = [[fx[1, 0], fx[1, 1]], [fy[1, 0], fy[1, 1]]]
+    q1 = [
+        [2 * fx[0, 0] / gamma[0], 2 * fx[0, 1] / gamma[0]],
+        [2 * fy[0, 0] / gamma[1], 2 * fy[0, 1] / gamma[1]],
+    ]
+
+    return numpy.array(q0), numpy.array(q1), x, q_dx, y, q_dy
+
+
+def chromaticity(
+    ring: Lattice,
+    method: Optional[str] = "linopt",
+    dpm: Optional[float] = 0.02,
+    npoints: Optional[int] = 11,
+    order: Optional[int] = 3,
+    dp: Optional[float] = 0,
+    **kwargs,
+):
+    r"""Computes the non-linear chromaticities
+
+    This function computes the tunes for the specified momentum offsets.
+    Then it fits this data and returns the chromaticity up to the given
+    order (npoints>order)
+
+    Parameters:
+        ring:       Lattice description
+        method:     ``'linopt'`` (dfault) returns the tunes from the
+          :py:func:`linopt6` function,
+
+          ``'fft'`` tracks a single particle and computes the tunes with fft,
+
+          ``'laskar'`` tracks a single particle and computes the tunes with
+          NAFF.
+        dpm:        Maximum momentum deviation
+        npoints:    Number of momentum deviations
+        order:      Order of the fit
+        dp:         Central momentum deviation
+
+    Returns:
+        fit (ndarray): Horizontal Vertical polynomial coefficients
+                       from ``numpy.polyfit`` of shape (2, order+1)
+        dpa: dp array of shape (npoints,)
+        qz: tune array of shape (npoints, 2)
+    """
+    if order == 0:
+        return get_chrom(ring, dp=dp, **kwargs)
+    elif order > npoints - 1:
+        raise ValueError("order should be smaller than npoints-1")
+    else:
+        dpa = numpy.linspace(-dpm, dpm, npoints)
+        qz = []
+        for dpi in dpa:
+            qz.append(
+                get_tune(ring, method=method, dp=dp + dpi, remove_dc=True, **kwargs)
+            )
+        fit = numpy.polyfit(dpa, qz, order)[::-1]
+        fitx = fit[:, 0] / factorial(numpy.arange(order + 1))
+        fity = fit[:, 1] / factorial(numpy.arange(order + 1))
+        return numpy.array([fitx, fity]), dpa, numpy.array(qz)
+
+
+def gen_detuning_elem(ring: Lattice, orbit: Optional[Orbit] = None) -> Element:
+    """Generates a detuning element
+
+    Parameters:
+        ring:           Lattice description
+        orbit:          Avoids looking for initial the closed orbit if it is
+          already known ((6,) array).
+
+    Returns:
+        detuneElem:     Element reproducing the detuning of the ring with
+          amplitude and momentum
+    """
+    if orbit is None:
+        orbit, _ = find_orbit(ring)
+    lindata0, _, _ = ring.linopt6(get_chrom=False, orbit=orbit)
+    xsi = get_chrom(ring.radiation_off(copy=True))
+    r0, r1, x, q_dx, y, q_dy = detuning(
+        ring.radiation_off(copy=True), xm=1.0e-4, ym=1.0e-4, npoints=3
+    )
+    nonlin_elem = Element(
+        "NonLinear",
+        PassMethod="DeltaQPass",
+        Betax=lindata0.beta[0],
+        Betay=lindata0.beta[1],
+        Alphax=lindata0.alpha[0],
+        Alphay=lindata0.alpha[1],
+        Qpx=xsi[0],
+        Qpy=xsi[1],
+        A1=r1[0][0],
+        A2=r1[0][1],
+        A3=r1[1][1],
+        T1=-orbit,
+        T2=orbit,
+    )
+    return nonlin_elem
+
+
+def feeddown_polynomba(
+    polb: numpy.ndarray or tuple = (),
+    pola: numpy.ndarray or tuple = (),
+    xoffset: float = 0,
+    yoffset: float = 0,
+    verbose: bool = False,
+    debug: bool = False,
+) -> dict[str, numpy.ndarray]:
+    """
+    Return the feeddown due to a transverse offset.
+
+    Parameters:
+        polb: numpy array. PolynomB.
+        pola: numpy array. PolynomA.
+        xoffset: float. Default zero. Horizontal offset in meters.
+        yoffset: float. Default zero. Vertical offset in meters.
+        verbose: prints additional info.
+        debug: prints information about the feeddown polynom construction.
+
+    Returns:
+        Dictionary with PolynomB and PolynomA feeddown components.
+
+    Raises:
+        ValueError: if none of the two polynoms is passed.
+
+    Note:
+        If only one polynom is passed, it is assumed to be PolynomB.
+    """
+    # check debug and verbose flags only once
+    debugprint = print if debug else lambda *a, **k: None
+    verboseprint = print if verbose else lambda *a, **k: None
+
+    # verify polynoms length
+    maxorda = len(pola)
+    maxordb = len(polb)
+    if maxorda == 0 and maxordb == 0:
+        raise ValueError("At least one polynom is needed")
+    maxord = max(maxorda, maxordb)
+    debugprint(f"maxord={maxord},maxorda={maxorda},maxordb={maxordb}")
+
+    debugprint("Padding polynoms")
+    polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))
+    polapad = numpy.pad(pola, (0, maxord - maxorda), "constant", constant_values=(0, 0))
+    debugprint(f"polbpad={polbpad}, polapad={polapad}")
+
+    verboseprint(f"polb={polb},pola={pola}")
+    verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
+    polasum = numpy.zeros(maxord - 1)
+    polbsum = numpy.zeros(maxord - 1)
+    debugprint("ith=1, first order nothing to do")
+    for ith in range(2, maxord + 1):
+        polbaux_b, polaaux_b = feeddown_from_nth_order(
+            ith, polbpad[ith - 1], xoffset, yoffset, poltype="B"
+        )
+        polbaux_a, polaaux_a = feeddown_from_nth_order(
+            ith, polapad[ith - 1], xoffset, yoffset, poltype="A"
+        )
+        polbshort = polbaux_b + polbaux_a
+        polashort = polaaux_b + polaaux_a
+        polbsum = polbsum + numpy.pad(
+            polbshort, (0, maxord - ith), "constant", constant_values=(0, 0)
+        )
+        polasum = polasum + numpy.pad(
+            polashort, (0, maxord - ith), "constant", constant_values=(0, 0)
+        )
+        debugprint(f"ith={ith},polbsum={polbsum},polasum={polasum}")
+    poldict = {"PolynomB": polbsum, "PolynomA": polasum}
+    verboseprint(f"poldict={poldict}")
+    return poldict
+
+
+def feeddown_from_nth_order(
+    nthorder: int,
+    nthpolcomp: float,
+    xoffset: float,
+    yoffset: float,
+    poltype: str = "B",
+    debug: bool = False,
+    verbose: bool = False,
+) -> tuple[numpy.ndarray, numpy.ndarray]:
+    """
+    Return the feeddown polynoms from an nth-order magnet component transverse offset.
+
+    Parameters:
+        nthorder: integer order of the magnet component, e.g. 1 for dipole,
+            2 for quadrupoles, 3 for sextupoles, etc.
+        nthpolcomp: float. nth component of the polynom, i.e. the value of
+            PolynomA/B[nthorder-1].
+        xoffset: float. Horizontal offset in meters.
+        yoffset: float. Vertical offset in meters.
+        poltype: Default 'B'. Could be 'B' or 'A', otherwise ignored.
+        debug: print info on the feeddown polynom construction.
+        verbose: print info on input and output parameters.
+
+    Returns:
+        Tuple of two numpy arrays with PolynomB and PolynomA from feeddown.
+    """
+    # print debugging output, equivalent to extra verbose
+    debugprint = print if debug else lambda *a, **k: None
+    verboseprint = print if verbose else lambda *a, **k: None
+    verboseprint(f"nthorder={nthorder},nthpolcomp={nthpolcomp},poltype={poltype}")
+    verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
+    fakeimag = {0: 1, 1: 0, 2: -1, 3: 0}
+    polbaux = numpy.zeros(nthorder - 1)
+    polaaux = numpy.zeros(nthorder - 1)
+    for kterm in range(1, nthorder):
+        debugprint(f"nthorder={nthorder}, kterm={kterm}, nthpolcomp={nthpolcomp}")
+        ichoosek = comb(nthorder - 1, kterm)
+        debugprint(f"ichoosek={ichoosek}")
+        pascalsn = comb(kterm, numpy.arange(kterm + 1))
+        debugprint(f"pascalsn={pascalsn}")
+        powk = numpy.arange(kterm + 1)
+        powkflip = numpy.arange(kterm, -1, -1)
+        debugprint(f"powk={powk}")
+        debugprint(f"powkflip={powkflip}")
+        recoefs = numpy.array([fakeimag[numpy.mod(idx, 4)] for idx in powk])
+        imcoefs = numpy.array([fakeimag[numpy.mod(idx + 3, 4)] for idx in powk])
+        debugprint(f"recoefs={recoefs}, imcoefs={imcoefs}")
+        commonfactor = nthpolcomp * ichoosek * (-1) ** kterm
+        debugprint(f"commonfactor={commonfactor}")
+        repart = (
+            recoefs
+            * commonfactor
+            * (pascalsn * (xoffset**powkflip * yoffset**powk))
+        )
+        impart = (
+            imcoefs
+            * commonfactor
+            * (pascalsn * (xoffset**powkflip * yoffset**powk))
+        )
+        debugprint(f"repart={repart}")
+        debugprint(f"impart={impart}")
+        polbaux[nthorder - kterm - 1] = polbaux[nthorder - kterm - 1] + repart.sum()
+        polaaux[nthorder - kterm - 1] = polaaux[nthorder - kterm - 1] + impart.sum()
+    verboseprint(f"polbaux={polbaux},polaaux={polaaux}")
+    polbout, polaout = polbaux, polaaux
+    # skew components swap the imaginary and real feed-down and change the sign
+    # of the real part, i.e. j*j = -1
+    if poltype == "A":
+        polbout, polaout = -1 * polaaux, polbaux
+    return polbout, polaout

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -36,9 +36,6 @@ def feeddown_polynomba(
     Returns:
         Dictionary with PolynomB and PolynomA feeddown components.
 
-    Raises:
-        ValueError: if none of the two polynoms is passed.
-
     Note:
         If only one polynom is passed, it is assumed to be PolynomB.
     """
@@ -49,7 +46,8 @@ def feeddown_polynomba(
     maxorda = len(pola)
     maxordb = len(polb)
     if maxorda == 0 and maxordb == 0:
-        raise ValueError("At least one polynom is needed")
+        verboseprint("Both polynoms are zero.")
+        return numpy.array([])
     maxord = max(maxorda, maxordb)
 
     polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -46,6 +46,7 @@ def feeddown_pol_from_element(
         verboseprint(f"Element {ele.FamName} has no PolynomB")
     if hasattr(ele, "PolynomA"):
         pola = ele.PolynomA
+    else:
         verboseprint(f"Element {ele.FamName} has no PolynomA")
 
     # check if user has set offsets

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -32,7 +32,6 @@ def feeddown_polynomba(
         xoffset: Default zero. Horizontal offset in meters.
         yoffset: Default zero. Vertical offset in meters.
         verbose: prints additional info.
-        debug: prints information about the feeddown polynom construction.
 
     Returns:
         Dictionary with PolynomB and PolynomA feeddown components.
@@ -43,8 +42,7 @@ def feeddown_polynomba(
     Note:
         If only one polynom is passed, it is assumed to be PolynomB.
     """
-    # check debug and verbose flags only once
-    debugprint = print if debug else lambda *a, **k: None
+    # check and verbose flags only once
     verboseprint = print if verbose else lambda *a, **k: None
 
     # verify polynoms length
@@ -53,18 +51,14 @@ def feeddown_polynomba(
     if maxorda == 0 and maxordb == 0:
         raise ValueError("At least one polynom is needed")
     maxord = max(maxorda, maxordb)
-    debugprint(f"maxord={maxord},maxorda={maxorda},maxordb={maxordb}")
 
-    debugprint("Padding polynoms")
     polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))
     polapad = numpy.pad(pola, (0, maxord - maxorda), "constant", constant_values=(0, 0))
-    debugprint(f"polbpad={polbpad}, polapad={polapad}")
 
     verboseprint(f"polb={polb},pola={pola}")
     verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
     polasum = numpy.zeros(maxord - 1)
     polbsum = numpy.zeros(maxord - 1)
-    debugprint("ith=1, first order nothing to do")
     for ith in range(2, maxord + 1):
         polbaux_b, polaaux_b = feeddown_from_nth_order(
             ith, polbpad[ith - 1], xoffset, yoffset, poltype="B"
@@ -80,7 +74,6 @@ def feeddown_polynomba(
         polasum = polasum + numpy.pad(
             polashort, (0, maxord - ith), "constant", constant_values=(0, 0)
         )
-        debugprint(f"ith={ith},polbsum={polbsum},polasum={polasum}")
     poldict = {"PolynomB": polbsum, "PolynomA": polasum}
     verboseprint(f"poldict={poldict}")
     return poldict

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -1,5 +1,5 @@
 """
-Non-linear optics
+Magnet tools
 """
 
 from __future__ import annotations
@@ -85,7 +85,6 @@ def feeddown_from_nth_order(
     xoffset: float,
     yoffset: float,
     poltype: str = "B",
-    debug: bool = False,
     verbose: bool = False,
 ) -> tuple[numpy.ndarray, numpy.ndarray]:
     """
@@ -99,14 +98,11 @@ def feeddown_from_nth_order(
         xoffset: float. Horizontal offset in meters.
         yoffset: float. Vertical offset in meters.
         poltype: Default 'B'. Could be 'B' or 'A', otherwise ignored.
-        debug: print info on the feeddown polynom construction.
         verbose: print info on input and output parameters.
 
     Returns:
         Tuple of two numpy arrays with PolynomB and PolynomA from feeddown.
     """
-    # print debugging output, equivalent to extra verbose
-    debugprint = print if debug else lambda *a, **k: None
     verboseprint = print if verbose else lambda *a, **k: None
     verboseprint(f"nthorder={nthorder},nthpolcomp={nthpolcomp},poltype={poltype}")
     verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
@@ -114,20 +110,13 @@ def feeddown_from_nth_order(
     polbaux = numpy.zeros(nthorder - 1)
     polaaux = numpy.zeros(nthorder - 1)
     for kterm in range(1, nthorder):
-        debugprint(f"nthorder={nthorder}, kterm={kterm}, nthpolcomp={nthpolcomp}")
         ichoosek = comb(nthorder - 1, kterm)
-        debugprint(f"ichoosek={ichoosek}")
         pascalsn = comb(kterm, numpy.arange(kterm + 1))
-        debugprint(f"pascalsn={pascalsn}")
         powk = numpy.arange(kterm + 1)
         powkflip = numpy.arange(kterm, -1, -1)
-        debugprint(f"powk={powk}")
-        debugprint(f"powkflip={powkflip}")
         recoefs = numpy.array([fakeimag[numpy.mod(idx, 4)] for idx in powk])
         imcoefs = numpy.array([fakeimag[numpy.mod(idx + 3, 4)] for idx in powk])
-        debugprint(f"recoefs={recoefs}, imcoefs={imcoefs}")
         commonfactor = nthpolcomp * ichoosek * (-1) ** kterm
-        debugprint(f"commonfactor={commonfactor}")
         repart = (
             recoefs
             * commonfactor
@@ -138,8 +127,6 @@ def feeddown_from_nth_order(
             * commonfactor
             * (pascalsn * (xoffset**powkflip * yoffset**powk))
         )
-        debugprint(f"repart={repart}")
-        debugprint(f"impart={impart}")
         polbaux[nthorder - kterm - 1] = polbaux[nthorder - kterm - 1] + repart.sum()
         polaaux[nthorder - kterm - 1] = polaaux[nthorder - kterm - 1] + impart.sum()
     verboseprint(f"polbaux={polbaux},polaaux={polaaux}")

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -7,258 +7,17 @@ from __future__ import annotations
 from typing import Optional, Sequence
 
 import numpy
-from scipy.special import comb, factorial
-
-from ..lattice import Element, Lattice
-from ..tracking import internal_lpass
-from .harmonic_analysis import get_tunes_harmonic
-from .linear import get_chrom, get_tune, linopt6
-from .orbit import Orbit, find_orbit
+from scipy.special import comb
 
 __all__ = [
-    "detuning",
-    "chromaticity",
-    "gen_detuning_elem",
-    "tunes_vs_amp",
     "feeddown_polynomba",
     "feeddown_from_nth_order",
 ]
 
 
-def tunes_vs_amp(
-    ring: Lattice,
-    amp: Optional[Sequence[float]] = None,
-    dim: Optional[int] = 0,
-    nturns: Optional[int] = 512,
-    **kwargs,
-) -> numpy.ndarray:
-    r"""Generates a range of tunes for varying x, y, or z amplitudes
-
-    Parameters:
-        ring:               Lattice description
-        amp:                Oscillation amplitude. If amp is None the
-                            tunes are calculated from :py:func:`.linopt6`
-                            else tracking is used
-        dim:                Coordinate index of the oscillation
-        nturns:             Number of turns
-        method:             ``'laskar'`` or ``'fft'``. Default: ``'laskar'``
-        num_harmonics:      Number of harmonic components to compute (before
-                            mask applied)
-        fmin:               Lower bound for tune
-        fmax:               Upper bound for tune
-        hann:               Turn on Hanning window. Default: :py:obj:`False`
-
-    Returns:
-        tunes (ndarray):    Array of tunes qx, qy with shape (len(amp), 2)
-    """
-
-    def _gen_part(ring, amp, dim, orbit, ld, nturns):
-        invx = numpy.array(
-            [
-                [1 / numpy.sqrt(ld["beta"][0]), 0],
-                [ld["alpha"][0] / numpy.sqrt(ld["beta"][0]), numpy.sqrt(ld["beta"][0])],
-            ]
-        )
-
-        invy = numpy.array(
-            [
-                [1 / numpy.sqrt(ld["beta"][1]), 0],
-                [ld["alpha"][1] / numpy.sqrt(ld["beta"][1]), numpy.sqrt(ld["beta"][1])],
-            ]
-        )
-        part = (
-            numpy.array(
-                [
-                    orbit,
-                ]
-                * len(amp)
-            ).T
-            + 1.0e-6
-        )
-        part[dim, :] += amp
-        part = internal_lpass(ring, part, nturns=nturns)
-        sh = part.shape
-        partx = numpy.reshape(part[0, :], (sh[1], sh[3]))
-        partxp = numpy.reshape(part[1, :], (sh[1], sh[3]))
-        party = numpy.reshape(part[2, :], (sh[1], sh[3]))
-        partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
-        px = numpy.array(
-            [numpy.matmul(invx, [partx[i], partxp[i]]) for i in range(len(amp))]
-        )
-        py = numpy.array(
-            [numpy.matmul(invy, [party[i], partyp[i]]) for i in range(len(amp))]
-        )
-        return px[:, 0, :] - 1j * px[:, 1, :], py[:, 0, :] - 1j * py[:, 1, :]
-
-    l0, bd, _ = linopt6(ring)
-    orbit = l0["closed_orbit"]
-    tunes = bd["tune"]
-
-    if amp is not None:
-        partx, party = _gen_part(ring, amp, dim, orbit, l0, nturns)
-        qx = get_tunes_harmonic(partx, **kwargs)
-        qy = get_tunes_harmonic(party, **kwargs)
-        tunes = numpy.vstack((qx, qy)).T
-
-    return numpy.array(tunes)
-
-
-def detuning(
-    ring: Lattice,
-    xm: Optional[float] = 0.3e-4,
-    ym: Optional[float] = 0.3e-4,
-    npoints: Optional[int] = 3,
-    nturns: Optional[int] = 512,
-    **kwargs,
-):
-    """Computes the tunes for a sequence of amplitudes
-
-    This function uses :py:func:`tunes_vs_amp` to compute the tunes for
-    the specified amplitudes. Then it fits this data and returns
-    the detuning coefficiant dQx/dx, dQy/dx, dQx/dy, dQy/dy and the
-    qx, qy arrays versus x, y arrays
-
-    Parameters:
-        ring:       Lattice description
-        xm:         Maximum x amplitude
-        ym:         Maximum y amplitude
-        npoints:    Number of points in each plane
-        nturns:     Number of turns for tracking
-        method:     ``'laskar'`` or ``'fft'``. Default: ``'laskar'``
-        num_harmonics:  Number of harmonic components to compute
-                       (before mask applied)
-        fmin:       Lower bound for tune
-        fmax:       Upper bound for tune
-        hann:       Turn on Hanning window. Default: :py:obj:`False`
-
-    Returns:
-        q0 (ndarray): qx, qy from horizontal and vertical amplitude scans.
-                      Fit results with shape (2, 2)
-        q1 (ndarray): Amplitude detuning coefficients with shape (2, 2)
-                      ``[[dQx/dx, dQy/dx], [dQx/dy, dQy/dy]]``
-        x (ndarray): x amplitudes (npoints, )
-        q_dx (ndarray): qx, qy tunes as a function of x amplitude (npoints, 2)
-        y (ndarray): y amplitudes (npoints, )
-        q_dy (ndarray): qx, qy tunes as a function of y amplitude (npoints, 2)
-    """
-    lindata0, _, _ = linopt6(ring)
-    gamma = (1 + lindata0.alpha * lindata0.alpha) / lindata0.beta
-
-    x = numpy.linspace(-xm, xm, npoints)
-    y = numpy.linspace(-ym, ym, npoints)
-    x2 = x * x
-    y2 = y * y
-
-    q_dx = tunes_vs_amp(ring, amp=x, dim=0, nturns=nturns, **kwargs)
-    q_dy = tunes_vs_amp(ring, amp=y, dim=2, nturns=nturns, **kwargs)
-
-    idx = numpy.isfinite(q_dx[:, 0]) & numpy.isfinite(q_dx[:, 1])
-    idy = numpy.isfinite(q_dy[:, 0]) & numpy.isfinite(q_dy[:, 1])
-
-    fx = numpy.polyfit(x2[idx], q_dx[idx], 1)
-    fy = numpy.polyfit(y2[idy], q_dy[idy], 1)
-
-    q0 = [[fx[1, 0], fx[1, 1]], [fy[1, 0], fy[1, 1]]]
-    q1 = [
-        [2 * fx[0, 0] / gamma[0], 2 * fx[0, 1] / gamma[0]],
-        [2 * fy[0, 0] / gamma[1], 2 * fy[0, 1] / gamma[1]],
-    ]
-
-    return numpy.array(q0), numpy.array(q1), x, q_dx, y, q_dy
-
-
-def chromaticity(
-    ring: Lattice,
-    method: Optional[str] = "linopt",
-    dpm: Optional[float] = 0.02,
-    npoints: Optional[int] = 11,
-    order: Optional[int] = 3,
-    dp: Optional[float] = 0,
-    **kwargs,
-):
-    r"""Computes the non-linear chromaticities
-
-    This function computes the tunes for the specified momentum offsets.
-    Then it fits this data and returns the chromaticity up to the given
-    order (npoints>order)
-
-    Parameters:
-        ring:       Lattice description
-        method:     ``'linopt'`` (dfault) returns the tunes from the
-          :py:func:`linopt6` function,
-
-          ``'fft'`` tracks a single particle and computes the tunes with fft,
-
-          ``'laskar'`` tracks a single particle and computes the tunes with
-          NAFF.
-        dpm:        Maximum momentum deviation
-        npoints:    Number of momentum deviations
-        order:      Order of the fit
-        dp:         Central momentum deviation
-
-    Returns:
-        fit (ndarray): Horizontal Vertical polynomial coefficients
-                       from ``numpy.polyfit`` of shape (2, order+1)
-        dpa: dp array of shape (npoints,)
-        qz: tune array of shape (npoints, 2)
-    """
-    if order == 0:
-        return get_chrom(ring, dp=dp, **kwargs)
-    elif order > npoints - 1:
-        raise ValueError("order should be smaller than npoints-1")
-    else:
-        dpa = numpy.linspace(-dpm, dpm, npoints)
-        qz = []
-        for dpi in dpa:
-            qz.append(
-                get_tune(ring, method=method, dp=dp + dpi, remove_dc=True, **kwargs)
-            )
-        fit = numpy.polyfit(dpa, qz, order)[::-1]
-        fitx = fit[:, 0] / factorial(numpy.arange(order + 1))
-        fity = fit[:, 1] / factorial(numpy.arange(order + 1))
-        return numpy.array([fitx, fity]), dpa, numpy.array(qz)
-
-
-def gen_detuning_elem(ring: Lattice, orbit: Optional[Orbit] = None) -> Element:
-    """Generates a detuning element
-
-    Parameters:
-        ring:           Lattice description
-        orbit:          Avoids looking for initial the closed orbit if it is
-          already known ((6,) array).
-
-    Returns:
-        detuneElem:     Element reproducing the detuning of the ring with
-          amplitude and momentum
-    """
-    if orbit is None:
-        orbit, _ = find_orbit(ring)
-    lindata0, _, _ = ring.linopt6(get_chrom=False, orbit=orbit)
-    xsi = get_chrom(ring.radiation_off(copy=True))
-    r0, r1, x, q_dx, y, q_dy = detuning(
-        ring.radiation_off(copy=True), xm=1.0e-4, ym=1.0e-4, npoints=3
-    )
-    nonlin_elem = Element(
-        "NonLinear",
-        PassMethod="DeltaQPass",
-        Betax=lindata0.beta[0],
-        Betay=lindata0.beta[1],
-        Alphax=lindata0.alpha[0],
-        Alphay=lindata0.alpha[1],
-        Qpx=xsi[0],
-        Qpy=xsi[1],
-        A1=r1[0][0],
-        A2=r1[0][1],
-        A3=r1[1][1],
-        T1=-orbit,
-        T2=orbit,
-    )
-    return nonlin_elem
-
-
 def feeddown_polynomba(
-    polb: numpy.ndarray or tuple = (),
-    pola: numpy.ndarray or tuple = (),
+    polb: Sequence[float],
+    pola: Sequence[float],
     xoffset: float = 0,
     yoffset: float = 0,
     verbose: bool = False,
@@ -268,10 +27,10 @@ def feeddown_polynomba(
     Return the feeddown due to a transverse offset.
 
     Parameters:
-        polb: numpy array. PolynomB.
-        pola: numpy array. PolynomA.
-        xoffset: float. Default zero. Horizontal offset in meters.
-        yoffset: float. Default zero. Vertical offset in meters.
+        polb: PolynomB.
+        pola: PolynomA.
+        xoffset: Default zero. Horizontal offset in meters.
+        yoffset: Default zero. Vertical offset in meters.
         verbose: prints additional info.
         debug: prints information about the feeddown polynom construction.
 

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -46,13 +46,17 @@ def feeddown_polynomba(
     maxorda = len(pola)
     maxordb = len(polb)
     maxord = max(maxorda, maxordb)
-    polasum = numpy.zeros(max(0,maxord - 1))
-    polbsum = numpy.zeros(max(0,maxord - 1))
+    polasum = numpy.zeros(max(0, maxord - 1))
+    polbsum = numpy.zeros(max(0, maxord - 1))
     if maxorda == 0 and maxordb == 0:
         verboseprint("Both polynoms are zero.")
     else:
-        polbpad = numpy.pad(polb, (0, maxord - maxordb), "constant", constant_values=(0, 0))
-        polapad = numpy.pad(pola, (0, maxord - maxorda), "constant", constant_values=(0, 0))
+        polbpad = numpy.pad(
+            polb, (0, maxord - maxordb), "constant", constant_values=(0, 0)
+        )
+        polapad = numpy.pad(
+            pola, (0, maxord - maxorda), "constant", constant_values=(0, 0)
+        )
 
         verboseprint(f"polb={polb},pola={pola}")
         verboseprint(f"xoffset={xoffset},yoffset={yoffset}")

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -1,10 +1,8 @@
-"""
-Magnet tools
-"""
+"""Magnet tools."""
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Sequence
 
 import numpy
 from scipy.special import comb
@@ -21,7 +19,6 @@ def feeddown_polynomba(
     xoffset: float = 0,
     yoffset: float = 0,
     verbose: bool = False,
-    debug: bool = False,
 ) -> dict[str, numpy.ndarray]:
     """
     Return the feeddown due to a transverse offset.

--- a/pyat/at/physics/magnet_tools.py
+++ b/pyat/at/physics/magnet_tools.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def feeddown_pol_from_element(ele):
+def feeddown_pol_from_element(ele,verbose: bool=False):
     """
     Return the feed down polynoms due to a transverse offset on an element.
 

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -1,6 +1,9 @@
 """
 Non-linear optics
 """
+
+from __future__ import annotations
+
 from typing import Optional, Sequence
 
 import numpy
@@ -256,8 +259,8 @@ def gen_detuning_elem(ring: Lattice, orbit: Optional[Orbit] = None) -> Element:
 def feeddown_polynomba(
     polb: numpy.ndarray = numpy.zeros(0),
     pola: numpy.ndarray = numpy.zeros(0),
-    x0: float = 0,
-    y0: float = 0,
+    xoffset: float = 0,
+    yoffset: float = 0,
     verbose=False,
     debug=False,
 ) -> dict[str, numpy.ndarray]:
@@ -283,16 +286,16 @@ def feeddown_polynomba(
     debugprint(f"polbpad={polbpad}, polapad={polapad}")
 
     verboseprint(f"polb={polb},pola={pola}")
-    verboseprint(f"x0={x0},y0={y0}")
+    verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
     polasum = numpy.zeros(maxord - 1)
     polbsum = numpy.zeros(maxord - 1)
     debugprint(f"ith=1, first order nothing to do")
     for ith in range(2, maxord + 1):
         polbaux_b, polaaux_b = feeddown_from_nth_order(
-            ith, polbpad[ith - 1], x0, y0, magtype="normal"
+            ith, polbpad[ith - 1], xoffset, yoffset, poltype="B"
         )
         polbaux_a, polaaux_a = feeddown_from_nth_order(
-            ith, polapad[ith - 1], x0, y0, magtype="skew"
+            ith, polapad[ith - 1], xoffset, yoffset, poltype="A"
         )
         polbshort = polbaux_b + polbaux_a
         polashort = polaaux_b + polaaux_a
@@ -310,46 +313,71 @@ def feeddown_polynomba(
 
 def feeddown_from_nth_order(
     nthorder: int,
-    nthfieldcomp: float,
-    x0: float,
-    y0: float,
-    magtype: str = "normal",
+    nthpolcomp: float,
+    xoffset: float,
+    yoffset: float,
+    poltype: str = "B",
     debug: bool = False,
-    verbose=False,
-):
+    verbose: bool = False,
+) -> tuple[numpy.ndarray, numpy.ndarray]:
+    """
+    Return the PolynomB and PolynomA from a magnet offset.
+
+    Parameters:
+        nthorder: integer order of the magnet component, e.g. 1 for dipole,
+            2 for quadrupoles, 3 for sextupoles, etc.
+        nthpolcomp: float. nth component of the polynom, i.e. the value of
+            PolynomA/B[nthorder-1]
+        xoffset: float. Horizontal offset
+        yoffset: float. Vertical offset.
+        poltype: Default 'B'. Could be 'B' or 'A', otherwise ignored.
+        debug: print info on the feeddown polynom construction.
+        verbose: print info on input and output parameters.
+
+    Returns:
+        Tuple of two numpy arrays with PolynomB and PolynomA from feeddown.
+    """
     # print debugging output, equivalent to extra verbose
     debugprint = print if debug else lambda *a, **k: None
     verboseprint = print if verbose else lambda *a, **k: None
-    verboseprint(f"nthorder={nthorder},nthfieldcomp={nthfieldcomp},magtype={magtype}")
-    verboseprint(f"x0={x0},y0={y0}")
+    verboseprint(f"nthorder={nthorder},nthpolcomp={nthpolcomp},poltype={poltype}")
+    verboseprint(f"xoffset={xoffset},yoffset={yoffset}")
     fakeimag = {0: 1, 1: 0, 2: -1, 3: 0}
     polbaux = numpy.zeros(nthorder - 1)
     polaaux = numpy.zeros(nthorder - 1)
-    for k in range(1, nthorder):
-        debugprint(f"nthorder={nthorder}, k={k}, nthfieldcomp={nthfieldcomp}")
-        ichoosek = comb(nthorder - 1, k)
+    for kterm in range(1, nthorder):
+        debugprint(f"nthorder={nthorder}, kterm={kterm}, nthpolcomp={nthpolcomp}")
+        ichoosek = comb(nthorder - 1, kterm)
         debugprint(f"ichoosek={ichoosek}")
-        pascalsn = comb(k, numpy.arange(k + 1))
+        pascalsn = comb(kterm, numpy.arange(kterm + 1))
         debugprint(f"pascalsn={pascalsn}")
-        powk = numpy.arange(k + 1)
-        powkflip = numpy.arange(k, -1, -1)
+        powk = numpy.arange(kterm + 1)
+        powkflip = numpy.arange(kterm, -1, -1)
         debugprint(f"powk={powk}")
         debugprint(f"powkflip={powkflip}")
-        recoefs = numpy.array(list(map(lambda x: fakeimag[x], numpy.mod(powk, 4))))
-        imcoefs = numpy.array(list(map(lambda x: fakeimag[x], numpy.mod(powk + 3, 4))))
+        recoefs = numpy.array([fakeimag[numpy.mod(idx, 4)] for idx in powk])
+        imcoefs = numpy.array([fakeimag[numpy.mod(idx + 3, 4)] for idx in powk])
         debugprint(f"recoefs={recoefs}, imcoefs={imcoefs}")
-        commonfactor = nthfieldcomp * ichoosek * (-1) ** k
+        commonfactor = nthpolcomp * ichoosek * (-1) ** kterm
         debugprint(f"commonfactor={commonfactor}")
-        repart = recoefs * commonfactor * (pascalsn * (x0**powkflip * y0**powk))
-        impart = imcoefs * commonfactor * (pascalsn * (x0**powkflip * y0**powk))
+        repart = (
+            recoefs
+            * commonfactor
+            * (pascalsn * (xoffset**powkflip * yoffset**powk))
+        )
+        impart = (
+            imcoefs
+            * commonfactor
+            * (pascalsn * (xoffset**powkflip * yoffset**powk))
+        )
         debugprint(f"repart={repart}")
         debugprint(f"impart={impart}")
-        polbaux[nthorder - k - 1] = polbaux[nthorder - k - 1] + repart.sum()
-        polaaux[nthorder - k - 1] = polaaux[nthorder - k - 1] + impart.sum()
+        polbaux[nthorder - kterm - 1] = polbaux[nthorder - kterm - 1] + repart.sum()
+        polaaux[nthorder - kterm - 1] = polaaux[nthorder - kterm - 1] + impart.sum()
     verboseprint(f"polbaux={polbaux},polaaux={polaaux}")
     polbout, polaout = polbaux, polaaux
     # skew components swap the imaginary and real feed-down and change the sign
     # of the real part, i.e. j*j = -1
-    if magtype == "skew":
+    if poltype == "A":
         polbout, polaout = -1 * polaaux, polbaux
     return polbout, polaout

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -334,7 +334,7 @@ def feeddown_from_nth_order(
     verbose: bool = False,
 ) -> tuple[numpy.ndarray, numpy.ndarray]:
     """
-    Return the PolynomB and PolynomA from a magnet transverse offset.
+    Return the feeddown polynoms from an nth-order magnet component transverse offset.
 
     Parameters:
         nthorder: integer order of the magnet component, e.g. 1 for dipole,

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -17,8 +17,8 @@ __all__ = [
     "chromaticity",
     "gen_detuning_elem",
     "tunes_vs_amp",
-    "feed_down_polynomba",
-    "feed_down_from_nth_ordera",
+    "feeddown_polynomba",
+    "feeddown_from_nth_ordera",
 ]
 
 
@@ -253,7 +253,7 @@ def gen_detuning_elem(ring: Lattice, orbit: Optional[Orbit] = None) -> Element:
     return nonlin_elem
 
 
-def feed_down_polynomba(
+def feeddown_polynomba(
     polb: numpy.ndarray = numpy.zeros(0),
     pola: numpy.ndarray = numpy.zeros(0),
     x0: float = 0,
@@ -288,10 +288,10 @@ def feed_down_polynomba(
     polbsum = numpy.zeros(maxord - 1)
     debugprint(f"ith=1, first order nothing to do")
     for ith in range(2, maxord + 1):
-        polbaux_b, polaaux_b = feed_down_from_nth_order(
+        polbaux_b, polaaux_b = feeddown_from_nth_order(
             ith, polbpad[ith - 1], x0, y0, magtype="normal"
         )
-        polbaux_a, polaaux_a = feed_down_from_nth_order(
+        polbaux_a, polaaux_a = feeddown_from_nth_order(
             ith, polapad[ith - 1], x0, y0, magtype="skew"
         )
         polbshort = polbaux_b + polbaux_a
@@ -308,7 +308,7 @@ def feed_down_polynomba(
     return poldict
 
 
-def feed_down_from_nth_order(
+def feeddown_from_nth_order(
     nthorder: int,
     nthfieldcomp: float,
     x0: float,

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -1,14 +1,16 @@
 """
 Non-linear optics
 """
-import numpy
 from typing import Optional, Sequence
-from scipy.special import factorial
+
+import numpy
+from scipy.special import comb, factorial
+
 from ..lattice import Element, Lattice
 from ..tracking import internal_lpass
-from .orbit import Orbit, find_orbit
-from .linear import get_tune, get_chrom, linopt6
 from .harmonic_analysis import get_tunes_harmonic
+from .linear import get_chrom, get_tune, linopt6
+from .orbit import Orbit, find_orbit
 
 __all__ = [
     "detuning",

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -279,7 +279,7 @@ def feeddown_polynomba(
         Dictionary with PolynomB and PolynomA feeddown components.
 
     Raises:
-        ValueError: if non of the two polynoms is passed.
+        ValueError: if none of the two polynoms is passed.
     """
     # check debug and verbose flags only once
     debugprint = print if debug else lambda *a, **k: None

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -10,12 +10,16 @@ from .orbit import Orbit, find_orbit
 from .linear import get_tune, get_chrom, linopt6
 from .harmonic_analysis import get_tunes_harmonic
 
-__all__ = ['detuning', 'chromaticity', 'gen_detuning_elem', 'tunes_vs_amp']
+__all__ = ["detuning", "chromaticity", "gen_detuning_elem", "tunes_vs_amp"]
 
 
-def tunes_vs_amp(ring: Lattice, amp: Optional[Sequence[float]] = None,
-                 dim: Optional[int] = 0, nturns: Optional[int] = 512,
-                 **kwargs) -> numpy.ndarray:
+def tunes_vs_amp(
+    ring: Lattice,
+    amp: Optional[Sequence[float]] = None,
+    dim: Optional[int] = 0,
+    nturns: Optional[int] = 512,
+    **kwargs,
+) -> numpy.ndarray:
     r"""Generates a range of tunes for varying x, y, or z amplitudes
 
     Parameters:
@@ -37,14 +41,28 @@ def tunes_vs_amp(ring: Lattice, amp: Optional[Sequence[float]] = None,
     """
 
     def _gen_part(ring, amp, dim, orbit, ld, nturns):
-        invx = numpy.array([[1/numpy.sqrt(ld['beta'][0]), 0],
-                            [ld['alpha'][0]/numpy.sqrt(ld['beta'][0]),
-                            numpy.sqrt(ld['beta'][0])]])
+        invx = numpy.array(
+            [
+                [1 / numpy.sqrt(ld["beta"][0]), 0],
+                [ld["alpha"][0] / numpy.sqrt(ld["beta"][0]), numpy.sqrt(ld["beta"][0])],
+            ]
+        )
 
-        invy = numpy.array([[1/numpy.sqrt(ld['beta'][1]), 0],
-                            [ld['alpha'][1]/numpy.sqrt(ld['beta'][1]),
-                            numpy.sqrt(ld['beta'][1])]])
-        part = numpy.array([orbit, ] * len(amp)).T + 1.0e-6
+        invy = numpy.array(
+            [
+                [1 / numpy.sqrt(ld["beta"][1]), 0],
+                [ld["alpha"][1] / numpy.sqrt(ld["beta"][1]), numpy.sqrt(ld["beta"][1])],
+            ]
+        )
+        part = (
+            numpy.array(
+                [
+                    orbit,
+                ]
+                * len(amp)
+            ).T
+            + 1.0e-6
+        )
         part[dim, :] += amp
         part = internal_lpass(ring, part, nturns=nturns)
         sh = part.shape
@@ -52,15 +70,17 @@ def tunes_vs_amp(ring: Lattice, amp: Optional[Sequence[float]] = None,
         partxp = numpy.reshape(part[1, :], (sh[1], sh[3]))
         party = numpy.reshape(part[2, :], (sh[1], sh[3]))
         partyp = numpy.reshape(part[3, :], (sh[1], sh[3]))
-        px = numpy.array([numpy.matmul(invx, [partx[i], partxp[i]])
-                          for i in range(len(amp))])
-        py = numpy.array([numpy.matmul(invy, [party[i], partyp[i]])
-                          for i in range(len(amp))])
-        return px[:, 0, :] - 1j*px[:, 1, :], py[:, 0, :] - 1j*py[:, 1, :]
+        px = numpy.array(
+            [numpy.matmul(invx, [partx[i], partxp[i]]) for i in range(len(amp))]
+        )
+        py = numpy.array(
+            [numpy.matmul(invy, [party[i], partyp[i]]) for i in range(len(amp))]
+        )
+        return px[:, 0, :] - 1j * px[:, 1, :], py[:, 0, :] - 1j * py[:, 1, :]
 
     l0, bd, _ = linopt6(ring)
-    orbit = l0['closed_orbit']
-    tunes = bd['tune']
+    orbit = l0["closed_orbit"]
+    tunes = bd["tune"]
 
     if amp is not None:
         partx, party = _gen_part(ring, amp, dim, orbit, l0, nturns)
@@ -71,10 +91,14 @@ def tunes_vs_amp(ring: Lattice, amp: Optional[Sequence[float]] = None,
     return numpy.array(tunes)
 
 
-def detuning(ring: Lattice,
-             xm: Optional[float] = 0.3e-4, ym: Optional[float] = 0.3e-4,
-             npoints: Optional[int] = 3,
-             nturns: Optional[int] = 512, **kwargs):
+def detuning(
+    ring: Lattice,
+    xm: Optional[float] = 0.3e-4,
+    ym: Optional[float] = 0.3e-4,
+    npoints: Optional[int] = 3,
+    nturns: Optional[int] = 512,
+    **kwargs,
+):
     """Computes the tunes for a sequence of amplitudes
 
     This function uses :py:func:`tunes_vs_amp` to compute the tunes for
@@ -122,19 +146,24 @@ def detuning(ring: Lattice,
     fx = numpy.polyfit(x2[idx], q_dx[idx], 1)
     fy = numpy.polyfit(y2[idy], q_dy[idy], 1)
 
-    q0 = [[fx[1, 0], fx[1, 1]],
-          [fy[1, 0], fy[1, 1]]]
-    q1 = [[2 * fx[0, 0] / gamma[0], 2 * fx[0, 1] / gamma[0]],
-          [2 * fy[0, 0] / gamma[1], 2 * fy[0, 1] / gamma[1]]]
+    q0 = [[fx[1, 0], fx[1, 1]], [fy[1, 0], fy[1, 1]]]
+    q1 = [
+        [2 * fx[0, 0] / gamma[0], 2 * fx[0, 1] / gamma[0]],
+        [2 * fy[0, 0] / gamma[1], 2 * fy[0, 1] / gamma[1]],
+    ]
 
     return numpy.array(q0), numpy.array(q1), x, q_dx, y, q_dy
 
 
-def chromaticity(ring: Lattice, method: Optional[str] = 'linopt',
-                 dpm: Optional[float] = 0.02, npoints: Optional[int] = 11,
-                 order: Optional[int] = 3,
-                 dp: Optional[float] = 0,
-                 **kwargs):
+def chromaticity(
+    ring: Lattice,
+    method: Optional[str] = "linopt",
+    dpm: Optional[float] = 0.02,
+    npoints: Optional[int] = 11,
+    order: Optional[int] = 3,
+    dp: Optional[float] = 0,
+    **kwargs,
+):
     r"""Computes the non-linear chromaticities
 
     This function computes the tunes for the specified momentum offsets.
@@ -164,16 +193,17 @@ def chromaticity(ring: Lattice, method: Optional[str] = 'linopt',
     if order == 0:
         return get_chrom(ring, dp=dp, **kwargs)
     elif order > npoints - 1:
-        raise ValueError('order should be smaller than npoints-1')
+        raise ValueError("order should be smaller than npoints-1")
     else:
         dpa = numpy.linspace(-dpm, dpm, npoints)
         qz = []
         for dpi in dpa:
-            qz.append(get_tune(ring, method=method, dp=dp+dpi, remove_dc=True,
-                      **kwargs))
+            qz.append(
+                get_tune(ring, method=method, dp=dp + dpi, remove_dc=True, **kwargs)
+            )
         fit = numpy.polyfit(dpa, qz, order)[::-1]
-        fitx = fit[:, 0]/factorial(numpy.arange(order + 1))
-        fity = fit[:, 1]/factorial(numpy.arange(order + 1))
+        fitx = fit[:, 0] / factorial(numpy.arange(order + 1))
+        fity = fit[:, 1] / factorial(numpy.arange(order + 1))
         return numpy.array([fitx, fity]), dpa, numpy.array(qz)
 
 
@@ -193,12 +223,22 @@ def gen_detuning_elem(ring: Lattice, orbit: Optional[Orbit] = None) -> Element:
         orbit, _ = find_orbit(ring)
     lindata0, _, _ = ring.linopt6(get_chrom=False, orbit=orbit)
     xsi = get_chrom(ring.radiation_off(copy=True))
-    r0, r1, x, q_dx, y, q_dy = detuning(ring.radiation_off(copy=True),
-                                        xm=1.0e-4, ym=1.0e-4, npoints=3)
-    nonlin_elem = Element('NonLinear', PassMethod='DeltaQPass',
-                          Betax=lindata0.beta[0], Betay=lindata0.beta[1],
-                          Alphax=lindata0.alpha[0], Alphay=lindata0.alpha[1],
-                          Qpx=xsi[0], Qpy=xsi[1],
-                          A1=r1[0][0], A2=r1[0][1], A3=r1[1][1],
-                          T1=-orbit, T2=orbit)
+    r0, r1, x, q_dx, y, q_dy = detuning(
+        ring.radiation_off(copy=True), xm=1.0e-4, ym=1.0e-4, npoints=3
+    )
+    nonlin_elem = Element(
+        "NonLinear",
+        PassMethod="DeltaQPass",
+        Betax=lindata0.beta[0],
+        Betay=lindata0.beta[1],
+        Alphax=lindata0.alpha[0],
+        Alphay=lindata0.alpha[1],
+        Qpx=xsi[0],
+        Qpy=xsi[1],
+        A1=r1[0][0],
+        A2=r1[0][1],
+        A3=r1[1][1],
+        T1=-orbit,
+        T2=orbit,
+    )
     return nonlin_elem

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -280,6 +280,9 @@ def feeddown_polynomba(
 
     Raises:
         ValueError: if none of the two polynoms is passed.
+
+    Note:
+        If only one polynom is passed, it is assumed to be PolynomB.
     """
     # check debug and verbose flags only once
     debugprint = print if debug else lambda *a, **k: None

--- a/pyat/at/physics/nonlinear.py
+++ b/pyat/at/physics/nonlinear.py
@@ -21,7 +21,7 @@ __all__ = [
     "gen_detuning_elem",
     "tunes_vs_amp",
     "feeddown_polynomba",
-    "feeddown_from_nth_ordera",
+    "feeddown_from_nth_order",
 ]
 
 


### PR DESCRIPTION
Dear all,

I have created a function in pyat that calculates the feeddown PolynomB and Polynom from a transverse offset on a magnet.
It requires to provide the polynom(s) of the magnet and the transverse offset. For example, a quadrupole with transverse offset of 1 mm in horizontal and 2 mm in vertical:
```python
>>> import numpy, at
>>> at.feeddown_polynomba(polb=numpy.array([0,10]),xoffset=1e-3,yoffset=2e-3)
{'PolynomB': array([-0.01]), 'PolynomA': array([-0.02])}
```
