### PR TITLE
Upgrade tests for new GitHub runners

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,24 +15,19 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            python-version: '3.7'
-          - os: macos-latest
-            python-version: '3.7'
-          - os: macos-latest
-            python-version: '3.8'
-          - os: macos-latest
-            python-version: '3.9'
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
         include:
           - os: macos-13
             python-version: '3.7'
           - os: macos-13
             python-version: '3.8'
-          - os: macos-13
-            python-version: '3.9'
+          - os: ubuntu-22.04
+            python-version: '3.7'
+          - os: ubuntu-22.04
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.8'
 
 
     steps:


### PR DESCRIPTION
GitHub just switches to ubuntu 24.04 which does not run python 3.7 and 3.8.

The new test sequences will now test for python 3.9 to 3.13 on 4 runners instead of 3:

`macos-13(Intel), macos-latest(arm), windows-latest, ubuntu-latest`

and additionally tests for python 3.7 and 3.8 where they are available, so on `macos-13, ubuntu-22.04 and windows-latest`

This increases the number of tests from 20 to 25 but covers all the possibilities and will be easier to maintain in the future.