### PR TITLE
Fix Matlab PassMethod type

### DIFF
--- a/atmat/atphysics/Radiation/atdiffmat.m
+++ b/atmat/atphysics/Radiation/atdiffmat.m
@@ -62,7 +62,7 @@ Batbeg=[zr;cellfun(@cumulb,ring,orbit,'UniformOutput',false)];
     
     function elem=substitute(elem)
         if ~any(strcmp(elem.PassMethod, newmethods))
-            elem.PassMethod = "BndMPoleSymplectic4RadPass";
+            elem.PassMethod = 'BndMPoleSymplectic4RadPass';
         end
     end
 end


### PR DESCRIPTION
#865 revealed another bug in Matlab: The PassMethod name substituted for the "old" *RadPass methods must be a "char array" and not a "string". This explains the strange error message reported in #865 and prevents using methods like `BndMPoleSymplectic4E2RadPass`.