### PR TITLE
Fix ohmienvelope with wigglers

### DIFF
--- a/atmat/atphysics/Radiation/atdiffmat.m
+++ b/atmat/atphysics/Radiation/atdiffmat.m
@@ -15,7 +15,9 @@ function [BCUM,Batbeg] = atdiffmat(ring,varargin)
 
 newmethods = {'BndMPoleSymplectic4RadPass', ...
               'StrMPoleSymplectic4RadPass', ...
-              'ExactMultipoleRadPass'};
+              'ExactMultipoleRadPass',...
+              'GWigSymplecticRadPass',...
+              'EnergyLossRadPass'};
 
 NumElements=length(ring);
 
@@ -62,7 +64,7 @@ Batbeg=[zr;cellfun(@cumulb,ring,orbit,'UniformOutput',false)];
     
     function elem=substitute(elem)
         if ~any(strcmp(elem.PassMethod, newmethods))
-            elem.PassMethod = "BndMPoleSymplectic4RadPass";
+            elem.PassMethod = 'BndMPoleSymplectic4RadPass';
         end
     end
 end

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -32,6 +32,7 @@ _new_methods = {
     "StrMPoleSymplectic4RadPass",
     "ExactMultipoleRadPass",
     "GWigSymplecticRadPass",
+    "EnergyLossRadPass",
 }
 
 _NSTEP = 60  # nb slices in a wiggler period

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -31,7 +31,7 @@ _new_methods = {
     "BndMPoleSymplectic4RadPass",
     "StrMPoleSymplectic4RadPass",
     "ExactMultipoleRadPass",
-    "GWigSymplectic4RadPass",
+    "GWigSymplecticRadPass",
 }
 
 _NSTEP = 60  # nb slices in a wiggler period


### PR DESCRIPTION
Fixes #869. ohmienvelope fails with wigglers because of a typo in passmethod names

This also includes similar bug fixes in the same files in #868 and #866