### PR TITLE
fix uninitialised random generators in elempass

### DIFF
--- a/pyat/at.c
+++ b/pyat/at.c
@@ -645,6 +645,8 @@ static PyObject *at_elempass(PyObject *self, PyObject *args, PyObject *kwargs)
     struct parameters param;
     struct LibraryListElement *LibraryListPtr;
 
+    param.common_rng=&common_state;
+    param.thread_rng=&thread_state;
     param.nturn = 0;
     param.energy=0.0;
     param.rest_energy=0.0;


### PR DESCRIPTION
A bug reported in #841 causes a segmentation fault in `ohmi_envelope` when called with  an element using random generators in the lattice. This was due to a non-initialised variable in the C function `elempass`.

This is corrected here.

There are very few functions calling `elempass` (`ohmi_envelope` is maybe the only one, and it's not supposed to be called with random elements), so this was not noticed until recently. 