### PR TITLE
Fix handling of JSON files when harmonic_number is undefined

### DIFF
--- a/atmat/lattice/atSetRingProperties.m
+++ b/atmat/lattice/atSetRingProperties.m
@@ -86,7 +86,7 @@ end
         % Check the validity of the harmonic number
         cell_h=ring_h/nper;
         % Check on full ring
-        if (round(ring_h) - ring_h) ~= 0
+        if isfinite(ring_h) && (round(ring_h) - ring_h) ~= 0
             error('AT:Invalid','The harmonic number must be integer')
         end
 %       % Check on cell

--- a/atmat/lattice/atloadlattice.m
+++ b/atmat/lattice/atloadlattice.m
@@ -94,8 +94,13 @@ lattice=atSetRingProperties(lattice,varargs{:});
         energy=props.energy;
         periodicity=props.periodicity;
         particle=atparticle.loadobj(props.particle);
-        harmnumber=props.harmonic_number;
-        props=rmfield(props,{'name','energy','periodicity','particle','harmonic_number'});
+        if isfield(props,'harmonic_number')
+            harmnumber=props.harmonic_number;
+            props=rmfield(props,'harmonic_number');
+        else
+            harmnumber=NaN;
+        end
+        props=rmfield(props,{'name','energy','periodicity','particle'});
         args=[fieldnames(props) struct2cell(props)]';
         lattice=atSetRingProperties(data.elements,...
             'FamName', name,...

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -222,7 +222,7 @@ class Lattice(list):
                 self.set_fillpattern(bunches=fp)
             except AssertionError:
                 self.set_fillpattern()
-        elif not math.isnan(ring_h):
+        elif not ((ring_h is None) or math.isnan(ring_h)):
             self._cell_harmnumber = ring_h / periodicity
 
     def __getitem__(self, key):


### PR DESCRIPTION
Exchanging JSON files between python and Matlab may fail when the harmonic number is undefined (no cavity in the lattice). This PR corrects 2 problems:

- Matlab expects a harmonic number (possibly `NaN`) while python did not store anything,
- python gets a `None` harmonic numbers stored by Matlab
