### PR TITLE
Suppress a wrong warning when using linopt in beamline mode

### DIFF
--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -516,7 +516,7 @@ def _linopt(
 
     # Perform analysis
     vps, dtype, el0, els, wtype = analyze(mxx, ms)
-    tunes = _tunes(ring, orbit=orbit)
+    tunes = np.mod(np.angle(vps) / 2.0 / pi, 1.0)
 
     if (get_chrom or get_w) and mt.shape == (6, 6):
         f0 = ring.get_rf_frequency(cavpts=cavpts)

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -104,6 +104,9 @@ _WX_DTYPE = [
 _IDX_DTYPE = [("idx", np.uint32)]
 
 
+warnings.filterwarnings("always", category=AtWarning, module=__name__)
+
+
 def _twiss22(t12, alpha0, beta0):
     """Propagate Twiss parameters"""
     bbb = t12[:, 0, 1]
@@ -146,7 +149,7 @@ def _tunes(ring, **kwargs):
         _, vps = a_matrix(mt)
         tunes = np.mod(np.angle(vps) / 2.0 / pi, 1.0)
     except AtError:
-        warnings.warn(AtWarning("Unstable ring"))
+        warnings.warn(AtWarning("Unstable ring"), stacklevel=1)
         tunes = np.empty(nd)
         tunes[:] = np.nan
     return tunes
@@ -377,12 +380,12 @@ def _linopt(
                 dd0 = twiss_in["ddispersion"]
                 dalpha = twiss_in["dalpha"]
                 dbeta = twiss_in["dbeta"]
-            except (ValueError, KeyError):  # record arrays throw ValueError !
+            except (ValueError, KeyError) as exc:  # record arrays throw ValueError !
                 msg = (
                     "'get_w' option for a line requires 'twiss_in' calculated "
                     "with 'get_w' activated"
                 )
-                raise AtError(msg)
+                raise AtError(msg) from exc
 
             orbit = orbit + np.hstack((dd0, 1.0, 0.0)) * dp * dp
             dorbit = np.hstack((d0 + dd0 * dp, 1.0, 0.0))
@@ -959,7 +962,7 @@ def linopt_auto(ring: Lattice, *args, **kwargs):
     This is a convenience function to automatically switch to the faster
     :py:func:`linopt2` in case the *coupled* keyword argument is
     :py:obj:`False` **and** ring.is_6d is :py:obj:`False`.
-    Otherwise the default :py:func:`linopt6` is used
+    Otherwise, the default :py:func:`linopt6` is used
 
     Parameters: Same as :py:func:`.linopt2` or :py:func:`.linopt6`
 
@@ -972,7 +975,7 @@ def linopt_auto(ring: Lattice, *args, **kwargs):
     Returns:
         elemdata0:      Linear optics data at the entrance of the ring
         ringdata:       Lattice properties
-        elemdata:       Linear optics at the points refered to by *refpts*,
+        elemdata:       Linear optics at the points referred to by *refpts*,
           if refpts is :py:obj:`None` an empty lindata structure is returned.
 
     Warning:
@@ -1129,7 +1132,7 @@ def linopt(
                         of linear motion [1]
         chrom           [ksi_A , ksi_B], chromaticities ksi = d(nu)/(dP/P).
                         Only computed if 'get_chrom' is :py:obj:`True`
-        lindata         linear optics at the points refered to by refpts, if
+        lindata         linear optics at the points referred to by refpts, if
                         refpts is None an empty lindata structure is returned.
 
         lindata is a record array with fields:
@@ -1235,7 +1238,7 @@ def avlinopt(ring: Lattice, dp: float = 0.0, refpts: Refpts = None, **kwargs):
           are ignored.
 
     Returns:
-        elemdata:   Linear optics at the points refered to by *refpts*,
+        elemdata:   Linear optics at the points referred to by *refpts*,
           if refpts is :py:obj:`None` an empty lindata structure is returned.
         avebeta:    Average beta functions
           [:math:`\hat{\beta_x},\hat{\beta_y}`] at *refpts*


### PR DESCRIPTION
When using `linopt*`/`get_optics` in beam line mode by providing the `twiss_in` entry, a warning _"Unstable beam"_ sometime appeared. This is fixed here.

In addition, the execution time of linopt is reduced by 16% !