### PR TITLE
Setting the nominal frequency on 6d lattices

### DIFF
--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -1,9 +1,6 @@
 function ring = atsetcavity(ring,varargin)
 %ATSECAVITY Set the parameters of RF cavities
 %
-%WARNING: This function modifies the time reference,
-%this should be avoided
-%
 %ATSETCAVITY may be used in two modes:
 %
 %Upgrade mode
@@ -42,9 +39,6 @@ function ring = atsetcavity(ring,varargin)
 %
 %  NOTES
 %  1. In this mode, the radiation state of the lattice is not modified.
-%  2. When dp is specified, the RF frequency is computed with the
-%     slip factor, so that the resulting dp may slightly differ from the
-%     specified value.
 %
 %
 %Compatibility mode
@@ -102,9 +96,9 @@ if isempty(varargs)             % New syntax
         lcell=findspos(ring,length(ring)+1);
         frev=beta0*CLIGHT/lcell;
         if (ischar(frequency) || isstring(frequency)) && strcmp(frequency, 'nominal')
-            hh=props_harmnumber(harmcell,cell_h);
+            hh = cellfun(@getcavh, cavities);
             if isfinite(df)
-                frev = frev + df/hh;
+                frev = frev + df/min(hh);
             elseif isfinite(dct)
                 frev=frev * lcell/(lcell+dct);
             elseif isfinite(dp)
@@ -168,6 +162,14 @@ end
                 error('AT:NoCavity','Harmonic number is unknown')
             end
             cellharm=cell_h;
+        end
+    end
+
+    function h=getcavh(cav,frev)
+        if isfield(cav,'HarmNumber')
+            h=cav.HarmNumber;
+        else
+            h=round(cav.Frequency/frev);
         end
     end
 end

--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -5,8 +5,12 @@ function ring = atsetcavity(ring,varargin)
 %
 %Upgrade mode
 %===================================================
+% By default, ATSETCAVITY will act on the "main" cavities: they are defined by the
+% cavpts ring property, or if absent by cavities at the lowest frequency.
+%
 %NEWRING=ATSETCAVITY(RING,...,'Frequency',FREQUENCY,...)
-%   Set the cavity frequency [Hz].
+%   Set the cavity frequency [Hz]. FREQUENCY is a scalar or an array as
+%   long as the list of selected cavities
 %
 %NEWRING=ATSETCAVITY(RING,...,'Frequency','nominal',...)
 %   Set the cavity frequency to the nominal value according to
@@ -22,20 +26,24 @@ function ring = atsetcavity(ring,varargin)
 %   Set the cavity frequency to the nominal value + df
 %
 %NEWRING=ATSETCAVITY(RING,...,'Voltage',VOLTAGE,...)
-%   Set the total voltage (all cells) [V]
-%   The voltage of each cavity is VOLTAGE / N_CAVITIES / PERIODICITY
+%   Set the total voltage (all cells) [V]. VOLTAGE will be distributed over the
+%   cells: CELL_VOLTAGE = VOLTAGE / PERIODICITY.
+%   Then if CELL_VOLTAGE is a scalar, it will be equally shared among the
+%   selected cavities. Otherwise it is an array as long as the list of
+%   selected cavities.
 %
 %NEWRING=ATSETCAVITY(RING,...,'HarmNumber',H,...)
-%   Set the harmonic number
+%   Set the harmonic number. H is a scalar or an array as
+%   long as the list of selected cavities
 %
 %NEWRING=ATSETCAVITY(RING,...,'TimeLag',TIMELAG,...)
-%   Set the time lag [m]
+%   Set the time lag [m], . TIMELAG is a scalar or an array as
+%   long as the list of selected cavities
 %
 %NEWRING=ATSETCAVITY(RING,...,'cavpts',CAVPTS)
-%   CAVPTS is the location of RF cavities. The default is to act on the
-%   "main" cavities: if there is is a 'cavpts' ring property. it defined
-%   the main cavities, otherwise the main cavities are cavities with the
-%   lowest frequency
+%   CAVPTS is the location of the selected RF cavities. The default is to act on the
+%   "main" cavities: they are defined by the cavpts ring property, or if absent by
+%   cavities at the lowest frequency.
 %
 %  NOTES
 %  1. In this mode, the radiation state of the lattice is not modified.

--- a/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
+++ b/atmat/atphysics/LongitudinalDynamics/atsetcavity.m
@@ -107,16 +107,18 @@ if isempty(varargs)             % New syntax
                 end
                 frequency = hh * frev;
             else
-                error('AT:Frequency', 'Wrong frequency specifiation')
+                error('AT:Frequency', 'Wrong frequency specifiation: ''%s''',frequency);
             end
         end
         cavities=atsetfieldvalues(cavities, 'Frequency', frequency);
     end
     if ~isempty(vring)
-        cavities=atsetfieldvalues(cavities, 'Voltage', vring/ncells/ncavs);
+        if numel(vring) ~= ncavs, vring=vring/ncavs; end
+        cavities=atsetfieldvalues(cavities, 'Voltage', vring/ncells);
     end
     if ~isempty(vcell)
-        cavities=atsetfieldvalues(cavities, 'Voltage', vring/ncavs);
+        if numel(vcell) ~= ncavs, vcell=vcell/ncavs; end
+        cavities=atsetfieldvalues(cavities, 'Voltage', vcell);
     end
     if ~isempty(timelag)
         cavities=atsetfieldvalues(cavities, 'TimeLag', timelag);

--- a/atmat/atutils/frequency_control.m
+++ b/atmat/atutils/frequency_control.m
@@ -21,8 +21,9 @@ if is_6d
                 'For a better efficiency, handle the RF frequency beforehand,',...
                 'or to avoid this warning, use "setoption(''WarningDp6D'',false)"');
         end
-        [cavargs,~]=getoption(varargs,{'cavpts'});
-        ring2=atsetcavity(ring,'Frequency','nominal',dpargs{:},cavargs{:});
+        [~,varargs]=getoption(varargs,{'cavpts'});  % Discard and ignore cavpts
+        cavpts=atgetcells(ring,'Frequency');        % Scale all cavities
+        ring2=atsetcavity(ring,'Frequency','nominal',dpargs{:},'cavpts',cavpts);
         [varargout{1:nargout}]=func(ring2,varargs{:},'is_6d',is_6d);
     else
         [varargout{1:nargout}]=func(ring,varargs{:},'is_6d',is_6d);

--- a/docs/p/howto/CavityControl.rst
+++ b/docs/p/howto/CavityControl.rst
@@ -15,7 +15,7 @@ select the cavities concerned by the command.
 -  if ``array is True``, the output attribute value is an array as long
    as the number of selected cavities. The input argument must be an
    array as long as the number of selected cavities or a scalar which
-   will be broadcasted to the number of cavities,
+   will be broadcasted to all the selected cavities,
 -  if ``array is False`` (default), the input and output are scalars.
    The scalar value applies to the set of cavities with the lowest
    frequency within the selection. The other cavities are ignored in
@@ -29,59 +29,50 @@ The ``cavpts`` argument is used as follows:
 - ``cavpts is None`` (default value), and the ``Lattice`` object has a
   ``cavpts`` attribute: the lattice attribute is used to select the cavities.
 - ``cavpts is None``, and the lattice has no ``cavpts`` attribute (or it is
-  ``None``): if ``array is True``, all cavities are taken into account.
-  Otherwise, the cavities with the lowest frequency are selected.
+  ``None``): all cavities are taken into account.
 
 .. note::
 
-   -  **single RF system:** you can forget the ``cavpts`` argument: by default
-      the methods address all cavities. However, using the ``Lattice.cavpts``
-      attribute makes calls significantly faster by skipping the search for
-      cavities.
-   -  **complex system:** an easy way is to have the ``Lattice.cavpts``
-      address the accelerating cavities so that they will be driven by default.
-      Harmonic cavities may be driven using the ``cavpts`` argument.
+   In most cases, the default behaviour (``cavpts=None``, ``array=False``) gives
+   the expected result: the scalar input arguments drives the main cavivities, and
+   all the other cavities are scaled or shifted.
 
-.. tip::
-
-   Adding to the Lattice "refpts"-like attributes addressing the different
-   cavity sets makes them available everywhere the lattice is visible.
+   For a more detailed control, the easiest way is to use ``cavpts`` to select
+   groups of similar cavities which can be tuned together.
 
 All ``set_*`` methods also have a ``copy`` argument to select either
 in-place modification of the lattice, or creation of a shallow copy with
 modified cavities.
 
-Voltage:
-~~~~~~~~
+Voltage
+~~~~~~~
 
-:py:func:`voltage = ring.get_rf_voltage(cavpts=None, array=False) <at.lattice.cavity_access.get_rf_voltage>`
+:py:func:`voltage = ring.get_rf_voltage(cavpts=None, array=False) <.get_rf_voltage>`
 
 The scalar voltage is the sum of the cavity voltages of the cavities
 with the lowest frequency within the selection, multiplied by the
 periodicity.
 
-:py:func:`ring.set_rf_voltage(voltage, cavpts=None, array=False, copy=False) <at.lattice.cavity_access.set_rf_voltage>`
+:py:func:`ring.set_rf_voltage(voltage, cavpts=None, array=False, copy=False) <.set_rf_voltage>`
 
-For array == False, all the existing voltages are scaled to reach the
-specified value on the fundamental mode.
+When ``array is False``, the voltages of all selected cavities are scaled to reach
+the specified value on the fundamental mode.
 
-Frequency:
-~~~~~~~~~~
+Frequency
+~~~~~~~~~
 
-:py:func:`frequency = ring.get_rf_frequency (cavpts=None, array=False) <at.lattice.cavity_access.get_rf_frequency>`
+:py:func:`frequency = ring.get_rf_frequency(cavpts=None, array=False) <.get_rf_frequency>`
 
 The frequency of the fundamental mode is returned.
 
-:py:func:`ring.set_rf_frequency(frequency=None, dp=None, dct=None, cavpts=None, array=False, copy=False) <at.physics.revolution.set_rf_frequency>`
+:py:func:`ring.set_rf_frequency(frequency=None, dp=None, dct=None, cavpts=None, array=False, copy=False) <.set_rf_frequency>`
 
 If the frequency is None, the method will set the frequency to the
 nominal value, according to the revolution frequency and harmonic
-number. An optional off-momentum may be applied using the ``dp`` or
-``dct`` arguments. The frequency shift is then computed using the linear
-slip factor :math:`\eta_c = 1/\gamma^2 - \alpha_c`, so that the resulting
-``dp`` may slightly differ from the specified value.
+number. An optional off-momentum may be applied using the ``dp``, ``dct``
+or ``df`` arguments.
 
-For array == False, the value is applied to the fundamental mode
+When ``array is False``, the value is applied to the fundamental mode
 cavities and the frequency of all other cavities is scaled by the same
 ratio.
 
@@ -91,23 +82,23 @@ Time lag
 The time lag is expressed in values of path lengthening :math:`c\tau`, the 6th
 particle coordinate [m].
 
-:py:func:`time_lag = ring.get_rf_timelag(cavpts=None, array=False) <at.lattice.cavity_access.get_rf_timelag>`
+:py:func:`time_lag = ring.get_rf_timelag(cavpts=None, array=False) <.get_rf_timelag>`
 
 The time lag of the fundamental mode is returned.
 
-:py:func:`ring.set_rf_timelag(time_lag, cavpts=None, array=False, copy=False) <at.lattice.cavity_access.set_rf_timelag>`
+:py:func:`ring.set_rf_timelag(time_lag, cavpts=None, array=False, copy=False) <.set_rf_timelag>`
 
-For array == False, the time lag is applied to the fundamental mode
+When ``array is False``, the time lag is applied to the fundamental mode
 cavities and the time lag of all the other selected cavities is shifted
 by the same amount.
 
 All-in-one method
 ~~~~~~~~~~~~~~~~~
 
-:py:func:`ring.set_cavity(ring, Voltage=None, Frequency=None, TimeLag=None, cavpts=None, array=False, copy=False) <at.lattice.cavity_access.set_cavity>`
+:py:func:`ring.set_cavity(ring, Voltage=None, Frequency=None, TimeLag=None, cavpts=None, array=False, copy=False) <.set_cavity>`
 
 This method sets only the explicitly provided values, the other ones are
-left unchanged. For the frequency, a special value :py:class:`at.Frf.NOMINAL <at.lattice.cavity_access.Frf>`
+left unchanged. For the frequency, a special value :py:class:`at.Frf.NOMINAL <.Frf>`
 means nominal frequency, according to the revolution frequency and
 harmonic number.
 
@@ -125,12 +116,12 @@ method:
   cavities by default),
 - Setting a property modifies the ring in-place (no copy).
 
-:py:attr:`~at.lattice.lattice_object.Lattice.rf_voltage`
+:py:attr:`~.Lattice.rf_voltage`
 
-:py:attr:`~at.lattice.lattice_object.Lattice.rf_frequency`
+:py:attr:`~.Lattice.rf_frequency`
 
-The special value :py:class:`at.Frf.NOMINAL <at.lattice.cavity_access.Frf>` means nominal frequency.
+The special value :py:class:`at.Frf.NOMINAL <.Frf>` means nominal frequency.
 
-:py:attr:`~at.lattice.lattice_object.Lattice.harmonic_number`
+:py:attr:`~.Lattice.harmonic_number`
 
-:py:attr:`~at.lattice.lattice_object.Lattice.rf_timelag`
+:py:attr:`~.Lattice.rf_timelag`

--- a/pyat/at/lattice/cavity_access.py
+++ b/pyat/at/lattice/cavity_access.py
@@ -1,19 +1,34 @@
-"""Access to properties of RF cavities"""
-from enum import Enum
-import numpy
-from typing import Optional
-import functools
-from .elements import RFCavity
-from .utils import AtError, make_copy, Refpts, get_bool_index
-from .lattice_object import Lattice
+"""Access to properties of RF cavities
 
-__all__ = ['frequency_control',
-           'get_rf_frequency', 'get_rf_voltage', 'set_rf_voltage',
-           'get_rf_timelag', 'set_rf_timelag', 'set_cavity', 'Frf']
+See :doc:`/p/howto/CavityControl` for a guide on using these functions.
+"""
+
+from __future__ import annotations
+
+import functools
+from enum import Enum
+
+import numpy as np
+
+from .elements import RFCavity
+from .lattice_object import Lattice
+from .utils import AtError, make_copy, Refpts
+
+__all__ = [
+    "frequency_control",
+    "get_rf_frequency",
+    "set_rf_frequency",
+    "get_rf_voltage",
+    "set_rf_voltage",
+    "get_rf_timelag",
+    "set_rf_timelag",
+    "set_cavity",
+    "Frf",
+]
 
 
 def frequency_control(func):
-    r""" Function to be used as decorator for
+    r"""Function to be used as decorator for
     :pycode:`func(ring, *args, **kwargs)`
 
     If :pycode:`ring.is_6d` is :py:obj:`True` **and** *dp*, *dct* or *df*
@@ -22,29 +37,25 @@ def frequency_control(func):
     *func* with the modified *ring*.
 
     If :pycode:`ring.is_6d` is :py:obj:`False` **or** no *dp*, *dct* or
-    *df* is specified in *kwargs*, *func* is called unchanged.
+    *df* is specified in *kwargs*, *func* is called with *ring* unchanged.
 
-    Examples:
+    Example:
 
-        .. code-block:: python
-
-            @frequency_control
-            def func(ring, *args, dp=None, dct=None, **kwargs):
-                pass
+        >>> @frequency_control
+        ... def func(ring, *args, dp=None, dct=None, df=None, **kwargs):
+        ...     pass
     """
 
     @functools.wraps(func)
     def wrapper(ring, *args, **kwargs):
         if ring.is_6d:
             momargs = {}
-            for key in ['dp', 'dct', 'df']:
+            for key in ["dp", "dct", "df"]:
                 v = kwargs.pop(key, None)
                 if v is not None:
                     momargs[key] = v
             if len(momargs) > 0:
-                frequency = ring.get_revolution_frequency(**momargs) \
-                            * ring.harmonic_number
-                ring = set_cavity(ring, Frequency=frequency, copy=True)
+                ring = set_rf_frequency(ring, copy=True, **momargs)
         return func(ring, *args, **kwargs)
 
     return wrapper
@@ -52,48 +63,50 @@ def frequency_control(func):
 
 class Frf(Enum):
     """Enum class for frequency setting"""
-    NOMINAL = 'nominal'
+
+    NOMINAL = "nominal"
 
 
-def _select_cav(ring: Lattice, cavpts):
+def _selected_cavities(ring: Lattice, cavpts: Refpts) -> list[RFCavity]:
     """Select the cavities"""
     if cavpts is None:
         try:
             cavpts = ring.cavpts
         except AttributeError:
-            cavpts = get_bool_index(ring, RFCavity)
+            cavpts = RFCavity
     return cavpts
 
 
 def _singlev(values, attr):
     """Return the single value"""
-    vals = numpy.unique(values)
+    vals = np.unique(values)
     if len(vals) > 1:
-        raise AtError('{0} not equal for all cavities'.format(attr))
+        raise AtError(f"{attr} not equal for all cavities")
     return vals[0]
 
 
 # noinspection PyUnusedLocal
 def _sumv(values, attr):
     """Return the sum of values"""
-    return numpy.sum(values)
+    return np.sum(values)
 
 
-def _fundmask(ring: Lattice, cavpts):
-    freqs = numpy.array([cav.Frequency for cav in ring.select(cavpts)])
+def _fundmask(cavities: list[RFCavity]):
+    freqs = np.array([cav.Frequency for cav in cavities])
     if len(freqs) < 1:
-        raise AtError('No cavity found in the lattice')
-    mask = (freqs == min(freqs))
+        raise AtError("No cavity found in the lattice")
+    mask = freqs == np.min(freqs)
     return mask
 
 
 def _get_cavity(ring: Lattice, attr, fsingle, cavpts=None, array=False):
-    cavpts = _select_cav(ring, cavpts)
-    vcell = numpy.array([getattr(cav, attr) for cav in ring.select(cavpts)])
+    cavpts = _selected_cavities(ring, cavpts)
+    cavities = list(ring.select(cavpts))
+    vcell = np.array([getattr(cav, attr) for cav in cavities])
     if array:
         return vcell
     else:
-        fundmask = _fundmask(ring, cavpts)
+        fundmask = _fundmask(cavities)
         if fundmask is not None:
             vcell = vcell[fundmask]
         return fsingle(vcell, attr)
@@ -103,40 +116,42 @@ def get_rf_frequency(ring: Lattice, **kwargs) -> float:
     """Return the RF frequency
 
     Parameters:
-        ring:           Lattice description
+        ring:               Lattice description
 
     Keyword Arguments:
-        cavpts=None:    Cavity location. If None, look for ring.cavpts,
-                          otherwise take all cavities.
-        array=False:    If False, return the frequency of the selected cavities
-                          with the lowest frequency.
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities. The main cavities are those with the lowest
+          frequency among the selected ones.
+        array (bool):       If :py:obj:`False`, return the frequency of the main
+          cavities (selected cavities with the lowest frequency).
 
-                          If True, return the frequency of all selected cavities
+          If :py:obj:`True`, return the frequency of each selected cavity.
 
     Returns:
-        rf_freq:    RF frequency
+        rf_freq:    RF frequency [Hz]
     """
-    return _get_cavity(ring, 'Frequency', _singlev, **kwargs)
+    return _get_cavity(ring, "Frequency", _singlev, **kwargs)
 
 
 def get_rf_voltage(ring: Lattice, **kwargs) -> float:
-    """Return the total RF voltage (full ring)
+    """Return the total RF voltage (full ring including periodicity)
 
     Parameters:
-        ring:           Lattice description
+        ring:               Lattice description
 
     Keyword Arguments:
-        cavpts=None:    Cavity location. If None, look for ring.cavpts,
-                          otherwise take all cavities.
-        array=False:    If False, return the frequency of the selected cavities
-                          with the lowest frequency.
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities. The main cavities are those with the lowest
+          frequency among the selected ones.
+        array (bool):       If :py:obj:`False`, return the sum of the voltage of the
+          main cavities (selected cavities with the lowest frequency).
 
-                          If True, return the frequency of all selected cavities
+          If :py:obj:`True`, return the voltage of each selected cavity.
 
     Returns:
-        rf_v:       Total RF voltage (full ring)
+        rf_v:       Total voltage (full ring including periodicity) [V]
     """
-    vcell = _get_cavity(ring, 'Voltage', _sumv, **kwargs)
+    vcell = _get_cavity(ring, "Voltage", _sumv, **kwargs)
     return ring.periodicity * vcell
 
 
@@ -147,137 +162,185 @@ def get_rf_timelag(ring: Lattice, **kwargs) -> float:
         ring:           Lattice description
 
     Keyword Arguments:
-        cavpts=None:    Cavity location. If None, look for ring.cavpts,
-                          otherwise take all cavities.
-        array=False:    If False, return the frequency of the selected cavities
-                          with the lowest frequency.
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities. The main cavities are those with the lowest
+          frequency among the selected ones.
+        array (bool):       If :py:obj:`False`, return the timelag of the main cavities
+          (selected cavities with the lowest frequency).
 
-                          If True, return the frequency of all selected cavities
+          If :py:obj:`True`, return the timelag of each selected cavity.
 
     Returns:
-        rf_timelag: RF time lag
+        rf_timelag: RF time lag as path lengthening [m]
     """
-    return _get_cavity(ring, 'TimeLag', _singlev, **kwargs)
+    return _get_cavity(ring, "TimeLag", _singlev, **kwargs)
 
 
-def set_rf_voltage(ring: Lattice, voltage: float, **kwargs):
+def set_rf_frequency(
+    ring: Lattice, frequency: float | Frf = Frf.NOMINAL, **kwargs
+) -> Lattice | None:
+    """Set the RF frequency
+
+    Parameters:
+        ring:           Lattice description
+        frequency:      RF frequency [Hz]. Default: nominal frequency.
+
+    Keyword Args:
+        dp (float | None):  Momentum deviation. Defaults to :py:obj:`None`
+        dct (float | None): Path lengthening. Defaults to :py:obj:`None`
+        df (float | None):  Deviation of RF frequency. Defaults to :py:obj:`None`
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities.
+        array (bool):       If :py:obj:`False` (default), *frequency* is applied to
+          the selected cavities with the lowest frequency. The frequency of all the
+          other selected cavities is scaled by the same ratio.
+
+          If :py:obj:`True`, directly apply *frequency* to the selected cavities. The
+          value must be broadcastable to the number of cavities.
+        copy (bool):        If :py:obj:`True`, returns a shallow copy of *ring* with
+          new cavity elements. Otherwise (default), modify *ring* in-place.
+    """
+    return set_cavity(ring, Frequency=frequency, **kwargs)
+
+
+def set_rf_voltage(ring: Lattice, voltage: float, **kwargs) -> Lattice | None:
     """Set the RF voltage for the full ring
 
     Parameters:
         ring:           Lattice description
-        voltage:        Total RF voltage (full ring)
+        voltage:        Total RF voltage (full ring taking periodicity into account) [V]
 
     Keyword Arguments:
-        cavpts=None:    Cavity location. If None, look for ring.cavpts,
-                          otherwise take all cavities.
-        array=False:    If False, return the frequency of the selected cavities
-                          with the lowest frequency.
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities.
+        array (bool):       If :py:obj:`False` (default), the voltage of the main
+          cavities is scaled to achieve the desired *voltage*. The voltage of the other
+          cavities is scaled by the same ratio.
 
-                          If True, return the frequency of all selected cavities
-        copy=False:     If True, returns a shallow copy of ``ring`` with new
-                          cavity elements. Otherwise, modify ``ring`` in-place.
+          If :py:obj:`True`, directly apply *voltage* to the selected cavities. The
+          value must be broadcastable to the number of cavities.
+        copy (bool):        If :py:obj:`True`, returns a shallow copy of *ring* with
+          new cavity elements. Otherwise (default), modify *ring* in-place.
     """
     return set_cavity(ring, Voltage=voltage, **kwargs)
 
 
-def set_rf_timelag(ring: Lattice, timelag: float, **kwargs):
+def set_rf_timelag(ring: Lattice, timelag: float, **kwargs) -> Lattice | None:
     """Set the RF time lag
 
     Parameters:
         ring:           Lattice description
-        timelag:        RF time lag
+        timelag:        RF time lag, expressed as path lengthening [m]
 
     Keyword Arguments:
-        cavpts=None:    Cavity location. If None, look for ring.cavpts,
-                          otherwise take all cavities.
-        array=False:    If False, return the frequency of the selected cavities
-                          with the lowest frequency.
+        cavpts (Refpts | None):  If :py:obj:`None`, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities.
+        array (bool):       If :py:obj:`False` (default), *timelag* is applied to the
+          main cavities. The timelag of the other cavities is shifted by the same
+          amount.
 
-                          If True, return the frequency of all selected cavities
-        copy=False:     If True, returns a shallow copy of ``ring`` with new
-                          cavity elements. Otherwise, modify ``ring`` in-place.
+          If :py:obj:`True`, directly apply *timelag* to the selected cavities. The
+          value must be broadcastable to the number of cavities.
+        copy (bool):    If :py:obj:`True`, returns a shallow copy of *ring* with new
+          cavity elements. Otherwise (default), modify *ring* in-place.
     """
     return set_cavity(ring, TimeLag=timelag, **kwargs)
 
 
 # noinspection PyPep8Naming
-def set_cavity(ring: Lattice, Voltage: Optional[float] = None,
-               Frequency: Optional[float] = None,
-               TimeLag: Optional[float] = None,
-               cavpts: Optional[Refpts] = None,
-               copy: Optional[bool] = False,
-               array: Optional[bool] = False):
+def set_cavity(
+    ring: Lattice,
+    Voltage: float | None = None,
+    Frequency: float | Frf | None = None,
+    TimeLag: float | None = None,
+    cavpts: Refpts | None = None,
+    copy: bool = False,
+    array: bool = False,
+    **kwargs,
+) -> Lattice | None:
     """
     Set the parameters of the RF cavities
 
     Parameters:
-        ring:       lattice description
-        Frequency:  RF frequency [Hz]
-        Voltage:    RF voltage [V]
-        TimeLag:    RF time shift [-ct]
-        cavpts:     Cavity location. If None, look for ring.cavpts, or
-                      otherwise take all cavities
-        array:      If False, the value is applied as described for
-                      set_rf_voltage, set_rf_timelag and set_rf_frequency
-                      If True, directly apply the value to the selected
-                      cavities. The value must be broadcastable to the number
-                      of cavities.
-        copy:       If True, returns a shallow copy of ring with new
-                      cavity elements. Otherwise, modify ring in-place
+        ring:           lattice description
+        Frequency:      RF frequency [Hz]
+        Voltage:        Total RF voltage [V]
+        TimeLag:        RF time shift expressed as path lengthening [m]
+        cavpts:         Cavity location. If None, look for :pycode:`ring.cavpts`, or
+          otherwise take all cavities
+        array:          If :py:obj:`False`, the value is applied as described for
+          :py:func:`set_rf_voltage`, :py:func:`set_rf_timelag` and
+          :py:func:`set_rf_frequency`.
+
+          If :py:obj:`True`, directly apply the values to the selected cavities. The
+          values must be broadcastable to the number of cavities.
+        copy (bool):    If :py:obj:`True`, returns a shallow copy of *ring* with new
+          cavity elements. Otherwise (default), modify *ring* in-place.
     """
+
     # noinspection PyShadowingNames
-    def getv(ring: Lattice, attr, refpts):
-        values = numpy.array([getattr(c, attr) for c in ring.select(refpts)])
+    def getv(cavities: list[RFCavity], attr: str):
+        values = np.array([getattr(el, attr) for el in cavities])
         valfund = values[fundmask]
         return values, valfund
 
-    cavpts = _select_cav(ring, cavpts)
-    fundmask = None if array else _fundmask(ring, cavpts)
+    def nominal(elem: RFCavity, cell_frev: float) -> float:
+        cell_h = getattr(elem, "HarmNumber", 0)
+        if cell_h == 0:
+            cell_h = round(elem.Frequency / cell_frev)
+        return cell_h * cell_frev
+
+    # noinspection PyShadowingNames
+    @make_copy(copy)
+    def apply(rg: Lattice, cavpts, modif):
+        cavities = list(rg.select(cavpts))
+        ncavs = len(cavities)
+        for attr, values in modif.items():
+            try:
+                values = np.broadcast_to(values, (ncavs,))
+            except ValueError:
+                raise ValueError(
+                    f"{attr} should be either scalar or a ({ncavs},) array"
+                ) from None
+            for val, cavity in zip(values, cavities):
+                setattr(cavity, attr, val)
+
+    cavpts = _selected_cavities(ring, cavpts)
+    cavities = list(ring.select(cavpts))
+    fundmask = _fundmask(cavities)
 
     modif = {}
     if Frequency is not None:
         if Frequency is Frf.NOMINAL:
-            Frequency = ring.revolution_frequency * ring.harmonic_number
-        if fundmask is not None:
-            vall, vmain = getv(ring, 'Frequency', cavpts)
+            cell_f = ring.get_revolution_frequency(**kwargs) * ring.periodicity
+            Frequency = np.array([nominal(el, cell_f) for el in cavities])
+        elif not array:
+            vall, vmain = getv(cavities, "Frequency")
             vmain = vmain[0]
             if vmain == 0.0:
                 vall[fundmask] = Frequency
                 Frequency = vall
             else:
-                Frequency *= vall/vmain
-        modif['Frequency'] = Frequency
+                Frequency *= vall / vmain
+        modif["Frequency"] = Frequency
 
     if TimeLag is not None:
-        if fundmask is not None:
-            vall, vmain = getv(ring, 'TimeLag', cavpts)
-            TimeLag += vall-_singlev(vmain, 'TimeLag')
-        modif['TimeLag'] = TimeLag
+        if not array:
+            vall, vmain = getv(cavities, "TimeLag")
+            TimeLag += vall - _singlev(vmain, "TimeLag")
+        modif["TimeLag"] = TimeLag
 
     if Voltage is not None:
         vcell = Voltage / ring.periodicity
-        if fundmask is not None:
-            vall, vmain = getv(ring, 'Voltage', cavpts)
-            vmain = numpy.sum(vmain)
+        if not array:
+            vall, vmain = getv(cavities, "Voltage")
+            vmain = np.sum(vmain)
             if vmain == 0.0:
-                vall[fundmask] = vcell/numpy.count_nonzero(fundmask)
+                vall[fundmask] = vcell / np.count_nonzero(fundmask)
                 vcell = vall
             else:
-                vcell *= vall/vmain
-        modif['Voltage'] = vcell
-
-    # noinspection PyShadowingNames
-    @make_copy(copy)
-    def apply(ring: Lattice, cavpts, modif):
-        ncavs = ring.refcount(cavpts)
-        for attr in modif.keys():
-            try:
-                values = numpy.broadcast_to(modif[attr], (ncavs,))
-            except ValueError:
-                raise AtError('set_cavity args should be either scalar or '
-                              'a ({0},) vector'.format(ncavs))
-            for val, cavity in zip(values, ring.select(cavpts)):
-                cavity.update({attr: val})
+                vcell *= vall / vmain
+        modif["Voltage"] = vcell
 
     return apply(ring, cavpts, modif)
 
@@ -286,9 +349,18 @@ Lattice.get_rf_voltage = get_rf_voltage
 Lattice.get_rf_frequency = get_rf_frequency
 Lattice.get_rf_timelag = get_rf_timelag
 Lattice.set_rf_voltage = set_rf_voltage
+Lattice.set_rf_frequency = set_rf_frequency
 Lattice.set_rf_timelag = set_rf_timelag
 Lattice.set_cavity = set_cavity
-Lattice.rf_voltage = property(get_rf_voltage, set_rf_voltage,
-                              doc="RF voltage of the full ring [V]")
-Lattice.rf_timelag = property(get_rf_timelag, set_rf_timelag,
-                              doc="Time lag of the fundamental mode [m]")
+Lattice.rf_voltage = property(
+    get_rf_voltage, set_rf_voltage, doc="RF voltage of the full ring [V]"
+)
+Lattice.rf_timelag = property(
+    get_rf_timelag, set_rf_timelag, doc="Time lag of the fundamental mode [m]"
+)
+Lattice.rf_frequency = property(
+    get_rf_frequency,
+    set_rf_frequency,
+    doc="Fundamental RF frequency [Hz]. The special value "
+    ":py:class:`Frf.NOMINAL <.Frf>` means nominal frequency.",
+)

--- a/pyat/at/physics/revolution.py
+++ b/pyat/at/physics/revolution.py
@@ -1,29 +1,32 @@
-from ..lattice import Lattice, get_rf_frequency, check_6d, get_s_pos
-from ..lattice import DConstant
-from ..constants import clight
-from ..tracking import internal_lpass
-from .orbit import find_orbit4
-import numpy
-from typing import Optional
+"""Revolution frequency, momentum compaction factor, slip factor"""
+from __future__ import annotations
 
-__all__ = ['get_mcf', 'get_slip_factor', 'get_revolution_frequency',
-           'set_rf_frequency']
+__all__ = ["get_mcf", "get_slip_factor", "get_revolution_frequency"]
+
+import numpy as np
+
+from .orbit import find_orbit4
+from ..constants import clight
+from ..lattice import DConstant, Lattice, check_6d, get_s_pos
+from ..tracking import internal_lpass
 
 
 @check_6d(False)
-def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
-            keep_lattice: bool = False,
-            fit_order: Optional[int] = 1,
-            n_step: Optional[int] = 2,
-            **kwargs) -> float:
+def get_mcf(
+    ring: Lattice,
+    dp: float = 0.0,
+    keep_lattice: bool = False,
+    fit_order: int = 1,
+    n_step: int = 2,
+    **kwargs,
+) -> float:
     r"""Compute the momentum compaction factor :math:`\alpha`
 
     Parameters:
         ring:           Lattice description (:pycode:`ring.is_6d` must be
           :py:obj:`False`)
-        dp:             Momentum deviation. Defaults to :py:obj:`None`
+        dp:             Momentum deviation
         keep_lattice:   Assume no lattice change since the previous tracking.
-          Default: :py:obj:`False`
         fit_order:      Maximum momentum compaction factor order to be fitted.
           Default to 1, corresponding to the first-order momentum compaction factor.
         n_step:         Number of different calculated momentum deviations to be fitted
@@ -31,30 +34,35 @@ def get_mcf(ring: Lattice, dp: Optional[float] = 0.0,
           Default to 2.
 
     Keyword Args:
-        DPStep (Optional[float]):       Momentum step size.
+        DPStep (float): Momentum step size.
           Default: :py:data:`DConstant.DPStep <.DConstant>`
 
     Returns:
         mcf (float/array):    Momentum compaction factor :math:`\alpha`
-          up to the order fit_order. Returns a float if fit_order=1 otherwise
+          up to the order *fit_order*. Returns a float if *fit_order==1* otherwise
           returns an array.
     """
-    if n_step < 2*fit_order:
-        raise ValueError('Low nunber of steps, it is advised to have n_step >= 2*fit_order'+
-        ' for a better fit.')
-    dp_step = kwargs.pop('DPStep', DConstant.DPStep)
-    dp_samples = numpy.linspace(-dp_step/2, dp_step/2, n_step)
-    fp_i = tuple(find_orbit4(ring, dp=dp + dp_i, keep_lattice=keep_lattice)[0] \
-       for dp_i in dp_samples)
-    fp = numpy.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
-    b = numpy.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
+    if n_step < 2 * fit_order:
+        raise ValueError(
+            "Low number of steps, it is advised to have n_step >= 2*fit_order"
+            + " for a better fit."
+        )
+    dp_step = kwargs.pop("DPStep", DConstant.DPStep)
+    dp_samples = np.linspace(-dp_step / 2, dp_step / 2, n_step)
+    fp_i = tuple(
+        find_orbit4(ring, dp=dp + dp_i, keep_lattice=keep_lattice)[0]
+        for dp_i in dp_samples
+    )
+    fp = np.stack(fp_i, axis=0).T  # generate a Fortran contiguous array
+    b = np.squeeze(internal_lpass(ring, fp, keep_lattice=True), axis=(2, 3))
     ring_length = get_s_pos(ring, len(ring))
-    p = numpy.polynomial.Polynomial.fit(b[4], b[5], deg=fit_order).convert().coef
+    p = np.polynomial.Polynomial.fit(b[4], b[5], deg=fit_order).convert().coef
     alphac = p[1:] / ring_length[0]
-    return alphac[0] if len(alphac)<2 else alphac
+    return alphac[0] if len(alphac) < 2 else alphac
+
 
 def get_slip_factor(ring: Lattice, **kwargs) -> float:
-    r"""Compute the slip factor :math:`\eta`
+    r"""Compute the slip factor :math:`\eta=1/\gamma^2-\alpha`
 
     Parameters:
         ring:           Lattice description (:pycode:`ring.is_6d` must be
@@ -69,14 +77,13 @@ def get_slip_factor(ring: Lattice, **kwargs) -> float:
         eta (float):    Slip factor :math:`\eta`
     """
     gamma = ring.gamma
-    etac = (1.0/gamma/gamma - get_mcf(ring, **kwargs))
+    etac = 1.0 / gamma / gamma - get_mcf(ring, **kwargs)
     return etac
 
 
-def get_revolution_frequency(ring: Lattice,
-                             dp: float = None,
-                             dct: float = None,
-                             df: float = None) -> float:
+def get_revolution_frequency(
+    ring: Lattice, dp: float = None, dct: float = None, df: float = None
+) -> float:
     """Compute the revolution frequency of the full ring [Hz]
 
     Parameters:
@@ -96,43 +103,11 @@ def get_revolution_frequency(ring: Lattice,
         # Find the path lengthening for dp
         rnorad = ring.disable_6d(copy=True) if ring.is_6d else ring
         orbit = internal_lpass(rnorad, rnorad.find_orbit4(dp=dp)[0])
-        dct = numpy.squeeze(orbit)[5]
+        dct = np.squeeze(orbit)[5]
         cell_frev *= lcell / (lcell + dct)
     elif df is not None:
         cell_frev += df / ring.cell_harmnumber
     return cell_frev / ring.periodicity
-
-
-def set_rf_frequency(ring: Lattice, frequency: float = None,
-                     dp: float = None, dct: float = None, df: float = None,
-                     **kwargs):
-    """Set the RF frequency
-
-    Parameters:
-        ring:           Lattice description
-        frequency:      RF frequency [Hz]. Default: nominal frequency.
-        dp:             Momentum deviation. Defaults to :py:obj:`None`
-        dct:            Path lengthening. Defaults to :py:obj:`None`
-        df:             Deviation of RF frequency. Defaults to :py:obj:`None`
-
-    Keyword Args:
-        cavpts (Optional[Refpts]):  If :py:obj:`None`, look for ring.cavpts, or
-          otherwise take all cavities.
-        array (Optional[bool]):     If :py:obj:`False` (default), *frequency*
-          is applied to the selected cavities with the lowest frequency. The
-          frequency of all the other selected cavities is scaled by the same
-          ratio.
-
-          If :py:obj:`True`, directly apply *frequency* to the selected
-          cavities. The value must be broadcastable to the number of cavities.
-        copy (Optional[bool]):     If :py:obj:`True`, returns a shallow copy of
-          *ring* with new cavity elements. Otherwise (default), modify
-          *ring* in-place
-    """
-    if frequency is None:
-        frequency = get_revolution_frequency(ring, dp=dp, dct=dct, df=df) \
-                    * ring.harmonic_number
-    return ring.set_cavity(Frequency=frequency, **kwargs)
 
 
 Lattice.mcf = property(get_mcf, doc="Momentum compaction factor")
@@ -140,7 +115,3 @@ Lattice.slip_factor = property(get_slip_factor, doc="Slip factor")
 Lattice.get_mcf = get_mcf
 Lattice.get_slip_factor = get_slip_factor
 Lattice.get_revolution_frequency = get_revolution_frequency
-Lattice.set_rf_frequency = set_rf_frequency
-Lattice.rf_frequency = property(get_rf_frequency, set_rf_frequency,
-    doc="Fundamental RF frequency [Hz]. The special value "
-        ":py:class:`Frf.NOMINAL <.Frf>` means nominal frequency.")


### PR DESCRIPTION
This modification follows what was done in #917: in 6d lattice, a momentum change is done by changing the RF frequency. #917 fixes a problem in chromaticity correction, we propose to do the same when setting the off-momentum for all optics computations: `find_orbit`, `linopt`, `get_tune`, `get_chrom`…

`frequency_control` (both Matlab and python) is responsible for setting the nominal frequency and will now act on all cavities for setting the off-momentum.

For this, `atsetcavity` (Matlab) and `set_cavity` (python) are modified for setting the nominal frequency. Their behaviour for other settings is unchanged. The modification is:

**Present behaviour:**
For all selected cavities:
1. Identify the "main" cavities and compute their new frequency for the required off momentum,
2. Set the main cavities to the new frequency and record the ratio new/old frequency,
3. Scale all other selected cavities by the same ratio.

**New behaviour:**
For all selected cavities (no change):
1. get the harmonic number of all cavities: take the cavity's HarmNumber attribute if existing, otherwise round the ratio cavity_frequency/revolution_frequency,
2. Apply h*frev on all selected cavities.

**Benefits:**
- no need to guess which are the "main" cavities (usually taken as the lowest frequency unless specified in Lattice attributes)
- the new setting totally ignores any previous one. If all cavity.HarmNumber are specified, one can start from unspecified (or 0)  frequencies, as in MAD-X

Apart from the new way of computing the nominal frequencies, the behaviour of  `atsetcavity`  and `set_cavity` is unchanged.
