### PR TITLE
Fix "fastring"

### DIFF
--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -1,4 +1,6 @@
 classdef pytests < matlab.unittest.TestCase
+    % ">> run(pytests)" to run all tests
+    % ">> run(pytests, 'orbit4')" to run a the single orbit4 method
 
     properties(Constant)
         mlist=[...
@@ -239,6 +241,36 @@ classdef pytests < matlab.unittest.TestCase
             testCase.verifyEqual(mperiodicity,double(lattice.p.periodicity));
             testCase.verifyEqual(mgamma,lattice.p.gamma);
             testCase.verifyEqual(mmcf,lattice.p.mcf,RelTol=1.E-8);
+        end
+
+        function fastring(testCase,lat2)
+            lattice=testCase.ring4.(lat2);
+            [rm, rmrad]=atfastring(lattice.m);
+            rpy=cell(py.at.fast_ring(lattice.p));
+            rp=cell(rpy{1});
+            rprad=cell(rpy{2});
+            checkattr(rm, rp);
+            checkattr(rmrad,rprad);
+
+            function checkattr(rm, rp)
+                testCase.verifyEqual(rm{2}.Frequency, rp{1}.Frequency, RelTol=1.0e-20);
+                testCase.verifyEqual(rm{2}.Voltage, rp{1}.Voltage, RelTol=1.0e-20);
+                testCase.verifyEqual(rm{3}.I2, rp{2}.I2, RelTol=1.0e-15);
+                testCase.verifyEqual(rm{3}.Length, rp{2}.Length, RelTol=1.0e-20);
+                testCase.verifyEqual(rm{3}.M66, double(rp{2}.M66), AbsTol=1.0e-7);
+                testCase.verifyEqual(rm{end}.A1, rp{3}.A1, RelTol=0.01);
+                testCase.verifyEqual(rm{end}.A2, rp{3}.A2, RelTol=0.02);
+                testCase.verifyEqual(rm{end}.A3, rp{3}.A3, RelTol=0.01);
+                testCase.verifyEqual(rm{end}.Alphax, rp{3}.Alphax, AbsTol=1.e-10);
+                testCase.verifyEqual(rm{end}.Alphay, rp{3}.Alphay, AbsTol=1.e-10);
+                testCase.verifyEqual(rm{end}.Betax, rp{3}.Betax, RelTol=1.e-10);
+                testCase.verifyEqual(rm{end}.Betay, rp{3}.Betay, RelTol=1.e-10);
+                testCase.verifyEqual(rm{end}.Qpx, rp{3}.Qpx, RelTol=1.e-8);
+                testCase.verifyEqual(rm{end}.Qpy, rp{3}.Qpy, RelTol=1.e-8);
+                if length(rm) >= 5
+                    testCase.verifyEqual(rm{end-1}.Lmatp, double(rp{4}.Lmatp), AbsTol=2.e-7);
+                end
+            end
         end
     end
 end

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -40,7 +40,7 @@ def _rearrange(ring: Lattice, split_inds=[]):
             cavl.TimeLag = cavf[0].TimeLag
             ring_slice.append(cavl)
         ringm = ringm + ring_slice
-    return all_rings, Lattice(ringm, energy=ring.energy)
+    return all_rings, Lattice(ringm, energy=ring.energy, periodicity=1)
 
 
 def _fring(ring, split_inds=[], detuning_elem=None):

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -84,9 +84,13 @@ def fast_ring(ring: Lattice, split_inds: Refpts = None) -> tuple[Lattice, Lattic
     * a detuning and chromaticity element,
     * a quantum diffusion element (for radiation ring).
 
-    2 new lattices are returned, one with radiation and one without
+
+    2 new lattices are returned, one with radiation and one without. These lattices
+    keep the same attributes (energy, particle, circumference, periodicity,…)
+    as the initial one.
+
     It is possible to split the original ring in multiple "fastrings"
-    using the ``split_inds`` argument
+    using the ``split_inds`` argument.
 
     Parameters:
         ring:       Lattice description

--- a/pyat/at/physics/fastring.py
+++ b/pyat/at/physics/fastring.py
@@ -1,52 +1,54 @@
 """
 Functions relating to fast_ring
 """
+
 from __future__ import annotations
-from functools import reduce
-import numpy
-from typing import Union
-from collections.abc import Sequence
-from at.lattice import Lattice, Particle
-from at.lattice import RFCavity, Element, Marker, get_cells, checkname
-from at.lattice import get_elements, M66, SimpleQuantDiff, AtError, SimpleRadiation
-from at.physics import gen_m66_elem, gen_detuning_elem, gen_quantdiff_elem
-from at.constants import clight
+
+__all__ = ["fast_ring", "simple_ring"]
+
 import copy
+from collections.abc import Sequence
+from functools import reduce
+
+import numpy as np
+
+from ..constants import clight
+from ..lattice import Lattice, Particle, Refpts
+from ..lattice import RFCavity, Element, Marker, get_cells, checkname
+from ..lattice import get_elements, M66, SimpleQuantDiff, AtError, SimpleRadiation
+from ..physics import gen_m66_elem, gen_detuning_elem, gen_quantdiff_elem
 
 
-__all__ = ['fast_ring', 'simple_ring']
-
-
-def _rearrange(ring: Lattice, split_inds=[]):
-    inds = numpy.append(split_inds, [0, len(ring)+1])
-    inds = numpy.unique(inds)
-    all_rings = [ring[int(b):int(e)] for b, e in zip(inds[:-1], inds[1:])]
+def _rearrange(ring: Lattice, split_inds: Refpts = None):
+    inds = ring.get_bool_index(split_inds, endpoint=True)
+    inds[0] = True
+    inds[-1] = True
+    inds = ring.get_uint32_index(inds)
+    all_rings = [ring[int(b) : int(e)] for b, e in zip(inds[:-1], inds[1:])]
 
     ringm = []
     for ring_slice in all_rings:
-        ring_slice.insert(0, Marker('xbeg'))
-        ring_slice.append(Marker('xend'))
+        ring_slice.insert(0, Marker("xbeg"))
+        ring_slice.append(Marker("xend"))
         cavs = [e for e in ring_slice if isinstance(e, RFCavity)]
-        newpass = ['IdentityPass' if c.Length == 0
-                   else 'DriftPass' for c in cavs]
+        newpass = ["IdentityPass" if c.Length == 0 else "DriftPass" for c in cavs]
         for c, pm in zip(cavs, newpass):
             c.PassMethod = pm
-        uni_freq = numpy.unique([e.Frequency for e in cavs])
-        for fr in numpy.atleast_1d(uni_freq):
+        uni_freq = np.unique([e.Frequency for e in cavs])
+        for fr in np.atleast_1d(uni_freq):
             cavf = [c for c in cavs if c.Frequency == fr]
-            vol = reduce(lambda x, y: x+y, (c.Voltage for c in cavf))
-            cavl = RFCavity('CAVL', 0, vol, fr,
-                            cavf[0].HarmNumber, cavf[0].Energy)
+            vol = reduce(lambda x, y: x + y, (c.Voltage for c in cavf))
+            cavl = RFCavity("CAVL", 0, vol, fr, cavf[0].HarmNumber, cavf[0].Energy)
             cavl.TimeLag = cavf[0].TimeLag
             ring_slice.append(cavl)
         ringm = ringm + ring_slice
     return all_rings, Lattice(ringm, energy=ring.energy, periodicity=1)
 
 
-def _fring(ring, split_inds=[], detuning_elem=None):
+def _fring(ring, split_inds: Refpts = None, detuning_elem=None):
     all_rings, merged_ring = _rearrange(ring, split_inds=split_inds)
-    ibegs = get_cells(merged_ring, checkname('xbeg'))
-    iends = get_cells(merged_ring, checkname('xend'))
+    ibegs = get_cells(merged_ring, checkname("xbeg"))
+    iends = get_cells(merged_ring, checkname("xend"))
     _, orbit = merged_ring.find_orbit(refpts=ibegs | iends)
     if detuning_elem is None:
         detuning_elem = gen_detuning_elem(merged_ring, orbit[-1])
@@ -56,11 +58,10 @@ def _fring(ring, split_inds=[], detuning_elem=None):
 
     fastring = []
     for counter, r in enumerate(all_rings):
-        cavs = [e for e in r if e.PassMethod.endswith('CavityPass')]
+        cavs = [e for e in r if e.PassMethod.endswith("CavityPass")]
         [r.remove(c) for c in cavs]
-        lin_elem = gen_m66_elem(r, orbit[2*counter],
-                                orbit[2*counter+1])
-        lin_elem.FamName = lin_elem.FamName + '_' + str(counter)
+        lin_elem = gen_m66_elem(r, orbit[2 * counter], orbit[2 * counter + 1])
+        lin_elem.FamName = lin_elem.FamName + "_" + str(counter)
         [fastring.append(c) for c in cavs]
         fastring.append(lin_elem)
     fastring.append(detuning_elem)
@@ -73,7 +74,7 @@ def _fring(ring, split_inds=[], detuning_elem=None):
     return fastring
 
 
-def fast_ring(ring: Lattice, split_inds=[]) -> tuple[Lattice, Lattice]:
+def fast_ring(ring: Lattice, split_inds: Refpts = None) -> tuple[Lattice, Lattice]:
     """Generates a "fast ring"
 
     A fast ring consisting in:
@@ -96,35 +97,48 @@ def fast_ring(ring: Lattice, split_inds=[]) -> tuple[Lattice, Lattice]:
         fringrad (Lattice): Fast ring with radiation
     """
     ringi = ring.deepcopy()
-    fastringnorad = _fring(ringi.radiation_off(copy=True),
-                           split_inds=split_inds)
-    detuning_elem = copy.deepcopy(get_elements(fastringnorad,
-                                               'NonLinear')[0])
-    fastringrad = _fring(ringi.radiation_on(copy=True),
-                         split_inds=split_inds,
-                         detuning_elem=detuning_elem)
+    fastringnorad = _fring(ringi.radiation_off(copy=True), split_inds=split_inds)
+    detuning_elem = copy.deepcopy(get_elements(fastringnorad, "NonLinear")[0])
+    fastringrad = _fring(
+        ringi.radiation_on(copy=True),
+        split_inds=split_inds,
+        detuning_elem=detuning_elem,
+    )
     return fastringnorad, fastringrad
 
 
-def simple_ring(energy: float, circumference: float,
-                harmonic_number: Union[float, Sequence[float]],
-                Qx: float, Qy: float,
-                Vrf: Union[float, Sequence[float]],
-                alpha: float,
-                betax: float = 1.0, betay: float = 1.0,
-                alphax: float = 0.0, alphay: float = 0.0,
-                dispx: float = 0.0, dispxp: float = 0.0,
-                dispy: float = 0.0, dispyp: float = 0.0,
-                Qpx: float = 0.0, Qpy: float = 0.0,
-                A1: float = 0.0, A2: float = 0.0,
-                A3: float = 0.0, emitx: float = 0.0,
-                emity: float = 0.0, espread: float = 0.0,
-                taux: float = 0.0, tauy: float = 0.0,
-                tauz: float = 0.0, U0: float = 0.0,
-                name: str = "",
-                particle: Union[str, Particle] = 'relativistic',
-                TimeLag: Union[float, Sequence[float]] = 0.0,
-                ) -> Lattice:
+def simple_ring(
+    energy: float,
+    circumference: float,
+    harmonic_number: float | Sequence[float],
+    Qx: float,
+    Qy: float,
+    Vrf: float | Sequence[float],
+    alpha: float,
+    betax: float = 1.0,
+    betay: float = 1.0,
+    alphax: float = 0.0,
+    alphay: float = 0.0,
+    dispx: float = 0.0,
+    dispxp: float = 0.0,
+    dispy: float = 0.0,
+    dispyp: float = 0.0,
+    Qpx: float = 0.0,
+    Qpy: float = 0.0,
+    A1: float = 0.0,
+    A2: float = 0.0,
+    A3: float = 0.0,
+    emitx: float = 0.0,
+    emity: float = 0.0,
+    espread: float = 0.0,
+    taux: float = 0.0,
+    tauy: float = 0.0,
+    tauz: float = 0.0,
+    U0: float = 0.0,
+    name: str = "",
+    particle: str | Particle = "relativistic",
+    TimeLag: float | Sequence[float] = 0.0,
+) -> Lattice:
     """Generates a "simple ring" based on a given dictionary
        of global parameters
 
@@ -186,78 +200,111 @@ def simple_ring(energy: float, circumference: float,
         ring:    Simple ring
     """
     try:
-        rfp = numpy.broadcast(Vrf, harmonic_number, TimeLag)
-    except ValueError:
-        raise AtError('Vrf, harmonic_number and TimeLag must be broadcastable')
+        rfp = np.broadcast(Vrf, harmonic_number, TimeLag)
+    except ValueError as exc:
+        raise AtError("Vrf, harmonic_number and TimeLag must be broadcastable") from exc
 
     # revolution frequency
     f0 = clight / circumference
 
-    all_cavities = [RFCavity(f"RFC{i+1}", 0.0, v, h*f0, h, energy, TimeLag=t)
-                    for i, (v, h, t) in enumerate(rfp)]
+    all_cavities = [
+        RFCavity(f"RFC{i+1}", 0.0, v, h * f0, h, energy, TimeLag=t)
+        for i, (v, h, t) in enumerate(rfp)
+    ]
 
     # Now we will use the optics parameters to compute the uncoupled M66 matrix
 
-    s_dphi_x = numpy.sin(2*numpy.pi*Qx)
-    c_dphi_x = numpy.cos(2*numpy.pi*Qx)
-    s_dphi_y = numpy.sin(2*numpy.pi*Qy)
-    c_dphi_y = numpy.cos(2*numpy.pi*Qy)
+    s_dphi_x = np.sin(2 * np.pi * Qx)
+    c_dphi_x = np.cos(2 * np.pi * Qx)
+    s_dphi_y = np.sin(2 * np.pi * Qy)
+    c_dphi_y = np.cos(2 * np.pi * Qy)
 
     M00 = c_dphi_x + alphax * s_dphi_x
     M01 = betax * s_dphi_x
-    M10 = -(1. + alphax**2) / betax * s_dphi_x
+    M10 = -(1.0 + alphax**2) / betax * s_dphi_x
     M11 = c_dphi_x - alphax * s_dphi_x
 
     M04 = (1 - M00) * dispx - M01 * dispxp
     M14 = -M10 * dispx + (1 - M11) * dispxp
-    
+
     M22 = c_dphi_y + alphay * s_dphi_y
     M23 = betay * s_dphi_y
-    M32 = -(1. + alphay**2) / betay * s_dphi_y
+    M32 = -(1.0 + alphay**2) / betay * s_dphi_y
     M33 = c_dphi_y - alphay * s_dphi_y
 
     M24 = (1 - M22) * dispy - M23 * dispyp
     M34 = -M32 * dispy + (1 - M33) * dispyp
-    
-    
-    M44 = 1.
-    M45 = 0.
-    M54 = alpha*circumference
+
+    M44 = 1.0
+    M45 = 0.0
+    M54 = alpha * circumference
     M55 = 1
 
-    Mat66 = numpy.array([[M00, M01, 0., 0., M04, 0.],
-                         [M10, M11, 0., 0., M14, 0.],
-                         [0., 0., M22, M23, M24, 0.],
-                         [0., 0., M32, M33, M34, 0.],
-                         [0., 0., 0., 0., M44, M45],
-                         [0., 0., 0., 0., M54, M55]], order='F')
+    Mat66 = np.array(
+        [
+            [M00, M01, 0.0, 0.0, M04, 0.0],
+            [M10, M11, 0.0, 0.0, M14, 0.0],
+            [0.0, 0.0, M22, M23, M24, 0.0],
+            [0.0, 0.0, M32, M33, M34, 0.0],
+            [0.0, 0.0, 0.0, 0.0, M44, M45],
+            [0.0, 0.0, 0.0, 0.0, M54, M55],
+        ],
+        order="F",
+    )
 
     # generate the linear tracking element, we set a length
     # which is needed to give the lattice object the correct length
     # (although it is not used for anything else)
-    lin_elem = M66('Linear', m66=Mat66, Length=circumference)
+    lin_elem = M66("Linear", m66=Mat66, Length=circumference)
 
     # Generate the simple radiation element
-    simplerad = SimpleRadiation('SR', taux=taux, tauy=tauy, 
-                                tauz=tauz, U0=U0, dispx=dispx,
-                                dispy=dispy, dispxp=dispxp, 
-                                dispyp=dispyp)
-                                
+    simplerad = SimpleRadiation(
+        "SR",
+        taux=taux,
+        tauy=tauy,
+        tauz=tauz,
+        U0=U0,
+        dispx=dispx,
+        dispy=dispy,
+        dispxp=dispxp,
+        dispyp=dispyp,
+    )
+
     # Generate the simple quantum diffusion element
-    quantdiff = SimpleQuantDiff('SQD', betax=betax, betay=betay,
-                                emitx=emitx, emity=emity,
-                                espread=espread, taux=taux,
-                                tauy=tauy, tauz=tauz)
+    quantdiff = SimpleQuantDiff(
+        "SQD",
+        betax=betax,
+        betay=betay,
+        emitx=emitx,
+        emity=emity,
+        espread=espread,
+        taux=taux,
+        tauy=tauy,
+        tauz=tauz,
+    )
 
     # Generate the detuning element
-    nonlin_elem = Element('NonLinear', PassMethod='DeltaQPass',
-                          Betax=betax, Betay=betay,
-                          Alphax=alphax, Alphay=alphay,
-                          Qpx=Qpx, Qpy=Qpy,
-                          A1=A1, A2=A2, A3=A3)
+    nonlin_elem = Element(
+        "NonLinear",
+        PassMethod="DeltaQPass",
+        Betax=betax,
+        Betay=betay,
+        Alphax=alphax,
+        Alphay=alphay,
+        Qpx=Qpx,
+        Qpy=Qpy,
+        A1=A1,
+        A2=A2,
+        A3=A3,
+    )
 
     # Assemble all elements into the lattice object
-    ring = Lattice(all_cavities + [lin_elem, nonlin_elem, simplerad, quantdiff],
-                   name=name, energy=energy, particle=particle, periodicity=1)
+    ring = Lattice(
+        all_cavities + [lin_elem, nonlin_elem, simplerad, quantdiff],
+        name=name,
+        energy=energy,
+        particle=particle,
+        periodicity=1,
+    )
 
     return ring


### PR DESCRIPTION
This fixes a regression bug that appeared in #837, causing the chromaticies and detuning of fast rings to be wrong.

For reviewers, the only significant modification is `fasting.py` line 45:
```python
return all_rings, Lattice(ringm, energy=ring.energy, periodicity=1)
```
which forces the analysis to be done on a single cell. Everything else is formatting.

This bug was identified in the `matlab_test` series of python tests which cannot be run on GitHub because of a problem of Matlab license. So now, a new test is added in `pytests.m`, executed on Matlab on each commit.