### PR TITLE
Fix OpenMP compilation bug

### DIFF
--- a/atmat/atmexall.m
+++ b/atmat/atmexall.m
@@ -219,8 +219,6 @@ warning(oldwarns.state,oldwarns.identifier);
             incdir=homeb;
         elseif exist('/opt/local/include/libomp/omp.h', 'file') % MacPorts
             incdir='/opt/local/include/libomp';
-            libdir='/opt/local/lib';
-            libname='omp';
         else
             error('AT:MissingLibrary', strjoin({'', ...
                 'libomp.dylib must be installed with your favourite package manager:', '', ...

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def select_omp():
     if exists(os.path.join(homeb, "include/omp.h")):  # Homebrew
         return "-I" + os.path.join(homeb, "include"), os.path.join(homeb, "lib")
     elif exists("/opt/local/include/libomp/omp.h"):  # MacPorts
-        return "/opt/local/include/libomp", "/opt/local/lib/libomp"
+        return "-I/opt/local/include/libomp", "/opt/local/lib/libomp"
     else:
         raise FileNotFoundError(
             "\n".join(


### PR DESCRIPTION
This fixes an OpenMP compilation error in the specific case of macOS with OpenMP installed with the MacPorts package manager.
