### PR TITLE
Bug fix in atavedata

### DIFF
--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -41,7 +41,7 @@ lg=initial(refs(needed)); % refpts
 
 beta0=avebeta(lg,:); %long
 alpha0=cat(1,lin0.alpha); %long
-mu0=avemu(lg);
+mu0=avemu(lg,:);
 disp0=avedisp(lg,:); %long
 
 mu1=cat(1,lin1.mu); %long

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -212,10 +212,12 @@ classdef pytests < matlab.unittest.TestCase
             a=cell(lattice.p.avlinopt(dp, prefs));
             pbeta = double(a{2});
             pdisp = double(a{4});
+            pmu = double(a{3});
             % Matlab
-            [~,mbeta,~,mdisp,~,~]=atavedata(lattice.m,dp,mrefs);
+            [~,mbeta,mmu,mdisp,~,~]=atavedata(lattice.m,dp,mrefs);
             % check
-            testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-7,RelTol=1.e-7);
+            testCase.verifyEqual(mbeta,pbeta,AbsTol=1.E-8,RelTol=1.e-8);
+            testCase.verifyEqual(mmu,pmu,AbsTol=1.E-8,RelTol=0);
             testCase.verifyEqual(mdisp,pdisp,AbsTol=1.E-8,RelTol=0);
         end
 

--- a/pyat/test_matlab/test_cmp_avlinopt.py
+++ b/pyat/test_matlab/test_cmp_avlinopt.py
@@ -29,6 +29,6 @@ def test_avlinopt(engine, request, lattices, dp):
         "atavedata", ml_lattice, dp, mlrefs, nargout=6
     )
     # Comparison
-    assert_close(avebeta, np.asarray(ml_avebeta), rtol=1e-7)
-    assert_close(avemu, np.asarray(ml_avemu), rtol=0, atol=1e-7)
+    assert_close(avebeta, np.asarray(ml_avebeta), rtol=1e-8)
+    assert_close(avemu, np.asarray(ml_avemu), rtol=0, atol=1e-8)
     assert_close(avedisp, np.asarray(ml_avedisp), rtol=0, atol=1e-8)


### PR DESCRIPTION
Still a bug in atavedata: the vertical phase advance was wrong.

The bug escaped the automatic tests. The tests are now more severe to try and avoid further problems.