### PR TITLE
Fix ohmienvelope wiggler mask

### DIFF
--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -101,6 +101,7 @@ oldwarns=warning('OFF','MATLAB:mex:GccVersion_link');
 % Diffusion matrices
 cdir=fullfile(atroot,'atphysics','Radiation');
 compile([alloptions, {passinclude}], fullfile(cdir,'findmpoleraddiffmatrix.c'));
+compile([alloptions, {passinclude}], fullfile(cdir,'FDW.c'));
 
 % RDTs
 cdir=fullfile(atroot,'atphysics','NonLinearDynamics');

--- a/atmat/atphysics/Radiation/ohmienvelope.m
+++ b/atmat/atphysics/Radiation/ohmienvelope.m
@@ -4,6 +4,10 @@ function [envelope, rmsdp, rmsbl, varargout] = ohmienvelope(ring,radindex,refpts
 % [1] K.Ohmi et al. Phys.Rev.E. Vol.49. (1994)
 %
 % [ENVELOPE, RMSDP, RMSBL] = ONMIENVELOPE(RING,RADELEMINDEX,REFPTS)
+% RING    - an AT ring
+% RADELEMEINDEX - index of elements with radiative PassMethod,
+%                 typically they finish in '...Rad'
+% REFPTS  - Reference points along the RING
 %
 % ENVELOPE is a structure with fields
 % Sigma   - [SIGMA(1); SIGMA(2)] - RMS size [m] along
@@ -21,13 +25,17 @@ function [envelope, rmsdp, rmsbl, varargout] = ohmienvelope(ring,radindex,refpts
 %   Returns in addition the 6x6 transfer matrices and the closed orbit
 %   from FINDM66
 
+check_6d(ring, true, 'strict', 0);
+
 NumElements = length(ring);
 if nargin<3, refpts=1; end
 
 % Erase wigglers from the radiative element list.
 % Diffusion matrix to be computed with separate FDW function.
 Wig=atgetcells(ring,'Bmax');
-radindex = radindex & ~Wig;
+[~,ia,~]= intersect(radindex, find(Wig));
+radindex(ia) = [];
+
 
 [mring, ms, orbit] = findm66(ring,1:NumElements+1);
 mt=squeeze(num2cell(ms,[1 2]));


### PR DESCRIPTION
This PR solves issue #825 .
The wiggler indexes and radiation element indexes are intersected. Common elements, if any, are removed from the radiation element list.
This is done in order to keep indexes compatible with the separation of the diffusion matrix calculation for the wigglers.

Additionally, help is modified and non-strict check_6d is included.

I also found out that the atmexall was not compiling `FDW.c`. I added it.

o