### PR TITLE
add EnergyLossRadPass to newmethods in atdiffmat.m

### DIFF
--- a/atmat/atphysics/Radiation/atdiffmat.m
+++ b/atmat/atphysics/Radiation/atdiffmat.m
@@ -15,7 +15,8 @@ function [BCUM,Batbeg] = atdiffmat(ring,varargin)
 
 newmethods = {'BndMPoleSymplectic4RadPass', ...
               'StrMPoleSymplectic4RadPass', ...
-              'ExactMultipoleRadPass'};
+              'ExactMultipoleRadPass', ...
+              'EnergyLossRadPass'};
 
 NumElements=length(ring);
 

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -32,6 +32,7 @@ _new_methods = {
     "StrMPoleSymplectic4RadPass",
     "ExactMultipoleRadPass",
     "GWigSymplectic4RadPass",
+    "EnergyLossRadPass",
 }
 
 _NSTEP = 60  # nb slices in a wiggler period


### PR DESCRIPTION
Dear all,
this PR fixes an issue described in #865 , where the function atx fails to compute all parameters when there is an `EnergyLoss` in the ring.

The pass method `EnergyLossRadPass` is added to atdiffmat cell called `newmethods`.