### PR TITLE
Fix the energyloss computation for simple ring

### DIFF
--- a/atintegrators/SimpleRadiationRadPass.c
+++ b/atintegrators/SimpleRadiationRadPass.c
@@ -13,7 +13,7 @@ struct elem
   double EnergyLossFactor;
 };
 
-void SimpleRadiationPass(double *r_in,
+void SimpleRadiationRadPass(double *r_in,
            double *damp_mat_diag, double dispx, double dispxp,
            double dispy, double dispyp, double EnergyLossFactor, int num_particles)
 
@@ -99,11 +99,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
             Elem->EnergyLossFactor=U0/Param->energy;
             Elem->damp_mat_diag=damp_mat_diag;
         }
-        SimpleRadiationPass(r_in, Elem->damp_mat_diag, Elem->dispx, Elem->dispxp, Elem->dispy, Elem->dispyp, Elem->EnergyLossFactor, num_particles);
+        SimpleRadiationRadPass(r_in, Elem->damp_mat_diag, Elem->dispx, Elem->dispxp, Elem->dispy, Elem->dispyp, Elem->EnergyLossFactor, num_particles);
     return Elem;
 }
 
-MODULE_DEF(SimpleRadiationPass)        /* Dummy module initialisation */
+MODULE_DEF(SimpleRadiationRadPass)        /* Dummy module initialisation */
 
 #endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
 
@@ -129,7 +129,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        SimpleRadiationPass(r_in, damp_mat_diag, dispx, dispxp, dispy, dispyp, EnergyLossFactor, num_particles);
+        SimpleRadiationRadPass(r_in, damp_mat_diag, dispx, dispxp, dispy, dispyp, EnergyLossFactor, num_particles);
     }
     else if (nrhs == 0) {
         /* list of required fields */

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1342,7 +1342,7 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
         Element._conversions, U0=float, damp_mat_diag=lambda v: _array(v, shape=(6,))
     )
 
-    default_pass = {False: "IdentityPass", True: "SimpleRadiationPass"}
+    default_pass = {False: "IdentityPass", True: "SimpleRadiationRadPass"}
 
     def __init__(
         self,
@@ -1363,7 +1363,7 @@ class SimpleRadiation(_DictLongtMotion, Radiative, Element):
             tauz:          Longitudinal damping time [turns]
             U0:            Energy loss per turn [eV]
 
-        Default PassMethod: ``SimpleRadiationPass``
+        Default PassMethod: ``SimpleRadiationRadPass``
         """
         assert taux >= 0.0, "taux must be greater than or equal to 0"
         if taux == 0.0:

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -82,7 +82,8 @@ def get_energy_loss(
         particle = ring.particle
         delta = 0.0
         for e in ring:
-            if e.PassMethod.endswith("RadPass"):
+            if np.logical_or(e.PassMethod.endswith("RadPass"),
+                             e.PassMethod.endswith('RadiationPass')):
                 ot = e.track(np.zeros(6), energy=energy, particle=particle)
                 delta += ot[4]
         return -delta * energy

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -82,8 +82,7 @@ def get_energy_loss(
         particle = ring.particle
         delta = 0.0
         for e in ring:
-            if np.logical_or(e.PassMethod.endswith("RadPass"),
-                             e.PassMethod.endswith('RadiationPass')):
+            if e.PassMethod.endswith("RadPass"):
                 ot = e.track(np.zeros(6), energy=energy, particle=particle)
                 delta += ot[4]
         return -delta * energy


### PR DESCRIPTION
This fixes issue #910 

The energy loss element has the name SimpleRadiationPass so was being ignored by the endswith('RadPass') when trying to compute the U0 for a lattice with a simple_ring.