### PR TITLE
Improvement of AT build process

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -40,10 +40,10 @@ jobs:
     - name: Atmexall
       uses: matlab-actions/run-command@v2
       with:
-        command: run('atmat/atpath');githubsetup();
+        command: run('atmat/atpath');githubsetup('-v');
 
     - name: Build and install at
-      run: python -m pip install .
+      run: python -m pip install -v .
 
     - name: Run tests
       uses: matlab-actions/run-command@v2

--- a/atintegrators/passFunctionMAC.map
+++ b/atintegrators/passFunctionMAC.map
@@ -1,4 +1,0 @@
-# _mexVersion no more provided in Matlab R2011b
-_mexFunction
-#_mexVersion
-_passFunction

--- a/atintegrators/passFunctionMAC.mapext
+++ b/atintegrators/passFunctionMAC.mapext
@@ -1,3 +1,0 @@
-_mexFunction
-_passFunction
-_mexfilerequiredapiversion

--- a/atintegrators/trackFunctionMAC.map
+++ b/atintegrators/trackFunctionMAC.map
@@ -1,4 +1,0 @@
-# _mexVersion no more provided in Matlab R2011b
-_mexFunction
-#_mexVersion
-_trackFunction

--- a/atintegrators/trackFunctionMAC.mapext
+++ b/atintegrators/trackFunctionMAC.mapext
@@ -1,3 +1,0 @@
-_mexFunction
-_trackFunction
-_mexfilerequiredapiversion

--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -75,9 +75,6 @@ if ispc()
 elseif ismac()
     mapc=make_flags(cflags, [ldflags {'-Wl,-exported_symbol,_trackFunction'}]);
     mapcpp=make_flags(cppflags, [ldflags {'-Wl,-exported_symbol,_trackFunction'}]);
-    % exportflag = sprintf('VERSIONMAP="%s"',fullfile(pdir, 'trackFunctionMAC.mapext'));
-    % mapc=[mexflags {exportflag, 'LINKEXPORT=""'}];
-    % mapcpp=[mexcpp {exportflag, 'LINKEXPORT=""'}];
 else
     exportflag = sprintf('VERSIONMAP="%s"',fullfile(pdir, 'mexFunctionGLNX86.mapext'));
     mapc=[mexflags {exportflag, 'LINKEXPORT=""'}];

--- a/atmat/atphysics/TuneAndChromaticity/findtune.m
+++ b/atmat/atphysics/TuneAndChromaticity/findtune.m
@@ -69,7 +69,7 @@ reject=find(~(keep | wrong));
 for bpm=reject
     fprintf('rejected BPM %d\n', bpm);
 end
-fprintf('%20s tune:%g (rms:%g)\n',methname, mean(tune(keep),2),std(tune(keep),0,2));
+% fprintf('%20s tune:%g (rms:%g)\n',methname, mean(tune(keep),2),std(tune(keep),0,2));
 
 function vv=phi(a,b,c) %#ok<DEFNU>
 d1=c*(a+b);

--- a/atmat/atphysics/atavedata.m
+++ b/atmat/atphysics/atavedata.m
@@ -26,9 +26,10 @@ long=atgetcells(ring,'Length',@(elem,lg) lg>0) & refs(1:end-1); %lr-1
 needed=refs | [false;long]; %lr
 initial=[long(needed(1:end-1));false]; %needed
 final=[false;initial(1:end-1)]; %needed
-setoption('WarningDp6D',false)
+wstate=getoption('WarningDp6D');
+setoption('WarningDp6D',false);
 [ringdata, lind]=atlinopt6(ring,needed,'dp',dpp,'get_chrom',varargin{:}); %needed
-setoption('WarningDp6D',true)
+setoption('WarningDp6D',wstate);
 nu = ringdata.tune;
 xsi = ringdata.chromaticity;
 

--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -1,4 +1,4 @@
-function githubsetup()
+function githubsetup(varargin)
 %GITHUBSETUP    Private. Setup Matlab for AT tests in GitHib Actions
 %
 % This function prepares a workflow in GitHub actions for using AT and
@@ -6,7 +6,7 @@ function githubsetup()
 % user workflow.
 
 savepath('pathdef.m');
-atmexall -fail
+atmexall('-fail', varargin{:});
 if ispc
     execfile=fullfile(getenv('pythonLocation'),'pythonw.exe');
 else

--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -7,6 +7,7 @@ function githubsetup(varargin)
 
 savepath('pathdef.m');
 mex -setup
+mex -setup C++
 atmexall('-fail', varargin{:});
 if ispc
     execfile=fullfile(getenv('pythonLocation'),'pythonw.exe');

--- a/atmat/attests/githubsetup.m
+++ b/atmat/attests/githubsetup.m
@@ -6,6 +6,7 @@ function githubsetup(varargin)
 % user workflow.
 
 savepath('pathdef.m');
+mex -setup
 atmexall('-fail', varargin{:});
 if ispc
     execfile=fullfile(getenv('pythonLocation'),'pythonw.exe');

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -24,13 +24,15 @@ classdef pytests < matlab.unittest.TestCase
     methods(TestClassSetup)
         function load_lattice(testCase)
             % Shared setup for the entire test class
-            t=warning('off','AT:atradon:NOCavity');
+            t1=warning('off','AT:atradon:NOCavity');
+            t2=warning('off','AT:NoRingParam');
             setoption('WarningDp6D',false);
             for fpath=testCase.mlist
                 [~,fname,~]=fileparts(fpath);
                 [testCase.ring4.(fname),testCase.ring6.(fname)]=mload(fpath);
             end
-            warning(t);
+            testCase.addTeardown(@warning, t2);
+            warning(t1);
 
             function [ring4,ring6]=mload(fpath)
                 mr=atradoff(atloadlattice(fullfile(atroot,'..',fpath)));
@@ -171,7 +173,7 @@ classdef pytests < matlab.unittest.TestCase
             ptune=double(lattice.p.get_tune(pyargs(dp=dp)));
             pchrom=double(lattice.p.get_chrom(pyargs(dp=dp)));
             testCase.verifyEqual(mod(mtune*periodicity,1),ptune,AbsTol=2.e-9);
-            testCase.verifyEqual(mchrom*periodicity,pchrom,AbsTol=3.e-4);
+            testCase.verifyEqual(mchrom*periodicity,pchrom,RelTol=2.e-4,AbsTol=2.e-4);
         end
 
         function tunechrom6(testCase,lat2,dp)

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,15 @@ from setuptools import setup, Extension
 
 
 def select_omp():
-    if exists("/usr/local/include/omp.h"):  # Homebrew
-        return "-I/usr/local/include", "/usr/local/lib"
+    if os.uname().machine.startswith("arm"):
+        homeb = "/opt/homebrew/opt/libomp"
+    else:
+        homeb = "/usr/local"
+
+    if exists(os.path.join(homeb, "include/omp.h")):  # Homebrew
+        return "-I" + os.path.join(homeb, "include"), os.path.join(homeb, "lib")
     elif exists("/opt/local/include/libomp/omp.h"):  # MacPorts
-        return "-I/opt/local/include/libomp", "/opt/local/lib/libomp"
+        return "/opt/local/include/libomp", "/opt/local/lib/libomp"
     else:
         raise FileNotFoundError(
             "\n".join(
@@ -40,9 +45,11 @@ cppflags = []
 
 if not platform.startswith("win32"):
     cflags += ["-std=c99", "-Wno-unused-function", "-Wno-unknown-pragmas"]
+    cppflags += ["-Wno-unused-function", "-Wno-unknown-pragmas"]
 
-if platform.startswith("darwin") and os.uname().machine.startswith("arm"):
+if platform.startswith("darwin"):
     cflags += ["-ffp-contract=off"]
+    cppflags += ["-ffp-contract=off"]
 
 mpi = eval(os.environ.get("MPI", "None"))
 if not mpi or (len(sys.argv) >= 2 and sys.argv[1] in {"egg_info", "sdist"}):

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,69 @@
-import glob
+import sys
 import os
 from os.path import basename, exists, join, splitext
-import sys
-from setuptools import setup, Extension
+import glob
 
 # Numpy build dependency defined in pyproject.toml.
-import numpy
+import numpy as np
+from setuptools import setup, Extension
 
 
 def select_omp():
-    if exists('/usr/local/include/omp.h'):              # Homebrew
-        return '-I/usr/local/include', '/usr/local/lib'
-    elif exists('/opt/local/include/libomp/omp.h'):     # MacPorts
-        return '-I/opt/local/include/libomp', '/opt/local/lib/libomp'
+    if exists("/usr/local/include/omp.h"):  # Homebrew
+        return "-I/usr/local/include", "/usr/local/lib"
+    elif exists("/opt/local/include/libomp/omp.h"):  # MacPorts
+        return "-I/opt/local/include/libomp", "/opt/local/lib/libomp"
     else:
-        raise FileNotFoundError('\n'.join((
-            '',
-            'libomp.dylib must be installed with your package manager:',
-            '',
-            'Use "$ brew install libomp"',
-            'Or  "$ sudo port install libomp"',
-            ''
-        )))
+        raise FileNotFoundError(
+            "\n".join(
+                (
+                    "",
+                    "libomp.dylib must be installed with your package manager:",
+                    "",
+                    'Use "$ brew install libomp"',
+                    'Or  "$ sudo port install libomp"',
+                    "",
+                )
+            )
+        )
 
 
 print("** Entering setup.py:", str(sys.argv))
-print("** MPI:", os.environ.get('MPI', None))
-print("** OPENMP:", os.environ.get('OPENMP', None))
-macros = [('PYAT', None)]
-with_openMP = False
+print("** MPI:", os.environ.get("MPI", None))
+print("** OPENMP:", os.environ.get("OPENMP", None))
 
-cflags = ['-std=c99']
+platform = sys.platform
+macros = [("PYAT", None)]
+
+cflags = []
 cppflags = []
 
-mpi = eval(os.environ.get('MPI', 'None'))
-if not mpi or (len(sys.argv) >= 2 and
-               any(sys.argv[1] == arg for arg in ('egg_info', 'sdist'))):
+if not platform.startswith("win32"):
+    cflags += ["-std=c99", "-Wno-unused-function", "-Wno-unknown-pragmas"]
+
+if platform.startswith("darwin") and os.uname().machine.startswith("arm"):
+    cflags += ["-ffp-contract=off"]
+
+mpi = eval(os.environ.get("MPI", "None"))
+if not mpi or (len(sys.argv) >= 2 and sys.argv[1] in {"egg_info", "sdist"}):
     mpi_macros = []
     mpi_includes = []
 else:
-    mpi_macros = [('MPI', None)]
-    os.environ["CC"] = 'mpicc'
-    os.environ["CXX"] = 'mpicxx'
+    mpi_macros = [("MPI", None)]
+    os.environ["CC"] = "mpicc"
+    os.environ["CXX"] = "mpicxx"
     try:
         import mpi4py
     except ImportError:
-        print('\npyAT with MPI requires mpi4py. '
-              'Please install mpi4py: "pip install mpi4py"\n')
+        print(
+            "\npyAT with MPI requires mpi4py. "
+            'Please install mpi4py: "pip install mpi4py"\n'
+        )
         sys.exit()
     mpi_includes = mpi4py.get_include()
 
 
-omp = eval(os.environ.get('OPENMP', 'None'))
+omp = eval(os.environ.get("OPENMP", "None"))
 if not omp:
     omp_cflags = []
     omp_lflags = []
@@ -59,29 +71,26 @@ if not omp:
 else:
     # Get the location of an alternate OpenMP library
     # Example: OMP_MATLAB=$MATLABROOT/sys/os/glnx64
-    omp_path = os.environ.get('OMP_MATLAB', None)
+    omp_path = os.environ.get("OMP_MATLAB", None)
     # Get the threshold on the number of particles
-    omp_threshold = int(os.environ.get('OMP_PARTICLE_THRESHOLD', 10))
-    omp_macros = [('OMP_PARTICLE_THRESHOLD', omp_threshold)]
-    if sys.platform.startswith('win'):
-        omp_cflags = ['/openmp']
+    omp_threshold = int(os.environ.get("OMP_PARTICLE_THRESHOLD", 10))
+    omp_macros = [("OMP_PARTICLE_THRESHOLD", omp_threshold)]
+    if platform.startswith("win"):
+        omp_cflags = ["/openmp"]
         omp_lflags = []
-    elif sys.platform.startswith('darwin'):
+    elif platform.startswith("darwin"):
         omp_inc, omp_lib = select_omp()
-        omp_cflags = ['-Xpreprocessor', '-fopenmp', omp_inc]
+        omp_cflags = ["-Xpreprocessor", "-fopenmp", omp_inc]
         if omp_path is None:
-            omp_lflags = ['-L' + omp_lib, '-lomp']
+            omp_lflags = ["-L" + omp_lib, "-lomp"]
         else:
-            omp_lflags = ['-L' + omp_path, '-Wl,-rpath,' + omp_path, '-liomp5']
+            omp_lflags = ["-L" + omp_path, "-Wl,-rpath," + omp_path, "-liomp5"]
     else:
-        omp_cflags = ['-fopenmp']
+        omp_cflags = ["-fopenmp"]
         if omp_path is None:
-            omp_lflags = ['-lgomp']
+            omp_lflags = ["-lgomp"]
         else:
-            omp_lflags = ['-L' + omp_path, '-Wl,-rpath,' + omp_path, '-liomp5']
-
-if not sys.platform.startswith('win32'):
-    cflags += ['-Wno-unused-function']
+            omp_lflags = ["-L" + omp_path, "-Wl,-rpath," + omp_path, "-liomp5"]
 
 # It is easier to copy the integrator files into a directory inside pyat
 # for packaging. However, we cannot always rely on this directory being
@@ -89,77 +98,64 @@ if not sys.platform.startswith('win32'):
 # this file is executed each time any setup.py command is run.
 # It appears that only copying the files when they are available is
 # sufficient.
-integrator_src_orig = 'atintegrators'
-diffmatrix_orig = join('atmat', 'atphysics', 'Radiation')
+integrator_src_orig = "atintegrators"
+diffmatrix_orig = join("atmat", "atphysics", "Radiation")
 
-c_pass_methods = glob.glob(join(integrator_src_orig, '*Pass.c'))
-cpp_pass_methods = glob.glob(join(integrator_src_orig, '*Pass.cc'))
-diffmatrix_source = join(diffmatrix_orig, 'findmpoleraddiffmatrix.c')
-at_source = join('pyat', 'at.c')
+c_pass_methods = glob.glob(join(integrator_src_orig, "*Pass.c"))
+cpp_pass_methods = glob.glob(join(integrator_src_orig, "*Pass.cc"))
+diffmatrix_source = join(diffmatrix_orig, "findmpoleraddiffmatrix.c")
+at_source = join("pyat", "at.c")
 
 
-def c_integrator_ext(pass_method):
+def integrator_ext(pass_method, flags):
     name, _ = splitext(basename(pass_method))
-    name = ".".join(('at', 'integrators', name))
+    name = ".".join(("at", "integrators", name))
     return Extension(
         name=name,
         sources=[pass_method],
-        include_dirs=[numpy.get_include(), mpi_includes, integrator_src_orig],
+        include_dirs=[np.get_include(), mpi_includes, integrator_src_orig],
         define_macros=macros + omp_macros + mpi_macros,
-        extra_compile_args=cflags + omp_cflags,
-        extra_link_args=omp_lflags
-    )
-
-
-def cpp_integrator_ext(pass_method):
-    name, _ = splitext(basename(pass_method))
-    name = ".".join(('at', 'integrators', name))
-    return Extension(
-        name=name,
-        sources=[pass_method],
-        include_dirs=[numpy.get_include(), mpi_includes, integrator_src_orig],
-        define_macros=macros + omp_macros + mpi_macros,
-        extra_compile_args=cppflags + omp_cflags,
-        extra_link_args=omp_lflags
+        extra_compile_args=flags + omp_cflags,
+        extra_link_args=omp_lflags,
     )
 
 
 at = Extension(
-    'at.tracking.atpass',
+    "at.tracking.atpass",
     sources=[at_source],
     define_macros=macros + omp_macros + mpi_macros,
-    include_dirs=[numpy.get_include(), integrator_src_orig],
+    include_dirs=[np.get_include(), integrator_src_orig],
     extra_compile_args=cflags + omp_cflags,
-    extra_link_args=omp_lflags
+    extra_link_args=omp_lflags,
 )
 
 cconfig = Extension(
-    'at.cconfig',
-    sources=[join('pyat', 'at', 'cconfig.c')],
+    "at.cconfig",
+    sources=[join("pyat", "at", "cconfig.c")],
     define_macros=macros + omp_macros + mpi_macros,
     extra_compile_args=cflags + omp_cflags,
 )
 
 diffmatrix = Extension(
-    name='at.physics.diffmatrix',
-    sources=[join(diffmatrix_orig, 'findmpoleraddiffmatrix.c')],
-    include_dirs=[numpy.get_include(), integrator_src_orig],
+    name="at.physics.diffmatrix",
+    sources=[join(diffmatrix_orig, "findmpoleraddiffmatrix.c")],
+    include_dirs=[np.get_include(), integrator_src_orig],
     define_macros=macros,
-    extra_compile_args=cflags
+    extra_compile_args=cflags,
 )
 
 wiggdiffmatrix = Extension(
-    name='at.physics.wiggdiffmatrix',
-    sources=[join(diffmatrix_orig, 'FDW.c')],
-    include_dirs=[numpy.get_include(), integrator_src_orig],
+    name="at.physics.wiggdiffmatrix",
+    sources=[join(diffmatrix_orig, "FDW.c")],
+    include_dirs=[np.get_include(), integrator_src_orig],
     define_macros=macros,
-    extra_compile_args=cflags
+    extra_compile_args=cflags,
 )
 
 setup(
-    ext_modules=[at, cconfig, diffmatrix, wiggdiffmatrix] +
-                [c_integrator_ext(pm) for pm in c_pass_methods] +
-                [cpp_integrator_ext(pm) for pm in cpp_pass_methods],
+    ext_modules=[at, cconfig, diffmatrix, wiggdiffmatrix]
+    + [integrator_ext(pm, cflags) for pm in c_pass_methods]
+    + [integrator_ext(pm, cppflags) for pm in cpp_pass_methods],
 )
 
 print("** Leaving setup.py")


### PR DESCRIPTION
The AT build process is updated to allow the OpenMP option on macOS and arm processor. At the sometime, a few improvement concern;

**For Matlab (atmexall)**
- Correctly locate the OpenMP libraries and includes on macOS arm
- remove spurious warnings in Matlab tests
- simplify the definition of global symbols on macOS

**For python (setup.py)**
- Correctly locate the OpenMP libraries and includes on macOS arm
- make Matlab tests succeed on macOS arm by using the same compiler options as in Matlab (see #885)
- remove some compiler warnings on Windows and Ubuntu