### PR TITLE
Fix wiggler radiation

### DIFF
--- a/atintegrators/gwigR.c
+++ b/atintegrators/gwigR.c
@@ -124,7 +124,6 @@ static void GWigPass_4th(struct gwigR *pWig, double *X)
   double dl, dl1, dl0;
   double B[3];
   double ax, ay, axpy, aypx;
-  double factorvect;
 
   Nstep = pWig->PN*(pWig->Nw);
   dl = pWig->Lw/(pWig->PN);
@@ -450,7 +449,7 @@ static void GWigB(struct gwigR *pWig, double *Xvec, double *B)
 {
   int    i;
   double x, y, z;
-  double kx, ky, kz, tz, kw;
+  double kx, ky, kz, tz;
   double cx, sx, chx, shx;
   double cy, sy, chy, shy;
   double cz, sz;
@@ -460,8 +459,6 @@ static void GWigB(struct gwigR *pWig, double *Xvec, double *B)
   x = Xvec[0];
   y = Xvec[2];
   z = pWig->Zw;
-
-  kw   = 2e0*PI/(pWig->Lw);
 
   B[0] = 0;
   B[1] = 0;
@@ -596,9 +593,9 @@ static void GWigRadiationKicks(struct gwigR *pWig, double *X, double *Bxy, doubl
 static void Hessian(struct gwigR *pWig, double *Xvec, double *H2)
 {
 	int i,j,k;
-	double x,px,y,py,D;
-	double ax,axx,axxx,axy,axyy,axxy;
-	double ay, ayx, ayxx, ayy, ayyy, ayxy;
+	double px, py,D;
+	double ax,axx,axxx,axy,axxy;
+	double ay, ayx, ayxx, ayy, ayxy;
 	double Pax[6];
 	double Pay[6];
 	double H[6][6];
@@ -610,19 +607,15 @@ static void Hessian(struct gwigR *pWig, double *Xvec, double *H2)
 	axx =Pax[1];
 	axxx=Pax[2];
 	axy =Pax[3];
-	axyy=Pax[4];
 	axxy=Pax[5];
 
 	ay  =Pay[0];
 	ayx =Pay[1];
 	ayxx=Pay[2];
 	ayy =Pay[3];
-	ayyy=Pay[4];
 	ayxy=Pay[5];
 
-	x =Xvec[0];
 	px=Xvec[1];
-	y =Xvec[2];
 	py=Xvec[3];
 	D =Xvec[4];
 

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -101,6 +101,7 @@ oldwarns=warning('OFF','MATLAB:mex:GccVersion_link');
 % Diffusion matrices
 cdir=fullfile(atroot,'atphysics','Radiation');
 compile([alloptions, {passinclude}], fullfile(cdir,'findmpoleraddiffmatrix.c'));
+compile([alloptions, {passinclude}], fullfile(cdir,'FDW.c'));
 
 % RDTs
 cdir=fullfile(atroot,'atphysics','NonLinearDynamics');

--- a/atmat/atphysics/Radiation/FDW.c
+++ b/atmat/atphysics/Radiation/FDW.c
@@ -23,12 +23,10 @@
  * Journal of Instrumentation, May 2021.
  */
 
-#include "atlalib.c"
 #include "atelem.c"
+#include "atlalib.c"
 #include "gwigR.c"
 #include <math.h>
-#include "mex.h"
-#include "matrix.h"
 #include "gwig.h"
 
 /* Fourth order-symplectic integrator constants */
@@ -121,13 +119,11 @@ static void wigglerB(struct gwigR *pWig, double* orbit_in, double L, double *B66
 	double Bxyz[3];
 	double p_norm = 1/(1+orbit_in[4]);
 	double p_norm2 = SQR(p_norm);
-	double x,px,y,py,D;
+	double px,py,D;
 	double DLDS;
   int i;
 
-	x = orbit_in[0];
 	px= orbit_in[1];
-	y = orbit_in[2];
 	py= orbit_in[3];
 	D = orbit_in[4];
 	GWigAx(pWig, orbit_in, &ax, &axpy);
@@ -204,7 +200,6 @@ static void FindElemB(double *orbit_in, double le, double Lw, double Bmax,
 	double ax,ay,axpy,aypx;
 	double B[3];
 	double E0G;
-	double factorvect;
   struct gwigR pWig;
   int flag;
 
@@ -327,7 +322,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	const mxArray *mxElem, *mxOrbit;
 	double *bdiff;
 	double orb[6];
-    double energy;
+    double energy = mxGetNaN(); /* Default energy value */
     int i, m, n;
 
 	if (nrhs < 2)
@@ -349,11 +344,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	    if (!(mxIsDouble(mxEnergy) && mxIsScalar(mxEnergy)))
 	        mexErrMsgIdAndTxt("AT:WrongArg", "Energy must be a double scalar");
 	    energy=mxGetScalar(mxEnergy);
-		}
+	}
 
-    else {
-        energy=mxGetNaN();
-    }
 	/* ALLOCATE memory for the output array */
 	plhs[0] = mxCreateDoubleMatrix(6,6,mxREAL);
 	bdiff = mxGetDoubles(plhs[0]);
@@ -374,7 +366,7 @@ static PyObject *compute_wiggdiffmatrix(PyObject *self, PyObject *args) {
     PyArrayObject *pyOrbit;
     double *orb0, *bdiff, *retval;
     double orb[6];
-    double energy;
+    double energy = NAN; /* Default energy value */
     npy_intp outdims[2] = {6, 6};
     int i;
 

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1301,17 +1301,16 @@ class Wiggler(Radiative, LongElement):
     See atwiggler.m
     """
 
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['Lw', 'Bmax',
-                                                         'Energy']
-    _conversions = dict(Element._conversions, Lw=float, Bmax=float,
-                        Energy=float,
+    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ['Lw', 'Bmax']
+    _conversions = dict(Element._conversions, Lw=_float, Bmax=_float,
+                        Energy=_float,
                         Bx=lambda v: _array(v, (6, -1)),
                         By=lambda v: _array(v, (6, -1)),
                         Nstep=int, Nmeth=int, NHharm=int, NVharm=int)
 
     # noinspection PyPep8Naming
     def __init__(self, family_name: str, length: float, wiggle_period: float,
-                 b_max: float, energy: float, Nstep: Optional[int] = 5,
+                 b_max: float, energy: float = 0.0, *, Nstep: Optional[int] = 5,
                  Nmeth: Optional[int] = 4,
                  By=(1, 1, 0, 1, 1, 0), Bx=(), **kwargs):
         """

--- a/pyat/at/physics/__init__.py
+++ b/pyat/at/physics/__init__.py
@@ -12,6 +12,7 @@ from .orbit import *
 from .matrix import *
 from .linear import *
 from .diffmatrix import find_mpole_raddiff_matrix
+from .wiggdiffmatrix import FDW
 from .radiation import *
 from .ring_parameters import *
 from .nonlinear import *

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -1,10 +1,18 @@
 """
 Radiation and equilibrium emittances
 """
+
 from __future__ import annotations
 
+__all__ = [
+    "ohmi_envelope",
+    "get_radiation_integrals",
+    "quantdiffmat",
+    "gen_quantdiff_elem",
+    "tapering",
+]
+
 from math import sin, cos, tan, sqrt, sinh, cosh, pi
-from typing import Union
 
 import numpy
 from scipy.linalg import inv, det, solve_sylvester
@@ -18,20 +26,19 @@ from at.physics import find_mpole_raddiff_matrix, FDW, get_tunes_damp
 from at.physics import find_orbit6, find_m66, find_elem_m66, Orbit
 from at.tracking import internal_lpass
 
-__all__ = ['ohmi_envelope', 'get_radiation_integrals', 'quantdiffmat',
-           'gen_quantdiff_elem', 'tapering']
-
 _NSTEP = 60  # nb slices in a wiggler period
 
 _submat = [slice(0, 2), slice(2, 4), slice(6, 3, -1)]
 
 # dtype for structured array containing optical parameters
-ENVELOPE_DTYPE = [('r66', numpy.float64, (6, 6)),
-                  ('r44', numpy.float64, (4, 4)),
-                  ('m66', numpy.float64, (6, 6)),
-                  ('orbit6', numpy.float64, (6,)),
-                  ('emitXY', numpy.float64, (2,)),
-                  ('emitXYZ', numpy.float64, (3,))]
+ENVELOPE_DTYPE = [
+    ("r66", numpy.float64, (6, 6)),
+    ("r44", numpy.float64, (4, 4)),
+    ("m66", numpy.float64, (6, 6)),
+    ("orbit6", numpy.float64, (6,)),
+    ("emitXY", numpy.float64, (2,)),
+    ("emitXYZ", numpy.float64, (3,)),
+]
 
 
 def _dmatr(ring: Lattice, orbit: Orbit = None, keep_lattice: bool = False):
@@ -50,7 +57,7 @@ def _dmatr(ring: Lattice, orbit: Orbit = None, keep_lattice: bool = False):
             yield cumul
 
     def diffusion_matrix(elem, orbit, energy):
-        if elem.PassMethod.endswith('RadPass'):
+        if elem.PassMethod.endswith("RadPass"):
             if hasattr(elem, "Bmax"):
                 return FDW(elem, orbit, energy)
             else:
@@ -65,8 +72,11 @@ def _dmatr(ring: Lattice, orbit: Orbit = None, keep_lattice: bool = False):
         keep_lattice = True
 
     orbs = numpy.squeeze(
-        internal_lpass(ring, orbit.copy(order='K'), refpts=All,
-                       keep_lattice=keep_lattice), axis=(1, 3)).T
+        internal_lpass(
+            ring, orbit.copy(order="K"), refpts=All, keep_lattice=keep_lattice
+        ),
+        axis=(1, 3),
+    ).T
     b0 = numpy.zeros((6, 6))
     bb = [diffusion_matrix(elem, elemorb, energy) for elem, elemorb in zip(ring, orbs)]
     bbcum = numpy.stack(list(_cumulb(zip(ring, orbs, bb))), axis=0)
@@ -91,8 +101,12 @@ def _lmat(dmat):
 
 
 @check_radiation(True)
-def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
-                  keep_lattice: bool = False):
+def ohmi_envelope(
+    ring: Lattice,
+    refpts: Refpts = None,
+    orbit: Orbit = None,
+    keep_lattice: bool = False,
+):
     """Calculates the equilibrium beam envelope
 
     Computation based on Ohmi's beam envelope formalism [1]_
@@ -148,9 +162,9 @@ def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
         # Prevent from unrealistic negative values of the determinant
         emit3 = numpy.sqrt(numpy.maximum(emit3sq, 0.0))
         # Emittance cut for dpp=0
-        if emit3[0] < 1.E-13:  # No equilibrium emittance
+        if emit3[0] < 1.0e-13:  # No equilibrium emittance
             r44 = numpy.nan * numpy.ones((4, 4))
-        elif emit3[1] < 1.E-13:  # Uncoupled machine
+        elif emit3[1] < 1.0e-13:  # Uncoupled machine
             minv = inv(r66[[0, 1, 4, 5], :][:, [0, 1, 4, 5]])
             r44 = numpy.zeros((4, 4))
             r44[:2, :2] = inv(minv[:2, :2])
@@ -158,8 +172,7 @@ def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
             minv = inv(r66)
             r44 = inv(minv[:4, :4])
         # betatron emittances (dpp=0)
-        emit2sq = numpy.array(
-            [det(r44[s, s], check_finite=False) for s in _submat[:2]])
+        emit2sq = numpy.array([det(r44[s, s], check_finite=False) for s in _submat[:2]])
         # Prevent from unrealistic negative values of the determinant
         emit2 = numpy.sqrt(numpy.maximum(emit2sq, 0.0))
         return r44, emit2, emit3
@@ -193,21 +206,23 @@ def ohmi_envelope(ring: Lattice, refpts: Refpts = None, orbit: Orbit = None,
     r66data = get_tunes_damp(mring, rr)
 
     data0 = numpy.rec.fromarrays(
-        (rr, rr4, mring, orbs[0], emitxy, emitxyz),
-        dtype=ENVELOPE_DTYPE)
+        (rr, rr4, mring, orbs[0], emitxy, emitxyz), dtype=ENVELOPE_DTYPE
+    )
     if uint32refs.shape == (0,):
         data = numpy.recarray((0,), dtype=ENVELOPE_DTYPE)
     else:
         data = numpy.rec.fromrecords(
             list(map(propag, ms, bbcum[uint32refs], orbs[uint32refs, :])),
-            dtype=ENVELOPE_DTYPE)
+            dtype=ENVELOPE_DTYPE,
+        )
 
     return data0, r66data, data
 
 
 @frequency_control
-def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
-        -> tuple[float, float, float, float, float]:
+def get_radiation_integrals(
+    ring, dp: float = None, twiss=None, **kwargs
+) -> tuple[float, float, float, float, float]:
     r"""Computes the 5 radiation integrals for uncoupled lattices.
 
     Parameters:
@@ -218,7 +233,7 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
     Keyword Args:
         dp (float):             Momentum deviation. Defaults to :py:obj:`None`
         dct (float):            Path lengthening. Defaults to :py:obj:`None`
-        df (float):             Deviation of RF frequency. Defaults to       
+        df (float):             Deviation of RF frequency. Defaults to
         method (Callable):  Method for linear optics:
 
           :py:obj:`~.linear.linopt2`: no longitudinal motion, no H/V coupling,
@@ -234,21 +249,21 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
         i5 (float): :math:`I_5 \quad [m^{-1}]`
     """
 
-    def element_radiation(elem: Union[Dipole, Quadrupole], vini, vend):
+    def element_radiation(elem: Dipole | Quadrupole, vini, vend):
         """Analytically compute the radiation integrals in dipoles"""
         beta0 = vini.beta[0]
         alpha0 = vini.alpha[0]
         eta0 = vini.dispersion[0]
         etap0 = vini.dispersion[1]
-        theta = getattr(elem, 'BendingAngle', None)
+        theta = getattr(elem, "BendingAngle", None)
         if theta is None:
-            xpi = vini.closed_orbit[1]/(1+vini.closed_orbit[4])
-            xpo = vend.closed_orbit[1]/(1+vend.closed_orbit[4])
-            theta = xpi-xpo
+            xpi = vini.closed_orbit[1] / (1 + vini.closed_orbit[4])
+            xpo = vend.closed_orbit[1] / (1 + vend.closed_orbit[4])
+            theta = xpi - xpo
         if abs(theta) < 1.0e-7:
             return numpy.zeros(5)
-        angin = getattr(elem, 'EntranceAngle', 0.0)
-        angout = getattr(elem, 'ExitAngle', 0.0)
+        angin = getattr(elem, "EntranceAngle", 0.0)
+        angout = getattr(elem, "ExitAngle", 0.0)
 
         ll = elem.Length
         rho = ll / theta
@@ -262,7 +277,7 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
         etap1 = etap0 + eta0 * eps1
         etap2 = vend.dispersion[1] - eta3 * eps2
 
-        h0 = gamma1*eta0*eta0 + 2.0*alpha1*eta0*etap1 + beta0*etap1*etap1
+        h0 = gamma1 * eta0 * eta0 + 2.0 * alpha1 * eta0 * etap1 + beta0 * etap1 * etap1
 
         if k2 != 0.0:
             if k2 > 0.0:  # Focusing
@@ -276,24 +291,37 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
             eta_ave = (theta - (etap2 - etap1)) / k2 / ll
             bb = 2.0 * (alpha1 * eta0 + beta0 * etap1) * rho
             aa = -2.0 * (alpha1 * etap1 + gamma1 * eta0) * rho
-            h_ave = h0 + (aa * (1.0 - ss) + bb * (1.0 - cc) / ll
-                          + gamma1 * (3.0 - 4.0 * ss + ss * cc) / 2.0 / k2
-                          - alpha1 * (1.0 - cc) ** 2 / k2 / ll
-                          + beta0 * (1.0 - ss * cc) / 2.0
-                          ) / k2 / rho2
+            h_ave = (
+                h0
+                + (
+                    aa * (1.0 - ss)
+                    + bb * (1.0 - cc) / ll
+                    + gamma1 * (3.0 - 4.0 * ss + ss * cc) / 2.0 / k2
+                    - alpha1 * (1.0 - cc) ** 2 / k2 / ll
+                    + beta0 * (1.0 - ss * cc) / 2.0
+                )
+                / k2
+                / rho2
+            )
         else:
             eta_ave = 0.5 * (eta0 + eta3) - ll * ll / 12.0 / rho
             hp0 = 2.0 * (alpha1 * eta0 + beta0 * etap1) / rho
             h2p0 = 2.0 * (-alpha1 * etap1 + beta0 / rho - gamma1 * eta0) / rho
-            h_ave = h0 + hp0 * ll / 2.0 + h2p0 * ll * ll / 6.0 \
-                - alpha1 * ll ** 3 / 4.0 / rho2 \
-                + gamma1 * ll ** 4 / 20.0 / rho2
+            h_ave = (
+                h0
+                + hp0 * ll / 2.0
+                + h2p0 * ll * ll / 6.0
+                - alpha1 * ll**3 / 4.0 / rho2
+                + gamma1 * ll**4 / 20.0 / rho2
+            )
 
         di1 = eta_ave * ll / rho
         di2 = ll / rho2
         di3 = ll / abs(rho) / rho2
-        di4 = eta_ave * ll * (2.0 * elem.K + 1.0 / rho2) / rho \
+        di4 = (
+            eta_ave * ll * (2.0 * elem.K + 1.0 / rho2) / rho
             - (eta0 * eps1 + eta3 * eps2) / rho
+        )
         di5 = h_ave * ll / abs(rho) / rho2
         return numpy.array([di1, di2, di3, di4, di5])
 
@@ -313,7 +341,7 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
             """On-axis wiggler field"""
 
             def harm(coef, h, phi):
-                return -Bmax * coef * numpy.cos(h*kws + phi)
+                return -Bmax * coef * numpy.cos(h * kws + phi)
 
             kw = 2 * pi / wiggler.Lw
             Bmax = wiggler.Bmax
@@ -331,8 +359,8 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
         gammax0 = (alphax0 * alphax0 + 1) / betax0
         eta0 = dini.dispersion[0]
         etap0 = dini.dispersion[1]
-        H0 = gammax0*eta0*eta0 + 2*alphax0*eta0*etap0 + betax0*etap0*etap0
-        avebetax = betax0 + alphax0*le + gammax0*le*le/3
+        H0 = gammax0 * eta0 * eta0 + 2 * alphax0 * eta0 * etap0 + betax0 * etap0 * etap0
+        avebetax = betax0 + alphax0 * le + gammax0 * le * le / 3
 
         kw = 2 * pi / elem.Lw
         rhoinv = elem.Bmax / Brho
@@ -343,8 +371,8 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
             di3 = le * coef2[0] ** 3 * 4 / 3 / pi
         else:
             bx, bz = b_on_axis(elem, numpy.linspace(0, elem.Lw, _NSTEP + 1))
-            rinv = numpy.sqrt(bx*bx + bz*bz) / Brho
-            di3 = numpy.trapz(rinv ** 3) * le / _NSTEP
+            rinv = numpy.sqrt(bx * bx + bz * bz) / Brho
+            di3 = numpy.trapz(rinv**3) * le / _NSTEP
         di2 = le * (numpy.sum(coefh * coefh) + numpy.sum(coefv * coefv)) / 2
         di1 = -di2 / kw / kw
         di4 = 0
@@ -359,15 +387,15 @@ def get_radiation_integrals(ring, dp: float = None, twiss=None, **kwargs)\
     integrals = numpy.zeros((5,))
 
     if twiss is None:
-        _, _, twiss = ring.get_optics(refpts=range(len(ring) + 1), dp=dp,
-                                      get_chrom=True, **kwargs)
+        _, _, twiss = ring.get_optics(
+            refpts=range(len(ring) + 1), dp=dp, get_chrom=True, **kwargs
+        )
     elif len(twiss) != len(ring) + 1:
-        raise ValueError('length of Twiss data should be {0}'
-                         .format(len(ring) + 1))
-    for (el, vini, vend) in zip(ring, twiss[:-1], twiss[1:]):
+        raise ValueError(f"length of Twiss data should be {len(ring) + 1}")
+    for el, vini, vend in zip(ring, twiss[:-1], twiss[1:]):
         if isinstance(el, (Dipole, Quadrupole)):
             integrals += element_radiation(el, vini, vend)
-        elif isinstance(el, Wiggler) and el.PassMethod != 'DriftPass':
+        elif isinstance(el, Wiggler) and el.PassMethod != "DriftPass":
             integrals += wiggler_radiation(el, vini)
     return tuple(integrals)
 
@@ -403,13 +431,12 @@ def gen_quantdiff_elem(ring: Lattice, orbit: Orbit = None) -> QuantumDiffusion:
     """
     dmat = quantdiffmat(ring, orbit=orbit)
     lmat = numpy.asfortranarray(_lmat(dmat))
-    diff_elem = QuantumDiffusion('Diffusion', lmat)
+    diff_elem = QuantumDiffusion("Diffusion", lmat)
     return diff_elem
 
 
 @check_radiation(True)
-def tapering(ring: Lattice, multipoles: bool = True,
-             niter: int = 1, **kwargs) -> None:
+def tapering(ring: Lattice, multipoles: bool = True, niter: int = 1, **kwargs) -> None:
     """Scales magnet strengths
 
     Scales magnet strengths with local energy to cancel the closed orbit
@@ -437,24 +464,34 @@ def tapering(ring: Lattice, multipoles: bool = True,
           Default: :py:data:`DConstant.DPStep <.DConstant>`
     """
 
-    xy_step = kwargs.pop('XYStep', DConstant.XYStep)
-    dp_step = kwargs.pop('DPStep', DConstant.DPStep)
-    method = kwargs.pop('method', ELossMethod.TRACKING)
+    xy_step = kwargs.pop("XYStep", DConstant.XYStep)
+    dp_step = kwargs.pop("DPStep", DConstant.DPStep)
+    method = kwargs.pop("method", ELossMethod.TRACKING)
     dipin = ring.get_bool_index(Dipole)
     dipout = numpy.roll(dipin, 1)
     multin = ring.get_bool_index(Multipole) & ~dipin
     multout = numpy.roll(multin, 1)
 
-    for i in range(niter):
-        _, o6 = find_orbit6(ring, refpts=range(len(ring)+1),
-                            XYStep=xy_step, DPStep=dp_step, method=method)
+    for _i in range(niter):
+        _, o6 = find_orbit6(
+            ring,
+            refpts=range(len(ring) + 1),
+            XYStep=xy_step,
+            DPStep=dp_step,
+            method=method,
+        )
         dpps = (o6[dipin, 4] + o6[dipout, 4]) / 2.0
-        set_value_refpts(ring, dipin, 'FieldScaling', 1+dpps)
+        set_value_refpts(ring, dipin, "FieldScaling", 1 + dpps)
         if multipoles:
-            _, o6 = find_orbit6(ring, refpts=range(len(ring)+1),
-                                XYStep=xy_step, DPStep=dp_step, method=method)
+            _, o6 = find_orbit6(
+                ring,
+                refpts=range(len(ring) + 1),
+                XYStep=xy_step,
+                DPStep=dp_step,
+                method=method,
+            )
             dppm = (o6[multin, 4] + o6[multout, 4]) / 2
-            set_value_refpts(ring, multin, 'FieldScaling', 1+dppm)
+            set_value_refpts(ring, multin, "FieldScaling", 1 + dppm)
 
 
 Lattice.ohmi_envelope = ohmi_envelope

--- a/pyat/at/physics/wiggdiffmatrix.pyi
+++ b/pyat/at/physics/wiggdiffmatrix.pyi
@@ -1,0 +1,10 @@
+"""Stub file for the 'diffmatrix' extension"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from . import Orbit
+from ..lattice import Element
+
+def FDW(element: Element, orbit: Orbit, energy: float | None = None) -> np.ndarray: ...

--- a/setup.py
+++ b/setup.py
@@ -142,14 +142,22 @@ cconfig = Extension(
 
 diffmatrix = Extension(
     name='at.physics.diffmatrix',
-    sources=[diffmatrix_source],
+    sources=[join(diffmatrix_orig, 'findmpoleraddiffmatrix.c')],
+    include_dirs=[numpy.get_include(), integrator_src_orig],
+    define_macros=macros,
+    extra_compile_args=cflags
+)
+
+wiggdiffmatrix = Extension(
+    name='at.physics.wiggdiffmatrix',
+    sources=[join(diffmatrix_orig, 'FDW.c')],
     include_dirs=[numpy.get_include(), integrator_src_orig],
     define_macros=macros,
     extra_compile_args=cflags
 )
 
 setup(
-    ext_modules=[at, cconfig, diffmatrix] +
+    ext_modules=[at, cconfig, diffmatrix, wiggdiffmatrix] +
                 [c_integrator_ext(pm) for pm in c_pass_methods] +
                 [cpp_integrator_ext(pm) for pm in cpp_pass_methods],
 )


### PR DESCRIPTION
The diffusion matrix of wigglers was recently introduced (#759) but has a few problems:

#### For Matlab
- FDW.c is not compiled in `atmexall`, and so is missing when needed,
- Compilation fails when requested on MacOS (wrong ordering of #include lines).

#### For python
- FDW.c is not compiled in `setup.py` (same as for Matlab),
- FDW is not imported in the `at.physics` module,
- Wigglers are not considered in the computation of emittances.


This PR corrects all this. As mentioned before, we have no way of cross-checking the results (specially for the python implementation), so we trust the computation. This is anyway better than before when it was wrong.