### PR TITLE
Set "periodicity" to 1 by default

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -98,12 +98,13 @@ class Lattice(list):
 
     # noinspection PyUnusedLocal
     def __init__(self, *args, iterator: Filter = None, scan: bool = False, **kwargs):
+        # noinspection PyUnresolvedReferences
         """
-        Lattice(elements, **params)
-        Lattice(filter, [filter, ...,] iterator=iter,**params)
+        Lattice(elements: Iterable[Element], **params)
+        Lattice(filter, [filter, ...,] iterator=iter, **params)
 
         Parameters:
-            elements: iterable of Element objects
+            elements: iterable of Element objects.
             iter: function called as :pycode:`iter(params, *args)`. It must
               return an iterable of :py:class:`.Element` objects for building
               the lattice. It must also fill the *params* dictionary providing
@@ -113,19 +114,18 @@ class Lattice(list):
               parameters will be set as Lattice attributes.
 
         Keyword Arguments:
-            name='':        Name of the lattice
-            energy:         Energy of the lattice
-            periodicity=1:  Number of periods
-            particle='relativistic': circulating particle. May be
-              'relativistic', 'electron', 'positron', 'proton'
-              or a Particle object
-            iterator=None:  custom iterator (see below)
-            *: all other keywords will be set as attributes of
-              the Lattice object
-            beam_current:   Total current in the beam, used for collective
-              effects
+            name (str): Name of the lattice, Default: "".
+            energy (float):  Energy of the beam.
+            periodicity (int): Number of periods. Default: 1. If <= 0, it will be
+              deduced from the sum of bending angles.
+            particle (Particle | str): circulating particle. May be "relativistic",
+              "electron", "positron", "proton", "antiproton", "posmuon", "negmuon"
+              or a Particle object. Default: "relativistic".
+            iterator:  custom iterator (see below). Default :py:obj:`None`.
+            *: all other keywords will be set as attributes of the Lattice object.
+            beam_current:   Total current in the beam, used for collective effects [A].
 
-        An iterator ``it`` is called as ``it(params, *args)`` where ``args``
+        An iterator ``it`` is called as :pycode:`it(params, *args)` where ``args``
         and ``params`` are the arguments of the ``Lattice`` constructor. It
         must yield the AT ``Elements`` for building the lattice. It must
         also fill its ``params`` dictionary argument, which will be used to
@@ -147,13 +147,12 @@ class Lattice(list):
         .. Note::
 
            It is possible to define a filling pattern for the beam using the
-           function ``ring.set_fillingpattern()``. The default configuration
+           function :pycode:`ring.set_fillingpattern()`. The default configuration
            (no arguments) is for single bunch and is the one loaded at lattice
            initialization. See function help for details.
            Changing ``Lattice.harmonic_number`` will reset the filling pattern
            to its default configuration.
-           The beam current can be changed with
-           ``Lattice.beam_current=current``
+           The beam current can be changed with :pycode:`Lattice.beam_current = current`
            The filling pattern and beam current are used by collective effects
            passmethods.
 
@@ -161,10 +160,8 @@ class Lattice(list):
         Examples:
             Chaining iterators (taken from ``load_mat``):
 
-            .. code-block:: python
-
-               Lattice(ringparam_filter, matfile_generator, filename
-                       iterator=params_filter, **params)
+            >>> ring = Lattice(ringparam_filter, matfile_generator, filename,
+                               iterator=params_filter, **params)
 
             ``matfile_generator(params, filename)``
                 opens filename and generates AT elements for each cell of the
@@ -1468,7 +1465,7 @@ def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None
 
     periodicity is taken from:
         1) The params dictionary
-        2) Sum of the bending angles of magnets
+        2) if periodicity <= 0, from the sum of the bending angles of magnets
     """
     el_energies = []
     thetas = []
@@ -1505,19 +1502,18 @@ def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None
                 warn(AtWarning('Inconsistent energy values, '
                                '"energy" set to {0}'.format(energy)))
 
-    if 'periodicity' not in params:
+    if params.setdefault("periodicity", 1) <= 0:
         # Guess periodicity from the bending angles of the lattice
         try:
             nbp = 2.0 * numpy.pi / sum(thetas)
         except ZeroDivisionError:
             periodicity = 1
-            warn(AtWarning('No bending in the cell, set "Periodicity" to 1'))
+            warn(AtWarning("No bending in the cell, set \"Periodicity\" to 1"))
         else:
             periodicity = int(round(nbp))
             if abs(periodicity - nbp) > _TWO_PI_ERROR:
-                warn(AtWarning('Non-integer number of cells: '
-                               '{0} -> {1}'.format(nbp, periodicity)))
-        params['periodicity'] = periodicity
+                warn(AtWarning(f"Non-integer number of cells: {nbp} -> {periodicity}"))
+        params["periodicity"] = periodicity
 
 
 Lattice.get_uint32_index = get_uint32_index

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -34,7 +34,7 @@ if sys.version_info.minor < 9:
 else:
     from typing import SupportsIndex
     from collections.abc import Callable, Iterable, Generator
-from warnings import warn
+import warnings
 
 import numpy as np
 
@@ -85,6 +85,7 @@ _DEFAULT_PASS = {
 
 # Don't warn on floating-point errors
 np.seterr(divide="ignore", invalid="ignore")
+warnings.filterwarnings("always", category=AtWarning, module=__name__)
 
 
 # noinspection PyAttributeOutsideInit
@@ -420,7 +421,7 @@ class Lattice(list):
             nbp = periodicity / n
             periodicity = int(round(nbp))
             if abs(periodicity - nbp) > _TWO_PI_ERROR:
-                warn(
+                warnings.warn(
                     AtWarning(
                         f"Non-integer number of cells: {self.periodicity}/{n}."
                         " Periodicity set to 1"
@@ -881,7 +882,7 @@ class Lattice(list):
         #                   .format(value, int(self.periodicity)))
         self._cell_harmnumber = cell_h
         if len(self._fillpattern) != value:
-            warn(
+            warnings.warn(
                 AtWarning(
                     "Harmonic number changed, resetting fillpattern to "
                     "default (single bunch)."
@@ -1322,7 +1323,7 @@ class Lattice(list):
         break_elems = np.reshape(break_elems, -1)
         # Check element lengths
         if not all(e.Length == 0 for e in break_elems):
-            warn(
+            warnings.warn(
                 AtWarning("Inserting elements with length!=0 may change the lattice"),
                 stacklevel=2,
             )
@@ -1480,7 +1481,7 @@ def type_filter(params, elems: Iterable[Element]) -> Generator[Element, None, No
                 radiate = True
             yield elem
         else:
-            warn(
+            warnings.warn(
                 AtWarning(f"item {idx} ({elem}) is not an AT element: " "ignored"),
                 stacklevel=2,
             )
@@ -1547,7 +1548,7 @@ def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None
             # Guess energy from the Energy attribute of the elements
             energy = params.setdefault("energy", max(energies))
             if min(energies) < max(energies):
-                warn(
+                warnings.warn(
                     AtWarning(
                         "Inconsistent energy values, " f'"energy" set to {energy}'
                     ),
@@ -1560,14 +1561,14 @@ def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None
             nbp = 2.0 * np.pi / sum(thetas)
         except ZeroDivisionError:
             periodicity = 1
-            warn(
+            warnings.warn(
                 AtWarning('No bending in the cell, set "Periodicity" to 1'),
                 stacklevel=2,
             )
         else:
             periodicity = int(round(nbp))
             if abs(periodicity - nbp) > _TWO_PI_ERROR:
-                warn(
+                warnings.warn(
                     AtWarning(f"Non-integer number of cells: {nbp} -> {periodicity}"),
                     stacklevel=2,
                 )

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -10,71 +10,81 @@ automatically imported.
 
 As an example, see the at.physics.orbit module
 """
+
 from __future__ import annotations
 
-__all__ = ['Lattice', 'Filter', 'type_filter', 'params_filter', 'lattice_filter',
-           'elem_generator', 'no_filter']
+__all__ = [
+    "Lattice",
+    "Filter",
+    "type_filter",
+    "params_filter",
+    "lattice_filter",
+    "elem_generator",
+    "no_filter",
+]
 
 import sys
 import copy
 import math
-from typing import Optional, Union
+
 if sys.version_info.minor < 9:
     from typing import Callable, Iterable, Generator
+
     SupportsIndex = int
 else:
     from typing import SupportsIndex
     from collections.abc import Callable, Iterable, Generator
 from warnings import warn
 
-import numpy
+import numpy as np
 
 from . import elements as elt
 from .elements import Element
 from .particle_object import Particle
 from .utils import AtError, AtWarning, Refpts
 from .utils import get_s_pos, get_elements, get_value_refpts, set_value_refpts
+
 # noinspection PyProtectedMember
 from .utils import get_uint32_index, get_bool_index, _refcount, Uint32Refpts
 from .utils import refpts_iterator, checktype, set_shift, set_tilt, get_geometry
 from ..constants import clight, e_mass
 
-_TWO_PI_ERROR = 1.E-4
+_TWO_PI_ERROR = 1.0e-4
 Filter = Callable[..., Iterable[Element]]
 
 _DEFAULT_PASS = {
     False: (
-        ('cavity_pass', elt.RFCavity, 'auto'),
-        ('dipole_pass', elt.Dipole, 'auto'),
-        ('quadrupole_pass', elt.Quadrupole, 'auto'),
-        ('wiggler_pass', elt.Wiggler, 'auto'),
-        ('sextupole_pass', elt.Sextupole, 'auto'),
-        ('octupole_pass', elt.Octupole, 'auto'),
-        ('multipole_pass', elt.Multipole, 'auto'),
-        ('collective_pass', elt.Collective, 'auto'),
-        ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
-        ('energyloss_pass', elt.EnergyLoss, 'auto'),
-        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto'),
-        ('simpleradiation_pass', elt.SimpleRadiation, 'auto')
+        ("cavity_pass", elt.RFCavity, "auto"),
+        ("dipole_pass", elt.Dipole, "auto"),
+        ("quadrupole_pass", elt.Quadrupole, "auto"),
+        ("wiggler_pass", elt.Wiggler, "auto"),
+        ("sextupole_pass", elt.Sextupole, "auto"),
+        ("octupole_pass", elt.Octupole, "auto"),
+        ("multipole_pass", elt.Multipole, "auto"),
+        ("collective_pass", elt.Collective, "auto"),
+        ("diffusion_pass", elt.QuantumDiffusion, "auto"),
+        ("energyloss_pass", elt.EnergyLoss, "auto"),
+        ("simplequantdiff_pass", elt.SimpleQuantDiff, "auto"),
+        ("simpleradiation_pass", elt.SimpleRadiation, "auto"),
     ),
     True: (
-        ('cavity_pass', elt.RFCavity, 'auto'),
-        ('dipole_pass', elt.Dipole, 'auto'),
-        ('quadrupole_pass', elt.Quadrupole, 'auto'),
-        ('wiggler_pass', elt.Wiggler, 'auto'),
-        ('sextupole_pass', elt.Sextupole, None),
-        ('octupole_pass', elt.Octupole, None),
-        ('multipole_pass', elt.Multipole, None),
-        ('collective_pass', elt.Collective, 'auto'),
-        ('diffusion_pass', elt.QuantumDiffusion, 'auto'),
-        ('energyloss_pass', elt.EnergyLoss, 'auto'),
-        ('simplequantdiff_pass', elt.SimpleQuantDiff, 'auto'),
-        ('simpleradiation_pass', elt.SimpleRadiation, 'auto')
-    )
+        ("cavity_pass", elt.RFCavity, "auto"),
+        ("dipole_pass", elt.Dipole, "auto"),
+        ("quadrupole_pass", elt.Quadrupole, "auto"),
+        ("wiggler_pass", elt.Wiggler, "auto"),
+        ("sextupole_pass", elt.Sextupole, None),
+        ("octupole_pass", elt.Octupole, None),
+        ("multipole_pass", elt.Multipole, None),
+        ("collective_pass", elt.Collective, "auto"),
+        ("diffusion_pass", elt.QuantumDiffusion, "auto"),
+        ("energyloss_pass", elt.EnergyLoss, "auto"),
+        ("simplequantdiff_pass", elt.SimpleQuantDiff, "auto"),
+        ("simpleradiation_pass", elt.SimpleRadiation, "auto"),
+    ),
 }
 
 # Don't warn on floating-point errors
-numpy.seterr(divide='ignore', invalid='ignore')
+np.seterr(divide="ignore", invalid="ignore")
 
 
 # noinspection PyAttributeOutsideInit
@@ -83,18 +93,34 @@ class Lattice(list):
 
     An AT lattice is a sequence of AT elements. In addition to :py:class:`list`
     methods, :py:class:`Lattice` supports
-    `extended indexing <https://numpy.org/doc/stable/user/basics.indexing.html
-    #advanced-indexing>`_ as a numpy :py:obj:`~numpy.ndarray`.
+    `extended indexing
+    <https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing>`_
+    as a numpy :py:obj:`~numpy.ndarray`.
     """
+
     # Attributes displayed:
-    _disp_attributes = ('name', 'energy', 'particle', 'periodicity',
-                        'harmonic_number', 'beam_current', 'nbunch')
+    _disp_attributes = (
+        "name",
+        "energy",
+        "particle",
+        "periodicity",
+        "harmonic_number",
+        "beam_current",
+        "nbunch",
+    )
     # excluded attributes
-    _excluded_attributes = ('nbunch', )
+    _excluded_attributes = ("nbunch",)
     # Attributes propagated in copies:
-    _std_attributes = ('name', '_energy', '_particle', 'periodicity',
-                       '_cell_harmnumber', '_radiation', '_beam_current',
-                       '_fillpattern')
+    _std_attributes = (
+        "name",
+        "_energy",
+        "_particle",
+        "periodicity",
+        "_cell_harmnumber",
+        "_radiation",
+        "_beam_current",
+        "_fillpattern",
+    )
 
     # noinspection PyUnusedLocal
     def __init__(self, *args, iterator: Filter = None, scan: bool = False, **kwargs):
@@ -185,7 +211,7 @@ class Lattice(list):
         else:
             elems = iterator(kwargs, *args)
 
-        super(Lattice, self).__init__(elems)
+        super().__init__(elems)
 
         # removing excluded attributes
         for attr in self._excluded_attributes:
@@ -196,10 +222,10 @@ class Lattice(list):
         kwargs.setdefault("particle", kwargs.pop("_particle", Particle()))
         kwargs.setdefault("beam_current", kwargs.pop("_beam_current", 0.0))
         # dummy initialization in case the harmonic number is not there
-        kwargs.setdefault("_fillpattern", numpy.ones(1))
+        kwargs.setdefault("_fillpattern", np.ones(1))
         # Remove temporary keywords
-        frequency: Optional[float] = kwargs.pop("_frequency", None)
-        cell_length: Optional[float] = kwargs.pop("_length", None)
+        frequency: float | None = kwargs.pop("_frequency", None)
+        cell_length: float | None = kwargs.pop("_length", None)
         cell_h = kwargs.pop("cell_harmnumber", kwargs.pop("_cell_harmnumber", math.nan))
         ring_h = kwargs.pop("harmonic_number", cell_h * periodicity)
 
@@ -215,7 +241,7 @@ class Lattice(list):
             rev = self.beta * clight / cell_length
             self._cell_harmnumber = int(round(frequency / rev))
             try:
-                fp = kwargs.pop("_fillpattern", numpy.ones(1))
+                fp = kwargs.pop("_fillpattern", np.ones(1))
                 self.set_fillpattern(bunches=fp)
             except AssertionError:
                 self.set_fillpattern()
@@ -223,40 +249,42 @@ class Lattice(list):
             self._cell_harmnumber = ring_h / periodicity
 
     def __getitem__(self, key):
-        try:                                # Integer
-            return super(Lattice, self).__getitem__(key.__index__())
+        try:  # Integer
+            return super().__getitem__(key.__index__())
         except (AttributeError, TypeError):
-            if isinstance(key, slice):      # Slice
+            if isinstance(key, slice):  # Slice
                 rg = range(*key.indices(len(self)))
-            else:                           # Array of integers or boolean
+            else:  # Array of integers or boolean
                 rg = get_uint32_index(self, key, endpoint=False)
-            return Lattice(elem_generator,
-                           (super(Lattice, self).__getitem__(i) for i in rg),
-                           iterator=self.attrs_filter)
+            return Lattice(
+                elem_generator,
+                (super(Lattice, self).__getitem__(i) for i in rg),
+                iterator=self.attrs_filter,
+            )
 
     def __setitem__(self, key, values):
-        try:                                # Integer or slice
-            super(Lattice, self).__setitem__(key, values)
-        except TypeError:                   # Array of integers or boolean
+        try:  # Integer or slice
+            super().__setitem__(key, values)
+        except TypeError:  # Array of integers or boolean
             rg = get_uint32_index(self, key, endpoint=False)
-            for i, v in zip(*numpy.broadcast_arrays(rg, values)):
-                super(Lattice, self).__setitem__(i, v)
+            for i, v in zip(*np.broadcast_arrays(rg, values)):
+                super().__setitem__(i, v)
 
     def __delitem__(self, key):
-        try:                                # Integer or slice
-            super(Lattice, self).__delitem__(key)
-        except TypeError:                   # Array of integers or boolean
+        try:  # Integer or slice
+            super().__delitem__(key)
+        except TypeError:  # Array of integers or boolean
             rg = get_uint32_index(self, key, endpoint=False)
             for i in reversed(rg):
-                super(Lattice, self).__delitem__(i)
+                super().__delitem__(i)
 
     def __repr__(self):
-        ks = ', '.join('{0}={1!r}'.format(k, v) for k, v in self.attrs.items())
-        return 'Lattice({0}, {1})'.format(super(Lattice, self).__repr__(), ks)
+        ks = ", ".join(f"{k}={v!r}" for k, v in self.attrs.items())
+        return f"Lattice({super().__repr__()}, {ks})"
 
     def __str__(self):
-        ks = ', '.join('{0}={1!r}'.format(k, v) for k, v in self.attrs.items())
-        return 'Lattice(<{0} elements>, {1})'.format(len(self), ks)
+        ks = ", ".join(f"{k}={v!r}" for k, v in self.attrs.items())
+        return f"Lattice(<{len(self)} elements>, {ks})"
 
     def __add__(self, elems):
         """Add elems, an iterable of AT elements, to the lattice"""
@@ -278,19 +306,19 @@ class Lattice(list):
             if isinstance(elem, elt.RFCavity):
                 cavities.append(elem)
                 elem.Energy = self._energy
-            elif elem.PassMethod.endswith('RadPass'):
+            elif elem.PassMethod.endswith("RadPass"):
                 elem.Energy = self._energy
-            elif hasattr(elem, 'Energy'):
+            elif hasattr(elem, "Energy"):
                 del elem.Energy
-            elif hasattr(elem, '_turnhistory'):
+            elif hasattr(elem, "_turnhistory"):
                 elem.clear_history(self)
-            length += getattr(elem, 'Length', 0.0)
+            length += getattr(elem, "Length", 0.0)
             if copy_elements:
                 yield elem.deepcopy()
             else:
                 yield elem
 
-        if cavities and not hasattr(self, '_cell_harmnumber'):
+        if cavities and not hasattr(self, "_cell_harmnumber"):
             cavities.sort(key=lambda el: el.Frequency)
             try:
                 self._cell_harmnumber = cavities[0].HarmNumber
@@ -299,7 +327,7 @@ class Lattice(list):
                 rev = self.beta * clight / length
                 frequency = cavities[0].Frequency
                 self._cell_harmnumber = int(round(frequency / rev))
-        self._radiation |= params.pop('_radiation')
+        self._radiation |= params.pop("_radiation")
 
     def insert(self, idx: SupportsIndex, elem: Element, copy_elements=False):
         r"""This method allow to insert an AT element in the lattice.
@@ -312,8 +340,9 @@ class Lattice(list):
                                  is used.
         """
         # scan the new element to update it
-        elist = list(self._addition_filter([elem],  # noqa: F841
-                     copy_elements=copy_elements))
+        elist = list(  # noqa: F841
+            self._addition_filter([elem], copy_elements=copy_elements)
+        )
         super().insert(idx, elem)
 
     def extend(self, elems: Iterable[Element], copy_elements=False):
@@ -333,7 +362,7 @@ class Lattice(list):
                                  If :py:obj:`True` deep copies of each
                                  element of elems are used
         """
-        if hasattr(self, '_energy'):
+        if hasattr(self, "_energy"):
             # When unpickling a Lattice, extend is called before the lattice
             # is initialized. So skip this.
             elems = self._addition_filter(elems, copy_elements=copy_elements)
@@ -379,6 +408,7 @@ class Lattice(list):
         Returns:
             newring (Lattice): the new repeated lattice
         """
+
         def copy_fun(elem, copy):
             if copy:
                 return elem.deepcopy()
@@ -390,20 +420,25 @@ class Lattice(list):
             nbp = periodicity / n
             periodicity = int(round(nbp))
             if abs(periodicity - nbp) > _TWO_PI_ERROR:
-                warn(AtWarning('Non-integer number of cells: {}/{}. Periodi'
-                               'city set to 1'.format(self.periodicity, n)))
+                warn(
+                    AtWarning(
+                        f"Non-integer number of cells: {self.periodicity}/{n}."
+                        " Periodicity set to 1"
+                    ),
+                    stacklevel=1,
+                )
                 periodicity = 1
-        hdict = dict(periodicity=periodicity)
+        hdict = {"periodicity": periodicity}
         try:
-            hdict.update(harmonic_number=self.cell_harmnumber*n*periodicity)
+            hdict.update(harmonic_number=self.cell_harmnumber * n * periodicity)
         except AttributeError:
             pass
         elems = (copy_fun(el, copy_elements) for _ in range(n) for el in self)
-        return Lattice(elem_generator, elems, iterator=self.attrs_filter,
-                       **hdict)
+        return Lattice(elem_generator, elems, iterator=self.attrs_filter, **hdict)
 
-    def concatenate(self, *lattices: Iterable[Element],
-                    copy_elements=False, copy=False):
+    def concatenate(
+        self, *lattices: Iterable[Element], copy_elements=False, copy=False
+    ):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection,PyRedeclaration
         """Concatenate several `Iterable[Element]` with the lattice
 
@@ -479,6 +514,7 @@ class Lattice(list):
     @property
     def attrs(self) -> dict:
         """Dictionary of lattice attributes"""
+
         def extattr(d):
             for k in self._disp_attributes:
                 d.pop(k, None)
@@ -488,14 +524,14 @@ class Lattice(list):
         # Standard attributes
         res = {k: v for k, v in extattr(vrs) if v is not None}
         # Custom attributes
-        res.update((k, v) for k, v in vrs.items() if not k.startswith('_'))
+        res.update((k, v) for k, v in vrs.items() if not k.startswith("_"))
         return res
 
     def rotate(self, n: int) -> Lattice:
         """Return a new lattice rotated left by n elements"""
         if len(self) == 0:
             return self.copy()
-        n = n % len(self)      # works for n<0
+        n = n % len(self)  # works for n<0
         return self[n:] + self[:n]
 
     def update(self, *args, **kwargs) -> None:
@@ -507,7 +543,7 @@ class Lattice(list):
         Update the lattice attributes with the given values
         """
         attrs = dict(*args, **kwargs)
-        for (key, value) in attrs.items():
+        for key, value in attrs.items():
             setattr(self, key, value)
 
     def copy(self) -> Lattice:
@@ -529,20 +565,19 @@ class Lattice(list):
         Returns:
             newring:    New Lattice object
         """
+
         def slice_generator(_):
             check = get_bool_index(self, refpts)
             for el, ok in zip(self, check):
                 if ok and (slices > 1):
-                    frac = numpy.ones(slices) / slices
-                    for elem in el.divide(frac):
-                        yield elem
+                    frac = np.ones(slices) / slices
+                    yield from el.divide(frac)
                 else:
                     yield el
 
         return Lattice(slice_generator, iterator=self.attrs_filter)
 
-    def slice(self, size: Optional[float] = None, slices: Optional[int] = 1) \
-            -> Lattice:
+    def slice(self, size: float | None = None, slices: int | None = 1) -> Lattice:
         """Create a new lattice by slicing the range of interest into small
         elements
 
@@ -555,14 +590,14 @@ class Lattice(list):
         Returns:
             newring:    New Lattice object
         """
+
         def slice_generator(_, ibeg, iend):
             yield from self[:ibeg]
             for elem in self[ibeg:iend]:
                 nslices = int(math.ceil(elem.Length / size))
                 if nslices > 1:
-                    frac = numpy.ones(nslices) / nslices
-                    for el in elem.divide(frac):
-                        yield el
+                    frac = np.ones(nslices) / nslices
+                    yield from elem.divide(frac)
                 else:
                     yield elem
             yield from self[iend:]
@@ -572,11 +607,17 @@ class Lattice(list):
             smin, smax = s_range
             size = (smax - smin) / slices
         i_range = self.i_range
-        return Lattice(slice_generator, i_range[0], i_range[-1],
-                       iterator=self.attrs_filter, s_range=s_range)
+        return Lattice(
+            slice_generator,
+            i_range[0],
+            i_range[-1],
+            iterator=self.attrs_filter,
+            s_range=s_range,
+        )
 
-    def attrs_filter(self, params: dict, elem_filter: Filter, *args) \
-            -> Iterable[Element]:
+    def attrs_filter(
+        self, params: dict, elem_filter: Filter, *args
+    ) -> Iterable[Element]:
         """Filter function which duplicates the lattice attributes
 
         Parameters:
@@ -592,9 +633,8 @@ class Lattice(list):
         return elem_filter(params, *args)
 
     @property
-    def s_range(self) -> Union[None, tuple[float, float]]:
-        """Range of interest: (s_min, s_max). :py:obj:`None` means
-          the full cell."""
+    def s_range(self) -> None | tuple[float, float]:
+        """Range of interest: (s_min, s_max). :py:obj:`None` means the full cell."""
         try:
             return self._s_range
         except AttributeError:
@@ -603,12 +643,11 @@ class Lattice(list):
 
     # noinspection PyAttributeOutsideInit
     @s_range.setter
-    def s_range(self, value: Optional[tuple[float, float]]):
+    def s_range(self, value: tuple[float, float] | None):
         spos = self.get_s_pos(range(len(self) + 1))
         if value is None:
             value = (0.0, spos[-1])
-        ok = numpy.flatnonzero(
-            numpy.logical_and(spos > value[0], spos < value[1]))
+        ok = np.flatnonzero(np.logical_and(spos > value[0], spos < value[1]))
         if len(ok) > 0:
             i1 = max(ok[0] - 1, 0)
             i2 = min(ok[-1] + 1, len(self))
@@ -636,12 +675,13 @@ class Lattice(list):
     def energy(self, energy: float):
         # Set the Energy attribute of radiating elements
         for elem in self:
-            if (isinstance(elem, (elt.RFCavity, elt.Wiggler))
-                    or elem.PassMethod.endswith('RadPass')):
+            if isinstance(
+                elem, (elt.RFCavity, elt.Wiggler)
+            ) or elem.PassMethod.endswith("RadPass"):
                 elem.Energy = energy
         # Set the energy attribute of the Lattice
         # Use a numpy scalar to allow division by zero
-        # self._energy = numpy.array(energy, dtype=float)
+        # self._energy = np.array(energy, dtype=float)
         self._energy = energy
 
     @property
@@ -675,9 +715,10 @@ class Lattice(list):
         """
         try:
             return self._cell_harmnumber
-        except AttributeError:
-            raise AttributeError('harmonic_number undefined: '
-                                 'No cavity found in the lattice') from None
+        except AttributeError as exc:
+            raise AttributeError(
+                "harmonic_number undefined: No cavity found in the lattice"
+            ) from exc
 
     @property
     def circumference(self) -> float:
@@ -706,7 +747,7 @@ class Lattice(list):
         return self._particle
 
     @particle.setter
-    def particle(self, particle: Union[str, Particle]):
+    def particle(self, particle: str | Particle):
         if isinstance(particle, Particle):
             self._particle = particle
         else:
@@ -721,7 +762,7 @@ class Lattice(list):
             if e.is_collective:
                 e.clear_history(ring=self)
 
-    def set_fillpattern(self, bunches: Union[int, numpy.ndarray] = 1):
+    def set_fillpattern(self, bunches: int | np.ndarray = 1):
         """Function to generate the filling pattern lof the ring.
         The filling pattern is computed as:
 
@@ -742,29 +783,28 @@ class Lattice(list):
         """
         if isinstance(bunches, int):
             if self.harmonic_number % bunches == 0:
-                fp = numpy.zeros(self.harmonic_number)
-                fp[::int(self.harmonic_number/bunches)] = 1
+                fp = np.zeros(self.harmonic_number)
+                fp[:: int(self.harmonic_number / bunches)] = 1
             else:
-                raise AtError('Harmonic number has to be a '
-                              'multiple of the scalar input '
-                              'bunches')
-        elif numpy.isscalar(bunches):
-            raise AtError('Scalar input for bunches must be '
-                          'an integer')
+                raise AtError(
+                    "Harmonic number has to be a multiple of the scalar input bunches"
+                )
+        elif np.isscalar(bunches):
+            raise AtError("Scalar input for bunches must be an integer")
         else:
-            bunches = bunches.astype(dtype=float, casting='safe',
-                                     copy=False)
-            assert len(bunches) == self.harmonic_number, \
-                'bunches array input has to be of shape ({0},)' \
-                .format(self.harmonic_number)
-            assert numpy.all(bunches >= 0.0), \
-                'bunches array can contain only positive numbers'
+            bunches = bunches.astype(dtype=float, casting="safe", copy=False)
+            assert (
+                len(bunches) == self.harmonic_number
+            ), f"bunches array input has to be of shape ({self.harmonic_number},)"
+            assert np.all(
+                bunches >= 0.0
+            ), "bunches array can contain only positive numbers"
             fp = bunches
-        self._fillpattern = fp/numpy.sum(fp)
+        self._fillpattern = fp / np.sum(fp)
         self.set_wake_turnhistory()
 
     @property
-    def fillpattern(self) -> numpy.ndarray:
+    def fillpattern(self) -> np.ndarray:
         """Filling pattern describing the bunch relative
         amplitudes such that ``sum(fillpattern)=1``
         """
@@ -779,9 +819,9 @@ class Lattice(list):
         self.set_fillpattern(value)
 
     @property
-    def bunch_list(self) -> numpy.ndarray:
+    def bunch_list(self) -> np.ndarray:
         """Indices of filled bunches"""
-        return numpy.flatnonzero(self._fillpattern)
+        return np.flatnonzero(self._fillpattern)
 
     def get_beam_current(self):
         return self._beam_current
@@ -794,27 +834,25 @@ class Lattice(list):
     beam_current = property(get_beam_current, set_beam_current)
 
     @property
-    def bunch_currents(self) -> numpy.ndarray:
+    def bunch_currents(self) -> np.ndarray:
         """Bunch currents [A]"""
-        return self.beam_current * \
-            self._fillpattern[self._fillpattern > 0]
+        return self.beam_current * self._fillpattern[self._fillpattern > 0]
 
     @property
-    def bunch_spos(self) -> numpy.ndarray:
+    def bunch_spos(self) -> np.ndarray:
         """Bunch position around the ring [m]"""
         try:
-            circ = self.beta * clight * \
-                self.harmonic_number/self.rf_frequency
+            circ = self.beta * clight * self.harmonic_number / self.rf_frequency
         except AtError:
             circ = self.circumference
-        bs = circ/len(self._fillpattern)
-        allpos = bs*numpy.arange(len(self._fillpattern))
+        bs = circ / len(self._fillpattern)
+        allpos = bs * np.arange(len(self._fillpattern))
         return allpos[self._fillpattern > 0]
 
     @property
     def nbunch(self) -> int:
         """Number of bunches"""
-        return numpy.count_nonzero(self._fillpattern)
+        return np.count_nonzero(self._fillpattern)
 
     @property
     def harmonic_number(self) -> int:
@@ -826,24 +864,30 @@ class Lattice(list):
         """
         try:
             return int(self.periodicity * self._cell_harmnumber)
-        except AttributeError:
-            raise AttributeError('harmonic_number undefined: '
-                                 'No cavity found in the lattice') from None
+        except AttributeError as exc:
+            raise AttributeError(
+                "harmonic_number undefined: " "No cavity found in the lattice"
+            ) from exc
 
     @harmonic_number.setter
     def harmonic_number(self, value):
         cell_h = float(value) / self.periodicity
         # check on ring
-        if value-round(value) != 0:
-            raise AtError('harmonic number ({}) must be integer'.format(value))
+        if value - round(value) != 0:
+            raise AtError(f"harmonic number ({value}) must be integer")
         # check on cell
         # if cell_h-round(cell_h) != 0:
         #     raise AtError('harmonic number ({}) must be a multiple of {}'
         #                   .format(value, int(self.periodicity)))
         self._cell_harmnumber = cell_h
         if len(self._fillpattern) != value:
-            warn(AtWarning('Harmonic number changed, resetting fillpattern to '
-                           'default (single bunch)'))
+            warn(
+                AtWarning(
+                    "Harmonic number changed, resetting fillpattern to "
+                    "default (single bunch)."
+                ),
+                stacklevel=1,
+            )
             self.set_fillpattern()
 
     @property
@@ -862,7 +906,7 @@ class Lattice(list):
             return 1.0
         else:
             gamma = float(self.energy / rest_energy)
-            return math.sqrt(1.0 - 1.0/gamma/gamma)
+            return math.sqrt(1.0 - 1.0 / gamma / gamma)
 
     # noinspection PyPep8Naming
     @property
@@ -871,7 +915,7 @@ class Lattice(list):
         rest_energy = self.particle.rest_energy
         if rest_energy == 0.0:
             rest_energy = e_mass
-        return math.sqrt(self.energy**2 - rest_energy**2)/clight
+        return math.sqrt(self.energy**2 - rest_energy**2) / clight
 
     @property
     def is_6d(self) -> bool:
@@ -907,13 +951,14 @@ class Lattice(list):
         :py:class:`RFCavity`
         """
         for elem in self:
-            if elem.PassMethod.endswith('CavityPass'):
+            if elem.PassMethod.endswith("CavityPass"):
                 return True
         return False
 
     # noinspection PyShadowingNames
-    def modify_elements(self, elem_modify: Callable,
-                        copy: Optional[bool] = True, **kwargs):
+    def modify_elements(
+        self, elem_modify: Callable, copy: bool | None = True, **kwargs
+    ):
         """Modify selected elements, in-place or in a lattice copy
 
         Parameters:
@@ -955,7 +1000,7 @@ class Lattice(list):
                 if elem.longt_motion:
                     radiate = True
                 yield elem
-            params['_radiation'] = radiate
+            params["_radiation"] = radiate
 
         if copy:
             return Lattice(lattice_copy, iterator=self.attrs_filter, **kwargs)
@@ -983,24 +1028,26 @@ class Lattice(list):
             for elem in self:
                 new_pass = getpass(elem)
                 if new_pass:
-                    elem = elem.set_longt_motion(enable, new_pass=new_pass,
-                                                 copy=True, **vargs)
+                    elem = elem.set_longt_motion(
+                        enable, new_pass=new_pass, copy=True, **vargs
+                    )
                 if elem.longt_motion:
                     radiate = True
                 yield elem
-            params['_radiation'] = radiate
+            params["_radiation"] = radiate
 
-        cp = kwargs.pop('copy', False)
+        cp = kwargs.pop("copy", False)
         if len(args) > 0:
+
             def getpass(elem):
-                return 'auto' if isinstance(elem, args) else None
+                return "auto" if isinstance(elem, args) else None
 
             if not all(issubclass(cl, elt.LongtMotion) for cl in args):
-                raise TypeError("All arguments must be subclasses of"
-                                " 'LongtMotion'")
+                raise TypeError("All arguments must be subclasses of 'LongtMotion'")
             if len(kwargs) > 0:
-                raise AtError('No keyword is allowed in this mode')
+                raise AtError("No keyword is allowed in this mode")
         else:
+
             def getpass(elem):
                 for eltype, psm in pass_table:
                     if isinstance(elem, eltype):
@@ -1014,7 +1061,7 @@ class Lattice(list):
 
             # Look for global defaults
             try:
-                all_pass = kwargs.pop('all_pass')
+                all_pass = kwargs.pop("all_pass")
             except KeyError:
                 allset = False
             else:
@@ -1022,14 +1069,14 @@ class Lattice(list):
             # Build table of PassMethods
             pass_table = [passm(*defs) for defs in _DEFAULT_PASS[enable]]
 
-        vargs = dict(energy=self.energy) if enable else {}
+        vargs = {"energy": self.energy} if enable else {}
         if cp:
             return Lattice(lattice_copy, iterator=self.attrs_filter, **kwargs)
         else:
             lattice_modify()
 
     # noinspection PyShadowingNames,PyIncorrectDocstring
-    def enable_6d(self, *args, **kwargs) -> Optional[Lattice]:
+    def enable_6d(self, *args, **kwargs) -> Lattice | None:
         # noinspection PyUnresolvedReferences
         r"""
         enable_6d(elem_class[, elem_class]..., copy=False)
@@ -1116,8 +1163,7 @@ class Lattice(list):
             Returns a new lattice with collective effects turned ON and nothing
             else changed
 
-            >>> newring = ring.enable_6d(all_pass=None, collective_pass='auto',
-            ... copy=True)
+            >>> newring = ring.enable_6d(all_pass=None, collective_pass="auto", copy=True)
 
             Same as the previous example, using the keyword syntax.
 
@@ -1128,7 +1174,7 @@ class Lattice(list):
         return self._set_6d(True, *args, **kwargs)
 
     # noinspection PyShadowingNames,PyIncorrectDocstring
-    def disable_6d(self, *args, **kwargs) -> Optional[Lattice]:
+    def disable_6d(self, *args, **kwargs) -> Lattice | None:
         # noinspection PyUnresolvedReferences
         r"""
         disable_6d(elem_class[, elem_class]... , copy=False)
@@ -1207,7 +1253,7 @@ class Lattice(list):
 
             Turn cavities OFF (nothing else modified).
 
-            >>> ring.disable_6d(all_pass=None, cavity_pass='auto')
+            >>> ring.disable_6d(all_pass=None, cavity_pass="auto")
 
             Same as the previous example, but using the keyword syntax.
 
@@ -1216,8 +1262,9 @@ class Lattice(list):
             Return a new Lattice (shallow copy of `ring`) with everything
             turned OFF except RF cavities.
 
-            >>> newring = ring.disable_6d(all_pass=None,
-            ... sextupole_pass='DriftPass', copy=True)
+            >>> newring = ring.disable_6d(
+            ...     all_pass=None, sextupole_pass="DriftPass", copy=True
+            ... )
 
             Return a new Lattice (shallow copy of `ring`) with sextupoles
             turned into Drifts (turned off) and everything else unchangedd.
@@ -1271,18 +1318,19 @@ class Lattice(list):
 
         # set default insertion
         if break_elems is None:
-            break_elems = elt.Marker('sbreak')
-        break_elems = numpy.reshape(break_elems, -1)
+            break_elems = elt.Marker("sbreak")
+        break_elems = np.reshape(break_elems, -1)
         # Check element lengths
         if not all(e.Length == 0 for e in break_elems):
-            warn(AtWarning(
-                 "Inserting elements with length!=0 may change the lattice"))
+            warn(
+                AtWarning("Inserting elements with length!=0 may change the lattice"),
+                stacklevel=2,
+            )
         # broadcast break_s and break_elems to arrays of same size
         # and create an iterator over the elements to be inserted
-        iter_mk = zip(*numpy.broadcast_arrays(break_s, break_elems))
+        iter_mk = zip(*np.broadcast_arrays(break_s, break_elems))
 
-        return Lattice(sbreak_iterator, iter_mk,
-                       iterator=self.attrs_filter, **kwargs)
+        return Lattice(sbreak_iterator, iter_mk, iterator=self.attrs_filter, **kwargs)
 
     def reduce(self, **kwargs) -> Lattice:
         """Removes all elements with an ``IdentityPass`` PassMethod and merges
@@ -1299,6 +1347,7 @@ class Lattice(list):
                 ``IdentityPass`` PassMethod. Default: keep :py:class:`.Monitor`
                 and :py:class:`.RFCavity` elements
         """
+
         def reduce_filter(_, itelem):
             try:
                 elem = next(itelem).copy()
@@ -1312,14 +1361,15 @@ class Lattice(list):
                     elem = nxt.copy()
             yield elem
 
-        kp = get_bool_index(self, lambda el: el.PassMethod != 'IdentityPass')
+        kp = get_bool_index(self, lambda el: el.PassMethod != "IdentityPass")
         try:
-            keep = get_bool_index(self, kwargs.pop('keep'))
+            keep = get_bool_index(self, kwargs.pop("keep"))
         except KeyError:
             keep = get_bool_index(self, checktype((elt.Monitor, elt.RFCavity)))
 
-        return Lattice(reduce_filter, self.select(kp | keep),
-                       iterator=self.attrs_filter, **kwargs)
+        return Lattice(
+            reduce_filter, self.select(kp | keep), iterator=self.attrs_filter, **kwargs
+        )
 
     def replace(self, refpts: Refpts, **kwargs) -> Lattice:
         """Return a shallow copy of the lattice replacing the selected
@@ -1330,11 +1380,10 @@ class Lattice(list):
         """
         check = get_bool_index(self, refpts)
         elems = (el.deepcopy() if ok else el for el, ok in zip(self, check))
-        return Lattice(elem_generator, elems,
-                       iterator=self.attrs_filter, **kwargs)
+        return Lattice(elem_generator, elems, iterator=self.attrs_filter, **kwargs)
 
     # Obsolete methods kept for compatibility
-    def radiation_on(self, *args, **kwargs) -> Optional[Lattice]:
+    def radiation_on(self, *args, **kwargs) -> Lattice | None:
         """Obsolete. Turn longitudinal motion on
 
         The function name is misleading, since the function deals with
@@ -1346,11 +1395,10 @@ class Lattice(list):
         See Also:
             :py:meth:`.enable_6d`
         """
-        kwargs.update(
-            zip(('cavity_pass', 'dipole_pass', 'quadrupole_pass'), args))
+        kwargs.update(zip(("cavity_pass", "dipole_pass", "quadrupole_pass"), args))
         return self._set_6d(True, **kwargs)
 
-    def radiation_off(self, *args, **kwargs) -> Optional[Lattice]:
+    def radiation_off(self, *args, **kwargs) -> Lattice | None:
         """Obsolete. Turn longitudinal motion off
 
         The function name is misleading, since the function deals with
@@ -1362,8 +1410,7 @@ class Lattice(list):
         See Also:
             :py:meth:`disable_6d`
         """
-        kwargs.update(
-            zip(('cavity_pass', 'dipole_pass', 'quadrupole_pass'), args))
+        kwargs.update(zip(("cavity_pass", "dipole_pass", "quadrupole_pass"), args))
         return self._set_6d(False, **kwargs)
 
     @property
@@ -1433,9 +1480,11 @@ def type_filter(params, elems: Iterable[Element]) -> Generator[Element, None, No
                 radiate = True
             yield elem
         else:
-            warn(AtWarning('item {0} ({1}) is not an AT element: '
-                           'ignored'.format(idx, elem)))
-    params['_radiation'] = radiate
+            warn(
+                AtWarning(f"item {idx} ({elem}) is not an AT element: " "ignored"),
+                stacklevel=2,
+            )
+    params["_radiation"] = radiate
 
 
 def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None, None]:
@@ -1475,44 +1524,53 @@ def params_filter(params, elem_filter: Filter, *args) -> Generator[Element, None
     for elem in elem_filter(params, *args):
         if isinstance(elem, elt.RFCavity):
             cavities.append(elem)
-        elif hasattr(elem, 'Energy'):
+        elif hasattr(elem, "Energy"):
             el_energies.append(elem.Energy)
             del elem.Energy
         if isinstance(elem, elt.Dipole):
             thetas.append(elem.BendingAngle)
-        cell_length += getattr(elem, 'Length', 0.0)
+        cell_length += getattr(elem, "Length", 0.0)
         yield elem
 
-    params['_length'] = cell_length
-    cav_energies = [el.Energy for el in cavities if hasattr(el, 'Energy')]
+    params["_length"] = cell_length
+    cav_energies = [el.Energy for el in cavities if hasattr(el, "Energy")]
     if cavities:
         cavities.sort(key=lambda el: el.Frequency)
         c0 = cavities[0]
-        params.setdefault('harmonic_number',
-                          getattr(c0, 'HarmNumber', math.nan))
+        params.setdefault("harmonic_number", getattr(c0, "HarmNumber", math.nan))
         # params['_harmnumber'] = getattr(c0, 'HarmNumber', math.nan)
-        params['_frequency'] = getattr(c0, 'Frequency', None)
+        params["_frequency"] = getattr(c0, "Frequency", None)
 
-    if 'energy' not in params:
+    if "energy" not in params:
         energies = cav_energies or el_energies
         if energies:
             # Guess energy from the Energy attribute of the elements
-            energy = params.setdefault('energy',  max(energies))
+            energy = params.setdefault("energy", max(energies))
             if min(energies) < max(energies):
-                warn(AtWarning('Inconsistent energy values, '
-                               '"energy" set to {0}'.format(energy)))
+                warn(
+                    AtWarning(
+                        "Inconsistent energy values, " f'"energy" set to {energy}'
+                    ),
+                    stacklevel=2,
+                )
 
     if params.setdefault("periodicity", 1) <= 0:
         # Guess periodicity from the bending angles of the lattice
         try:
-            nbp = 2.0 * numpy.pi / sum(thetas)
+            nbp = 2.0 * np.pi / sum(thetas)
         except ZeroDivisionError:
             periodicity = 1
-            warn(AtWarning("No bending in the cell, set \"Periodicity\" to 1"))
+            warn(
+                AtWarning('No bending in the cell, set "Periodicity" to 1'),
+                stacklevel=2,
+            )
         else:
             periodicity = int(round(nbp))
             if abs(periodicity - nbp) > _TWO_PI_ERROR:
-                warn(AtWarning(f"Non-integer number of cells: {nbp} -> {periodicity}"))
+                warn(
+                    AtWarning(f"Non-integer number of cells: {nbp} -> {periodicity}"),
+                    stacklevel=2,
+                )
         params["periodicity"] = periodicity
 
 

--- a/pyat/at/load/matfile.py
+++ b/pyat/at/load/matfile.py
@@ -157,6 +157,7 @@ def ringparam_filter(
         else:
             yield elem
     params["_radiation"] = radiate
+    params.setdefault("periodicity", 0)
 
     if len(ringparams) > 1:
         warn(

--- a/pyat/test/test_lattice_object.py
+++ b/pyat/test/test_lattice_object.py
@@ -25,7 +25,7 @@ def test_lattice_energy_radiation_periodicity():
         Energy=5.0e6,
         PassMethod="BndMPoleSymplectic4RadPass",
     )
-    lat = Lattice([d], name="lattice", energy=3.0e6)
+    lat = Lattice([d], name="lattice", periodicity=0, energy=3.0e6)
     assert lat.energy == 3.0e6
     assert lat.periodicity == 32
     assert lat.radiation is True
@@ -35,7 +35,7 @@ def test_lattice_energy_radiation_periodicity():
 def test_lattice_voltage_harmonic_number():
     rf = elements.RFCavity("rf", 0, 0.2e6, 0.5e9, 5, 3.0e6)
     d = elements.Dipole("d1", 2.99792458, BendingAngle=numpy.pi / 5)
-    lat = Lattice([rf, d], name="lattice")
+    lat = Lattice([rf, d], name="lattice", periodicity=0)
     assert lat.energy == 3.0e6
     assert lat.periodicity == 10
     assert lat.rf_voltage == 2e6


### PR DESCRIPTION
Following the discussion in https://github.com/atcollab/at/pull/837#issuecomment-2411445444, this PR modifies the behaviour of the Lattice creation:

- for a lattice initialised from a sequence of elements, the periodicity will be set to 1 by default. Up to now it was deduced from the total bending angle. This is also the case when creating lattices form "foreign" files (MAD and Elegant) which have no notion of periodicity,
- however, the periodicity is still saved and retrieved when saving/loading `.m`, `.mat` and  `.json` files. So nothing changes there,
- the previous behaviour (automatic determination) can now be obtained by specifying `periodicity=0`.

The idea is that the periodicity will be set to 1 unless it is **explicitly set** to something else. This should avoid part of the unexpected behaviour linked to `periodicity`, at the cost of a slight behaviour change/