### PR TITLE
update AT matlab help default pass method in atthinmultipole

### DIFF
--- a/atmat/lattice/element_creation/atthinmultipole.m
+++ b/atmat/lattice/element_creation/atthinmultipole.m
@@ -4,10 +4,10 @@ function elem=atthinmultipole(fname,varargin)
 % ATTHINMULTIPOLE(FAMNAME,POLYNOMA,POLYNOMB,PASSMETHOD)
 %	
 %  INPUTS
-%	 1. FNAME        	family name 
+%	 1. FNAME           family name
 %	 2. POLYNOMA        skew [dipole quad sext oct];	 
 %	 3. POLYNOMB        normal [dipole quad sext oct]; 
-%	 4. PASSMETHOD      tracking function. Defaults to 'StrMPoleSymplectic4Pass'
+%	 4. PASSMETHOD      tracking function. Defaults to 'ThinMPolePass'
 %
 %  OPTIONS (order does not matter)
 %    R1				6 x 6 rotation matrix at the entrance


### PR DESCRIPTION
This PR updates the help info in AT matlab for the `atthinmultipole`  element.
The default PassMethod is now 'ThinMPolePass'.

This PR solves Issue #818 .