### PR TITLE
Fix  a bug in load_madx

### DIFF
--- a/pyat/at/load/file_input.py
+++ b/pyat/at/load/file_input.py
@@ -159,11 +159,10 @@ class ElementDescr(AnyDescr, dict):
         else:
             yield from elems
 
-    def _length(self) -> float:
+    @property
+    def length(self) -> float:
         """Element length"""
         return self.get("l", 0.0)
-
-    length = property(_length)
 
 
 class SequenceDescr(AnyDescr, list, abc.ABC):

--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -216,7 +216,7 @@ class rbend(_MadElement):
     @staticmethod
     @set_tilt
     def convert(name, l, angle, e1=0.0, e2=0.0, **params):  # noqa: E741
-        hangle = 0.5 * angle
+        hangle = abs(0.5 * angle)
         arclength = l / sinc(hangle)
         return sbend.convert(
             name, arclength, angle, e1=hangle + e1, e2=hangle + e2, **params

--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -224,6 +224,7 @@ class rbend(_MadElement):
 
     @property
     def length(self):
+        """Element length"""
         hangle = 0.5 * self["angle"]
         return self["l"] / sinc(hangle)
 
@@ -708,13 +709,17 @@ class _MadParser(UnorderedParser):
 
             params["_length"] = cell_length
             rev = beta() * clight / cell_length
+
+            # Set the frequency of cavities in which it is not specified
+            hn = 2147483647
             for cav in cavities:
                 if np.isnan(cav.Frequency):
                     cav.Frequency = rev * cav.HarmNumber
-            if cavities:
-                cavities.sort(key=lambda el: el.Frequency)
-                c0 = cavities[0]
-                params["_cell_harmnumber"] = getattr(c0, "HarmNumber", np.nan)
+                elif cav.HarmNumber == 0:
+                    cav.HarmNumber = cav.Frequency / rev
+                if cav.HarmNumber < hn:
+                    hn = cav.HarmNumber
+            params["_cell_harmnumber"] = hn
 
         part = kwargs.get("particle", None)
         if isinstance(part, str):

--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -217,14 +217,15 @@ class rbend(_MadElement):
     @set_tilt
     def convert(name, l, angle, e1=0.0, e2=0.0, **params):  # noqa: E741
         hangle = 0.5 * angle
-        arclength = l * hangle / sin(hangle)
+        arclength = l / sinc(hangle)
         return sbend.convert(
             name, arclength, angle, e1=hangle + e1, e2=hangle + e2, **params
         )
 
-    def _length(self):
-        hangle = 0.5 * self.angle
-        return self["l"] * hangle / sin(hangle)
+    @property
+    def length(self):
+        hangle = 0.5 * self["angle"]
+        return self["l"] / sinc(hangle)
 
 
 # noinspection PyPep8Naming
@@ -475,9 +476,9 @@ class _Sequence(SequenceDescr):
 
     def expand(self, parser: MadxParser) -> Generator[elt.Element, None, None]:
         def insert_drift(dl, el):
-            if dl > 1.0e-10:
+            if dl > 1.0e-5:
                 yield from drift(name="filler", l=dl).expand(parser)
-            elif dl < -1.0e-10:
+            elif dl < -1.0e-5:
                 elemtype = type(el).__name__.upper()
                 raise ValueError(f"{elemtype}({el.name!r}) is overlapping by {-dl} m")
 

--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -719,7 +719,8 @@ class _MadParser(UnorderedParser):
                     cav.HarmNumber = cav.Frequency / rev
                 if cav.HarmNumber < hn:
                     hn = cav.HarmNumber
-            params["_cell_harmnumber"] = hn
+            if cavities:
+                params["_cell_harmnumber"] = hn
 
         part = kwargs.get("particle", None)
         if isinstance(part, str):


### PR DESCRIPTION
This fixes a problem reported by @elafmusa in #850.

The fixes concern the length of RBEND magnets and the determination of the harmonic number.