### PR TITLE
Improve radiation_parameters

### DIFF
--- a/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/atsummary.m
@@ -162,7 +162,7 @@ global THERING %#ok<GVMIS>
             fprintf('                     E: \t% 4.5f\n', smm.damping(3));
             fprintf('   Radiation Loss: \t\t% 4.5f [keV]\n', smm.radiation*1e6);
             fprintf('   Natural Energy Spread: \t% 4.5e\n', smm.naturalEnergySpread);
-            fprintf('   Natural Emittance: \t\t% 4.5e [mrad]\n', smm.naturalEmittance);
+            fprintf('   Natural Emittance: \t\t% 4.5e [m]\n', smm.naturalEmittance);
             fprintf('   Radiation Damping H: \t% 4.5f [ms] or %4.2f turns\n', smm.radiationDamping(1)*1e3, smm.radiationDamping(1)/smm.revTime);
             fprintf('                     V: \t% 4.5f [ms] or %4.2f turns\n', smm.radiationDamping(2)*1e3, smm.radiationDamping(2)/smm.revTime);
             fprintf('                     E: \t% 4.5f [ms] or %4.2f turns\n', smm.radiationDamping(3)*1e3, smm.radiationDamping(3)/smm.revTime);

--- a/atmat/lattice/element_creation/atenergyloss.m
+++ b/atmat/lattice/element_creation/atenergyloss.m
@@ -5,6 +5,11 @@ function elem = atenergyloss(fname, varargin)
 %   FAMNAME:    family name
 %   ELOSS:      Energy loss [eV]
 %   PASSMETHOD: Tracking methods, defaults to 'IdentityPass'
+%
+%the "energy loss" element is taken into account in ATSUMMARY: it adds damping by
+%contributing to the I2 integral, thus reducing the equilibrium emittance.
+%But it does not generate any diffusion. This makes sense only if the losses
+%summarised in the element occur in non-dispersive locations.
 
 [rsrc,eloss,method]=decodeatargs({0,'IdentityPass'},varargin);
 [eloss,rsrc]=getoption(rsrc,'EnergyLoss',eloss);

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1471,6 +1471,12 @@ class EnergyLoss(_DictLongtMotion, Element):
     def __init__(self, family_name: str, energy_loss: float, **kwargs):
         """Energy loss element
 
+        the :py:class:`EnergyLoss` element is taken into account in
+        :py:func:`.radiation_parameters`: it adds damping by contributing to the
+        :math:`I_2` integral, thus reducing the equilibrium emittance. But it does not
+        generate any diffusion. This makes sense only if the losses summarised in
+        the element occur in non-dispersive locations.
+
         Args:
             family_name:    Name of the element
             energy_loss:    Energy loss [eV]

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -425,7 +425,7 @@ def get_radiation_integrals(
             integrals += element_radiation(el, vini, vend)
         elif isinstance(el, Wiggler) and el.PassMethod != "DriftPass":
             integrals += wiggler_radiation(el, vini)
-        elif isinstance(el, EnergyLoss) and el.PassMethod == "EnergyLossPass":
+        elif isinstance(el, EnergyLoss):
             integrals += eloss_radiation(el, elosscoef)
     return tuple(integrals)
 

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -406,6 +406,7 @@ def get_radiation_integrals(
         return np.array([di1, di2, di3, di4, di5])
 
     def eloss_radiation(elem: EnergyLoss, coef):
+        # Assuming no diffusion
         di2 = elem.EnergyLoss / coef
         return np.array([0.0, di2, 0.0, 0.0, 0.0])
 

--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -17,11 +17,12 @@ from math import sin, cos, tan, sqrt, sinh, cosh, pi
 import numpy as np
 from scipy.linalg import inv, det, solve_sylvester
 
-from ..lattice import Dipole, Wiggler, DConstant, test_mode
+from ..lattice import Dipole, Wiggler, EnergyLoss, DConstant, test_mode
 from ..lattice import Lattice, Element, check_radiation, Refpts, All
 from ..lattice import Quadrupole, Multipole, QuantumDiffusion
 from ..lattice import Collective, SimpleQuantDiff
 from ..lattice import frequency_control, set_value_refpts
+from ..constants import Cgamma
 from . import ELossMethod
 from . import find_mpole_raddiff_matrix, FDW, get_tunes_damp
 from . import find_orbit6, find_m66, find_elem_m66, Orbit
@@ -404,7 +405,12 @@ def get_radiation_integrals(
         di5 = max(H0 * di3, d5lim)
         return np.array([di1, di2, di3, di4, di5])
 
+    def eloss_radiation(elem: EnergyLoss, coef):
+        di2 = elem.EnergyLoss / coef
+        return np.array([0.0, di2, 0.0, 0.0, 0.0])
+
     Brho = ring.BRho
+    elosscoef = Cgamma / 2.0 / pi * ring.energy**4
     integrals = np.zeros((5,))
 
     if twiss is None:
@@ -418,6 +424,8 @@ def get_radiation_integrals(
             integrals += element_radiation(el, vini, vend)
         elif isinstance(el, Wiggler) and el.PassMethod != "DriftPass":
             integrals += wiggler_radiation(el, vini)
+        elif isinstance(el, EnergyLoss) and el.PassMethod == "EnergyLossPass":
+            integrals += eloss_radiation(el, elosscoef)
     return tuple(integrals)
 
 


### PR DESCRIPTION
This answers 2 issues reported by @oscarxblanco in #886:

- a unit bug in `atsummary` (Matlab)
- the `EnergyLoss` element is taken into account in the radiation integrals. Note that the energy loss element adds damping ($I_2$ integral), thus reducing the equilibrium emittance, but generates no diffusion. This makes sense assuming that the losses summarised in the element occur in non-dispersive locations.