### PR TITLE
remove seed from `atQuantumDiff.m` help

### DIFF
--- a/atmat/lattice/element_creation/atQuantDiff.m
+++ b/atmat/lattice/element_creation/atQuantDiff.m
@@ -1,5 +1,5 @@
 function elem=atQuantDiff(fname,varargin)
-%atQuantDiff creates a quantum diffusion element
+%atQuantDiff creates a quantum diffusion element.
 %
 %ELEM=ATQUANTDIFF(FAMNAME,DIFFMAT) uses the given diffusion matrix
 %   FAMNAME:   family name
@@ -13,6 +13,10 @@ function elem=atQuantDiff(fname,varargin)
 %   matrix of the ring without computing the closed orbit
 %   ORBIT:	closed orbit at beginning of the ring 
 %           (this option is useful for the islands)
+%
+%The default pass method is 'QuantDiffPass' which uses a global
+%pseudo-random pcg32 stream inplemented in C. More details at:
+%https://github.com/atcollab/at/discussions/879
 %
 %See also quantumDiff
 

--- a/atmat/lattice/element_creation/atQuantDiff.m
+++ b/atmat/lattice/element_creation/atQuantDiff.m
@@ -14,10 +14,6 @@ function elem=atQuantDiff(fname,varargin)
 %   ORBIT:	closed orbit at beginning of the ring 
 %           (this option is useful for the islands)
 %
-%  The optional field Seed can be added. In that case, the seed of the
-%  random number generator is set at the first turn.
-%  ELEM=ATQUANTDIFF(FAMNANE,RING,'Seed',4)
-%
 %See also quantumDiff
 
 [rsrc,arg,method]=decodeatargs({[],'QuantDiffPass'},varargin);


### PR DESCRIPTION
Dear all,
this PR modifies the help message of the function `atQuantDiff` in AT matlab.
As discussed in https://github.com/atcollab/at/discussions/879  the seed parameter is not used.
I add a few lines to include the Default pass method  and the the pseudo-random stream.

Best regards,
o