### PR TITLE
Fix atlinopt with harmonic cavity

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt6.m
+++ b/atmat/atphysics/LinearOptics/atlinopt6.m
@@ -89,7 +89,7 @@ function [ringdata,elemdata] = atlinopt6(ring, varargin)
         [dpargs,varargs]=getoption(varargs,{'orbit','dp','dct','df'});
         [twiss_in,varargs]=getoption(varargs,'twiss_in',[]);
         [DPStep,~]=getoption(varargs,'DPStep');
-        [cavargs,varargs]=getoption(varargs,{'cavpts'});
+        [~,varargs]=getoption(varargs,'cavpts',[]);  % Ignore the cavpts keyword
         [refpts,varargs]=getargs(varargs,1,'check',@(arg) isnumeric(arg) || islogical(arg));
         is_6d=getoption(varargs,'is_6d',[]); % Always set by frequency_control, keep in varargs
 
@@ -124,10 +124,12 @@ function [ringdata,elemdata] = atlinopt6(ring, varargin)
         if is_6d                     % 6D processing
             [alpha,beta,disp]=cellfun(@output6,ri,'UniformOutput',false);
             if get_w || get_chrom
-                frf=get_rf_frequency(ring);
-                DFStep=-DPStep*mcf(atradoff(ring))*frf;
-                rgup=atsetcavity(ring,'Frequency',frf+0.5*DFStep,cavargs{:});
-                rgdn=atsetcavity(ring,'Frequency',frf-0.5*DFStep,cavargs{:});
+                cavities=atgetcells(ring,'Frequency');
+                freqs=atgetfieldvalues(ring,cavities,'Frequency');
+                dff=-DPStep*mcf(atradoff(ring));
+                % Scale all frequencies by the same factor
+                rgup=atsetfieldvalues(ring,cavities,freqs*(1.0+0.5*dff));
+                rgdn=atsetfieldvalues(ring,cavities,freqs*(1.0-0.5*dff));
                 [~,o1P]=findorbit6(rgup,'guess',orbitin,varargs{:});
                 [~,o1M]=findorbit6(rgdn,'guess',orbitin,varargs{:});
                 if get_w
@@ -225,13 +227,6 @@ function [ringdata,elemdata] = atlinopt6(ring, varargin)
                 bet=ab(2);
                 sigma(slc,slc)=[bet -alp;-alp (1+alp*alp)/bet];
             end
-        end
-
-        function f=get_rf_frequency(ring)
-            % Get the initial RF frequency
-            cavities=ring(atgetcells(ring, 'Frequency'));
-            freqs=atgetfieldvalues(cavities,'Frequency');
-            f=freqs(1);
         end
 
         function [chrom,w]=chrom_w(ringup,ringdn,orbup,orbdn,refpts)

--- a/atmat/atphysics/LinearOptics/atlinopt6.m
+++ b/atmat/atphysics/LinearOptics/atlinopt6.m
@@ -128,8 +128,8 @@ function [ringdata,elemdata] = atlinopt6(ring, varargin)
                 freqs=atgetfieldvalues(ring,cavities,'Frequency');
                 dff=-DPStep*mcf(atradoff(ring));
                 % Scale all frequencies by the same factor
-                rgup=atsetfieldvalues(ring,cavities,freqs*(1.0+0.5*dff));
-                rgdn=atsetfieldvalues(ring,cavities,freqs*(1.0-0.5*dff));
+                rgup=atsetfieldvalues(ring,cavities,'Frequency',freqs*(1.0+0.5*dff));
+                rgdn=atsetfieldvalues(ring,cavities,'Frequency',freqs*(1.0-0.5*dff));
                 [~,o1P]=findorbit6(rgup,'guess',orbitin,varargs{:});
                 [~,o1M]=findorbit6(rgdn,'guess',orbitin,varargs{:});
                 if get_w

--- a/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
+++ b/atmat/atphysics/ParameterSummaryFunctions/ringpara.m
@@ -47,7 +47,7 @@ global THERING %#ok<GVMIS>
     function varargout=doit(ring,is6d,Ux,varargin)
         e_mass=PhysConstant.electron_mass_energy_equivalent_in_MeV.value*1e6;	% eV
         e_radius=PhysConstant.classical_electron_radius.value;                  % m
-        hbar=PhysConstant.Planck_constant_over2pi_times_c_in_MeV_fm.value;
+        hbar=PhysConstant.reduced_Planck_constant_times_c_in_MeV_fm.value;
         cspeed = PhysConstant.speed_of_light_in_vacuum.value;                   % m/s
 
         Cq=55/32/sqrt(3)*hbar/e_mass*1E-9;   % m

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -1570,12 +1570,17 @@ def get_chrom(
         print("Warning fft method not accurate to get the chromaticity")
 
     if ring.is_6d:
-        f0 = ring.get_rf_frequency(cavpts=cavpts)
-        df = dp_step * ring.disable_6d(copy=True).slip_factor * f0
-        rgup = ring.set_rf_frequency(f0 + 0.5 * df, cavpts=cavpts, copy=True)
+        dff = dp_step * ring.disable_6d(copy=True).slip_factor
+        cavities = get_bool_index(ring, RFCavity)
+        freqs = get_value_refpts(ring, cavities, "Frequency")
+        rgup = set_value_refpts(
+            ring, cavities, "Frequency", freqs * (1.0 + 0.5 * dff), copy=True
+        )
+        rgdn = set_value_refpts(
+            ring, cavities, "Frequency", freqs * (1.0 - 0.5 * dff), copy=True
+        )
         o0up, _ = find_orbit6(rgup, **kwargs)
         tune_up = get_tune(rgup, method=method, orbit=o0up, **kwargs)
-        rgdn = ring.set_rf_frequency(f0 - 0.5 * df, cavpts=cavpts, copy=True)
         o0dn, _ = find_orbit6(rgdn, **kwargs)
         tune_down = get_tune(rgdn, method=method, orbit=o0dn, **kwargs)
         dp_step = o0up[4] - o0dn[4]

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -16,10 +16,10 @@ from .harmonic_analysis import get_tunes_harmonic
 from .matrix import find_m44, find_m66
 from .orbit import find_orbit4, find_orbit6
 from ..constants import clight
-from ..lattice import AtError
-from ..lattice import AtWarning, Lattice, Orbit, check_6d, get_s_pos
-from ..lattice import DConstant, Refpts, get_bool_index, get_uint32_index
-from ..lattice import frequency_control
+from ..lattice import AtError, AtWarning, RFCavity
+from ..lattice import Lattice, Orbit, Refpts, check_6d, get_s_pos
+from ..lattice import DConstant, get_bool_index, get_uint32_index
+from ..lattice import frequency_control, set_value_refpts, get_value_refpts
 from ..tracking import internal_lpass
 
 __all__ = [
@@ -103,7 +103,6 @@ _WX_DTYPE = [
 
 _IDX_DTYPE = [("idx", np.uint32)]
 warnings.filterwarnings("always", category=AtWarning, module=__name__)
-
 
 
 def _twiss22(t12, alpha0, beta0):
@@ -521,10 +520,15 @@ def _linopt(
     tunes = np.mod(np.angle(vps) / 2.0 / pi, 1.0)
 
     if (get_chrom or get_w) and mt.shape == (6, 6):
-        f0 = ring.get_rf_frequency(cavpts=cavpts)
-        df = dp_step * ring.disable_6d(copy=True).slip_factor * f0
-        rgup = ring.set_rf_frequency(f0 + 0.5 * df, cavpts=cavpts, copy=True)
-        rgdn = ring.set_rf_frequency(f0 - 0.5 * df, cavpts=cavpts, copy=True)
+        dff = dp_step * ring.disable_6d(copy=True).slip_factor
+        cavities = get_bool_index(ring, RFCavity)
+        freqs = get_value_refpts(ring, cavities, "Frequency")
+        rgup = set_value_refpts(
+            ring, cavities, "Frequency", freqs * (1.0 + 0.5 * dff), copy=True
+        )
+        rgdn = set_value_refpts(
+            ring, cavities, "Frequency", freqs * (1.0 - 0.5 * dff), copy=True
+        )
         if o0up is None:
             o0up, _ = get_orbit(rgup, guess=orbit, orbit=o0up, **kwargs)
             o0dn, _ = get_orbit(rgdn, guess=orbit, orbit=o0dn, **kwargs)
@@ -1176,6 +1180,7 @@ def linopt(
         mname="m44",
         **kwargs,
     )
+    # noinspection PyUnresolvedReferences
     return eld0, bd.tune, bd.chromaticity, eld
 
 


### PR DESCRIPTION
This fixes issue #915 reported by @ZeusMarti:
For computing the chromaticity, the frequency of all cavities is scaled by the same amount.

This is corrected in 
- `linopt6`/4/2 and `get_chrom` (python)
- `atlinopt6` and `tunechrom` (Matlab)
