### PR TITLE
add units and example of use to help

### DIFF
--- a/atmat/atphysics/Radiation/atsetenergy.m
+++ b/atmat/atphysics/Radiation/atsetenergy.m
@@ -1,6 +1,19 @@
 function newring = atsetenergy(ring,E)
-%atsetenergy(ring,Energy) sets the Energy field in all
-%elements to the value given by E.  If no such field exists, it creates it.
+% ATSETENERGY sets the Energy field in all elements.
+% If no such field exists, it creates it.
+%
+% newring = atsetenergy(ring,Energy)
+%
+%   ring: an AT ring.
+%   Energy: Value to set the Energy field. Units: eV
+%   newring: new AT ring with Energy field set.
+%
+% Example:
+%   Set the energy of the elements in RING to 3 GeV.
+%   NEWRING = atsetenergy(RING,3e9)
+%
+% See also atenergy
+%
 newring=ring;
 for j=1:length(ring)
     newring{j}.Energy = E;


### PR DESCRIPTION
This PR address issue #826 .
The help message of `atsetenergy`has been modified to state the units of Energy and an example has been added.
