### PR TITLE
Allow setting the seed of random generators

### DIFF
--- a/atintegrators/TestRandomPass.c
+++ b/atintegrators/TestRandomPass.c
@@ -1,4 +1,4 @@
-/* RandomPass.c
+ /* RandomPass.c
    Accelerator Toolbox
 
    Test of random generators
@@ -21,7 +21,7 @@ static void RandomPass(double *r_in,
         pcg32_random_t* thread_rng,
         int num_particles)
 {	
-    double common_val = atrandn_r(common_rng, 0.0, 0.001);
+    double common_val;
 #ifdef MPI
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -29,6 +29,7 @@ static void RandomPass(double *r_in,
     int rank = 0;
 #endif /* MPI */
 
+    common_val = atrandn_r(common_rng, 0.0, 0.001);
     for (int c = 0; c<num_particles; c++) {	/*Loop over particles  */
         double *r6 = r_in+c*6;
         r6[0] = atrandn_r(thread_rng, 0.0, 0.001);
@@ -37,6 +38,7 @@ static void RandomPass(double *r_in,
         r6[5] = 0.01*c;
     }
 
+    common_val = atrandn_r(common_rng, 0.0, 0.001);
     #pragma omp parallel for if (num_particles > OMP_PARTICLE_THRESHOLD) default(none)                      \
     shared(r_in, num_particles, common_val, thread_rng)
     for (int c = 0; c<num_particles; c++) {	/*Loop over particles  */

--- a/atmat/attrack/atpass.c
+++ b/atmat/attrack/atpass.c
@@ -52,6 +52,7 @@ typedef double mxDouble;
 #define RINGPROPERTIES prhs[9]
 #define TURN prhs[10]
 #define KEEPCOUNTER prhs[11]
+#define SEED prhs[12]
 
 #define LIMIT_AMPLITUDE		1	/*  if any of the phase space variables (except the sixth N.C.) 
 									exceeds this limit it is marked as lost */
@@ -249,6 +250,7 @@ static mxDouble *passhook(mxArray *mxPassArg[], mxArray *mxElem, mxArray *func)
 @param[in]      [9] RINGPROPERTIES
 @param[in]     [10] TURN
 @param[in]     [11] KEEPCOUNTER
+@param[in]     [12] SEED
 */
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
@@ -281,6 +283,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     int num_particles = mxGetN(INITCONDITIONS);
     int counter = (nrhs >= 11) ? (int)mxGetScalar(TURN) : 0;
     int keep_counter = (nrhs >= 12) ? (int)mxGetScalar(KEEPCOUNTER) : 0;
+    int seed = (nrhs >= 13) ? (int)mxGetScalar(SEED) : -1;
     int np6 = num_particles*6;
     int ihist, lhist;
     mxDouble *histbuf = NULL;
@@ -306,7 +309,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     param.nbunch = 1;
     param.num_turns = num_turns;
     param.bdiff = NULL;
-
+    
+    if (seed >= 0) {
+        pcg32_srandom_r(&common_state, seed, AT_RNG_INC);
+        pcg32_srandom_r(&thread_state, seed, 0);
+    }
     if (keep_counter)
         param.nturn = last_turn;
     else

--- a/atmat/attrack/linepass.m
+++ b/atmat/attrack/linepass.m
@@ -58,6 +58,12 @@ function [Rout,varargout] = linepass(line,Rin,varargin)
 % ROUT=LINEPASS(...,'reuse') is kept for compatibilty with previous
 % versions. It has no effect.
 %
+% ROUT=LINEPASS(...,'seed',SEED)  The random generators are reset to start 
+%   with SEED.
+%
+% ROUT=LINEPASS(...,'omp_num_threads',NTHREADS)  Number of OpenMP threads.
+%   By default, OpenMP chooses the number of threads.
+%
 % Rfin=LINEPASS(...,PREFUNC)
 % Rfin=LINEPASS(...,PREFUNC,POSTFUNC)
 % Rfin=LINEPASS(...,cell(0),POSTFUNC)
@@ -75,6 +81,7 @@ function [Rout,varargout] = linepass(line,Rin,varargin)
 [dummy,args]=getflag(args,'reuse');	%#ok<ASGLU> % Kept for compatibility and ignored
 [nhist,args]=getoption(args,'nhist',1);
 [omp_num_threads,args]=getoption(args,'omp_num_threads');
+[seed,args]=getoption(args,'seed',-1);
 funcargs=cellfun(@(arg) isa(arg,'function_handle'), args);
 refpts=getargs(args(~funcargs),length(line)+1);
 [prefunc,postfunc]=getargs(args(funcargs),cell(0),cell(0));
@@ -88,7 +95,7 @@ props=atCheckRingProperties(line);
 
 try
     [Rout,lossinfo] = atpass(line,Rin,newlattice,1,refpts, ...
-        prefunc,postfunc,nhist,omp_num_threads,props,0);
+        prefunc,postfunc,nhist,omp_num_threads,props,0,0,seed);
     
     if nargout>1
         if nargout>2, varargout{2}=lossinfo; end

--- a/atmat/attrack/ringpass.m
+++ b/atmat/attrack/ringpass.m
@@ -48,7 +48,10 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 % ROUT=RINGPASS(...,'reuse') is kept for compatibilty with previous
 % versions. It has no effect.
 %
-% ROUT=RINGPASS(...,'turn',turn)    Initial turn number. Default 0.
+% ROUT=RINGPASS(...,'seed',SEED)  The random generators are reset to start 
+%   with SEED.
+%
+% ROUT=RINGPASS(...,'turn',TURN)    Initial turn number. Default 0.
 %   The turn number is necessary to compute the absolute path length used
 %   by RFCavityPass. Ignored if KeepCounter is set.
 %
@@ -59,6 +62,9 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 % To resume an interrupted tracking (for instance to get intermediate
 % results), one must use one of the 'turn' option or 'KeepCounter' flag to
 % ensure the continuity of the turn number.
+%
+% ROUT=RINGPASS(...,'omp_num_threads',NTHREADS)  Number of OpenMP threads.
+%   By default, OpenMP chooses the number of threads.
 %
 % ROUT=RINGPASS(...,'Silent') does not output the particle coordinates at
 %    each turn but only at the end of the tracking
@@ -83,6 +89,7 @@ function [Rout, varargout] = ringpass(ring, Rin, varargin)
 [turn,args]=getoption(args,'turn',0);
 [keep_counter,args]=getflag(args,'KeepCounter');
 [omp_num_threads,args]=getoption(args,'omp_num_threads');
+[seed,args]=getoption(args,'seed',-1);
 funcargs=cellfun(@(arg) isa(arg,'function_handle'), args);
 nturns=getargs(args(~funcargs),1);
 [prefunc,postfunc]=getargs(args(funcargs),cell(0),cell(0));
@@ -99,7 +106,7 @@ props=atCheckRingProperties(ring);
 
 try
     [Rout,lossinfo] = atpass(ring,Rin,newlattice,nturns,refpts, ...
-        prefunc,postfunc,nhist,omp_num_threads,props,turn,double(keep_counter));
+        prefunc,postfunc,nhist,omp_num_threads,props,turn,double(keep_counter),seed);
     
     if nargout>1
         if nargout>3, varargout{3}=lossinfo; end

--- a/pyat/at/tracking/atpass.pyi
+++ b/pyat/at/tracking/atpass.pyi
@@ -10,9 +10,9 @@ _defref = np.array([], dtype=np.uint32)
 
 def atpass(
     line: list[Element],
-    r_in: np.ndarray[np.float64],
+    r_in: np.ndarray,
     nturns: int,
-    refpts: np.ndarray[np.uint32] = _defref,
+    refpts: np.ndarray = _defref,
     turn: int | None = None,
     energy: float | None = None,
     particle: Particle | None = None,
@@ -25,13 +25,13 @@ def atpass(
 ): ...
 def elempass(
     element: Element,
-    r_in: np.ndarray[np.float64],
+    r_in: np.ndarray,
     energy: float | None = None,
     particle: Particle | None = None,
 ): ...
 def diffusion_matrix(
     element: Element,
-    r_in: np.ndarray[np.float64],
+    r_in: np.ndarray,
     energy: float | None = None,
     particle: Particle | None = None,
 ): ...

--- a/pyat/at/tracking/track.py
+++ b/pyat/at/tracking/track.py
@@ -1,24 +1,29 @@
 from __future__ import annotations
+
+__all__ = [
+    "lattice_track",
+    "element_track",
+    "internal_lpass",
+    "internal_epass",
+    "internal_plpass",
+]
+
+import multiprocessing
+from collections.abc import Iterable
+from functools import partial
+from warnings import warn
+
 import numpy
-from .atpass import atpass as _atpass, elempass as _elempass
+
+from .atpass import atpass as _atpass, elempass as _elempass, reset_rng
 from .utils import fortran_align, has_collective, format_results
 from .utils import initialize_lpass, disable_varelem, variable_refs
+from ..lattice import AtWarning, DConstant, random
 from ..lattice import Lattice, Element, Refpts, End
 from ..lattice import get_uint32_index
-from ..lattice import AtWarning, DConstant, random
-from collections.abc import Iterable
-from typing import Optional
-from functools import partial
-import multiprocessing
-from warnings import warn
-from .atpass import reset_rng
-
-
-__all__ = ['lattice_track', 'element_track', 'internal_lpass',
-           'internal_epass', 'internal_plpass']
 
 _imax = numpy.iinfo(int).max
-_globring: Optional[list[Element]] = None
+_globring: list[Element] | None = None
 
 
 def _atpass_fork(seed, rank, rin, **kwargs):
@@ -42,7 +47,7 @@ def _pass(ring, r_in, pool_size, start_method, seed, **kwargs):
     # Generate a new starting point for C RNGs
     global _globring
     _globring = ring
-    if ctx.get_start_method() == 'fork':
+    if ctx.get_start_method() == "fork":
         passfunc = partial(_atpass_fork, seed, **kwargs)
     else:
         passfunc = partial(_atpass_spawn, ring, seed, **kwargs)
@@ -51,7 +56,7 @@ def _pass(ring, r_in, pool_size, start_method, seed, **kwargs):
         results = pool.starmap(passfunc, args)
     _globring = None
     # Gather the results
-    losses = kwargs.pop('losses', False)
+    losses = kwargs.pop("losses", False)
     return format_results(results, r_in, losses)
 
 
@@ -61,14 +66,21 @@ def _element_pass(element: Element, r_in, **kwargs):
 
 
 @fortran_align
-def _lattice_pass(lattice: list[Element], r_in, nturns: int = 1,
-                  refpts: Refpts = End, no_varelem=True, seed: int | None = None, **kwargs):
-    kwargs['reuse'] = kwargs.pop('keep_lattice', False)
+def _lattice_pass(
+    lattice: list[Element],
+    r_in,
+    nturns: int = 1,
+    refpts: Refpts = End,
+    no_varelem=True,
+    seed: int | None = None,
+    **kwargs,
+):
+    kwargs["reuse"] = kwargs.pop("keep_lattice", False)
     if no_varelem:
         lattice = disable_varelem(lattice)
     else:
         if sum(variable_refs(lattice)) > 0:
-            kwargs['reuse'] = False
+            kwargs["reuse"] = False
     refs = get_uint32_index(lattice, refpts)
     if seed is not None:
         reset_rng(seed=seed)
@@ -76,36 +88,62 @@ def _lattice_pass(lattice: list[Element], r_in, nturns: int = 1,
 
 
 @fortran_align
-def _plattice_pass(lattice: list[Element], r_in, nturns: int = 1,
-                   refpts: Refpts = End, seed: int | None = None, pool_size: int = None,
-                   start_method: str = None, **kwargs):
+def _plattice_pass(
+    lattice: list[Element],
+    r_in,
+    nturns: int = 1,
+    refpts: Refpts = End,
+    seed: int | None = None,
+    pool_size: int = None,
+    start_method: str = None,
+    **kwargs,
+):
     refpts = get_uint32_index(lattice, refpts)
     any_collective = has_collective(lattice)
-    kwargs['reuse'] = kwargs.pop('keep_lattice', False)
+    kwargs["reuse"] = kwargs.pop("keep_lattice", False)
     rshape = r_in.shape
     if len(rshape) >= 2 and rshape[1] > 1 and not any_collective:
         if seed is None:
             seed = random.common.integers(0, high=_imax, dtype=int)
         if pool_size is None:
-            pool_size = min(len(r_in[0]), multiprocessing.cpu_count(),
-                            DConstant.patpass_poolsize)
+            pool_size = min(
+                len(r_in[0]), multiprocessing.cpu_count(), DConstant.patpass_poolsize
+            )
         if start_method is None:
             start_method = DConstant.patpass_startmethod
-        return _pass(lattice, r_in, pool_size, start_method, seed=seed, nturns=nturns,
-                     refpts=refpts, **kwargs)
+        return _pass(
+            lattice,
+            r_in,
+            pool_size,
+            start_method,
+            seed=seed,
+            nturns=nturns,
+            refpts=refpts,
+            **kwargs,
+        )
     else:
         if seed is not None:
             reset_rng(seed=seed)
         if any_collective:
-            warn(AtWarning('Collective PassMethod found: use single process'))
+            warn(
+                AtWarning("Collective PassMethod found: use single process"),
+                stacklevel=2,
+            )
         else:
-            warn(AtWarning('no parallel computation for a single particle'))
+            warn(
+                AtWarning("no parallel computation for a single particle"), stacklevel=2
+            )
         return _atpass(lattice, r_in, nturns=nturns, refpts=refpts, **kwargs)
 
 
-def lattice_track(lattice: Iterable[Element], r_in,
-                  nturns: int = 1, refpts: Refpts = End,
-                  in_place: bool = False, **kwargs):
+def lattice_track(
+    lattice: Iterable[Element],
+    r_in,
+    nturns: int = 1,
+    refpts: Refpts = End,
+    in_place: bool = False,
+    **kwargs,
+):
     """
     :py:func:`track_function` tracks particles through each element of a
     lattice or throught a single Element calling the element-specific
@@ -118,7 +156,7 @@ def lattice_track(lattice: Iterable[Element], r_in,
     Parameters:
         lattice: list of elements
         r_in: (6, N) array: input coordinates of N particles.
-          *r_in* is modified in-place only if *in_place* is 
+          *r_in* is modified in-place only if *in_place* is
           :py:obj:`True` and reports the coordinates at
           the end of the element. For the best efficiency, *r_in*
           should be given as F_CONTIGUOUS numpy array.
@@ -235,52 +273,49 @@ def lattice_track(lattice: Iterable[Element], r_in,
     """
     trackdata = {}
     trackparam = {}
-    part_kw = ['energy', 'particle']
+    part_kw = ["energy", "particle"]
     try:
         npart = numpy.shape(r_in)[1]
     except IndexError:
         npart = 1
 
     [trackparam.update((kw, kwargs.get(kw))) for kw in kwargs if kw in part_kw]
-    trackparam.update({'npart': npart})
+    trackparam.update({"npart": npart})
 
     if not in_place:
         r_in = r_in.copy()
 
     lattice = initialize_lpass(lattice, nturns, kwargs)
-    ldtype = [('islost', numpy.bool_),
-              ('turn', numpy.uint32),
-              ('elem', numpy.uint32),
-              ('coord', numpy.float64, (6,)),
-              ]
+    ldtype = [
+        ("islost", numpy.bool_),
+        ("turn", numpy.uint32),
+        ("elem", numpy.uint32),
+        ("coord", numpy.float64, (6,)),
+    ]
     loss_map = numpy.recarray((npart,), ldtype)
-    lat_kw = ['turn']
-    [trackparam.update((kw, kwargs.get(kw)))
-     for kw in kwargs if kw in lat_kw]
-    trackparam.update({'refpts': get_uint32_index(lattice, refpts),
-                       'nturns': nturns})
+    lat_kw = ["turn"]
+    [trackparam.update((kw, kwargs.get(kw))) for kw in kwargs if kw in lat_kw]
+    trackparam.update({"refpts": get_uint32_index(lattice, refpts), "nturns": nturns})
 
-    use_mp = kwargs.pop('use_mp', False)
-    start_method = kwargs.pop('start_method', None)
-    pool_size = kwargs.pop('pool_size', None)
+    use_mp = kwargs.pop("use_mp", False)
+    start_method = kwargs.pop("start_method", None)
+    pool_size = kwargs.pop("pool_size", None)
     if use_mp:
-        kwargs.update({'pool_size': pool_size,
-                       'start_method': start_method})
-        rout = _plattice_pass(lattice, r_in, nturns=nturns,
-                              refpts=refpts, **kwargs)
+        kwargs.update({"pool_size": pool_size, "start_method": start_method})
+        rout = _plattice_pass(lattice, r_in, nturns=nturns, refpts=refpts, **kwargs)
     else:
-        rout = _lattice_pass(lattice, r_in, nturns=nturns,
-                             refpts=refpts, no_varelem=False,
-                             **kwargs)
+        rout = _lattice_pass(
+            lattice, r_in, nturns=nturns, refpts=refpts, no_varelem=False, **kwargs
+        )
 
-    if kwargs.get('losses', False):
+    if kwargs.get("losses", False):
         rout, lm = rout
-        lm['coord'] = lm['coord'].T
+        lm["coord"] = lm["coord"].T
         for k, v in lm.items():
             loss_map[k] = v
 
-    trackdata.update({'loss_map': loss_map})
-    trackparam.update({'rout': r_in})
+    trackdata.update({"loss_map": loss_map})
+    trackparam.update({"rout": r_in})
 
     return rout, trackparam, trackdata
 
@@ -321,7 +356,7 @@ def element_track(element: Element, r_in, in_place: bool = False, **kwargs):
 
     rout = _element_pass(element, r_in, **kwargs)
     return rout
-    
+
 
 internal_lpass = _lattice_pass
 internal_epass = _element_pass


### PR DESCRIPTION
Following #879, we introduce an optional `seed` keyword argument in
- `lattice_track` (python)
- `linepass`, `ringpass` (Matlab)

When provided, this will reset the seed of the two C random generators. If omitted, the sequences of random numbers will continue as before: no change.