### PR TITLE
Fix saving lattices in m-files

### DIFF
--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -713,7 +713,7 @@ class _MadParser(UnorderedParser):
             if cavities:
                 cavities.sort(key=lambda el: el.Frequency)
                 c0 = cavities[0]
-                params["_harmnumber"] = getattr(c0, "HarmNumber", np.nan)
+                params["_cell_harmnumber"] = getattr(c0, "HarmNumber", np.nan)
 
         part = kwargs.get("particle", None)
         if isinstance(part, str):


### PR DESCRIPTION
This fixes a problem described in #829: the string representation of numpy arrays changed in numpy 2.0, resulting in m-files refused by Matlab.

This is corrected here.