### PR TITLE
Fix OpenMP compilation

### DIFF
--- a/atintegrators/BndMPoleSymplectic4RadPass.c
+++ b/atintegrators/BndMPoleSymplectic4RadPass.c
@@ -67,7 +67,7 @@ void BndMPoleSymplectic4RadPass(double *r, double le, double irho, double *A, do
         A[0] += sin(KickAngle[1])/le;
     }
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
-    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,bdiff,\
     irho,gap,A,B,L1,L2,K1,K2,max_order,num_int_steps,rad_const, diff_const,scaling,\
     FringeBendEntrance,entrance_angle,fint1,FringeBendExit,exit_angle,fint2,\
     FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0)

--- a/atintegrators/ExactMultipoleRadPass.c
+++ b/atintegrators/ExactMultipoleRadPass.c
@@ -50,7 +50,7 @@ static void multipole_pass(double *r, double le, double *A, double *B,
   #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) \
                        default(none) \
                        shared(r, num_particles, R1, T1, R2, T2, \
-                       RApertures, EApertures, \
+                       RApertures, EApertures, bdiff, \
                        A, B, L1, L2, K1, K2, max_order, num_int_steps, \
                        rad_const, diff_const, \
                        FringeQuadEntrance, FringeQuadExit, \

--- a/atintegrators/StrMPoleSymplectic4RadPass.c
+++ b/atintegrators/StrMPoleSymplectic4RadPass.c
@@ -55,8 +55,8 @@ void StrMPoleSymplectic4RadPass(double *r, double le, double *A, double *B,
         A[0] += sin(KickAngle[1])/le;
     }
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none) \
-    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,\
-    A,B,L1,L2,K1,K2,max_order,num_int_steps,,rad_const, diff_const,scaling,\
+    shared(r,num_particles,R1,T1,R2,T2,RApertures,EApertures,bdiff,\
+    A,B,L1,L2,K1,K2,max_order,num_int_steps,rad_const, diff_const,scaling,\
     FringeQuadEntrance,useLinFrEleEntrance,FringeQuadExit,useLinFrEleExit,fringeIntM0,fringeIntP0)
     for (int c = 0; c<num_particles; c++) { /* Loop over particles */
         double *r6 = r + 6*c;


### PR DESCRIPTION
The new integrators including the computation of diffusion matrices do not compile with openMP.
 The bug in the `#pragma omp` is fixed here.