### PR TITLE
Reorganise the rotation and translation functions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -14,6 +14,7 @@ from .elements import *
 from .rectangular_bend import *
 from .idtable_element import InsertionDeviceKickMap
 from .utils import *
+from .transformation import *
 from .lattice_object import *
 # from .lattice_variables import *
 from .cavity_access import *

--- a/pyat/at/lattice/deprecated.py
+++ b/pyat/at/lattice/deprecated.py
@@ -45,7 +45,7 @@ def get_cells(ring: Sequence[Element], refpts: Refpts, *args,
         >>> refpts = get_cells(ring, 'Frequency')
 
         Returns a numpy array of booleans where all elements having a
-        :pycode:`Frequency` attribute are :py:obj:`True`
+        :pycode:`Frequency` attribute :py:obj:`True`
 
         >>> refpts = get_cells(ring, 'K', 0.0)
 
@@ -88,27 +88,27 @@ def get_refpts(ring: Sequence[Element], refpts: Refpts,
 
 def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
                 yaw: float = 0.0, relative: bool = False) -> None:
-    r"""Set the tilt, pitch and yaw angle of an :py:class:`.Element`.
+    r"""Set the tilt, pitch, and yaw angle of an :py:class:`.Element`.
     The tilt is a rotation around the *s*-axis, the pitch is a
-    rotation around the *x*-axis and the yaw is a rotation around
+    rotation around the *x*-axis, and the yaw is a rotation around
     the *y*-axis.
 
     A positive angle represents a clockwise rotation when
     looking in the direction of the rotation axis.
 
-    The transformations are not all commmutative, the pitch and yaw
-    are applied first and the tilt is always the last transformation
+    The transformations are not all commutative, the pitch and yaw
+    are applied first, and the tilt is always the last transformation
     applied. The element is rotated around its mid-point.
 
     If *relative* is :py:obj:`True`, the previous angle and shifts
-    are rebuilt form the *R* and *T* matrix and incremented by the
+    are rebuilt from the *R* and *T* matrix and incremented by the
     input arguments.
 
     The shift is always conserved regardless of the value of *relative*.
 
     The transformations are applied by changing the particle coordinates
     at the entrance of the element and restoring them at the end. Following
-    the small angles approximation the longitudinal shift of the particle
+    the small angles approximation, the longitudinal shift of the particle
     coordinates is neglected and the element length is unchanged.
 
     Parameters:
@@ -168,28 +168,6 @@ def rotate_elem(elem: Element, tilt: float = 0.0, pitch: float = 0.0,
     elem.R2 = r2
     elem.T1 = t1+t10
     elem.T2 = t2+t20
-    
-def shift_elem(elem: Element, deltax: float = 0.0, deltaz: float = 0.0,
-               relative: bool = False) -> None:
-    r"""Sets the transverse displacement of an :py:class:`.Element`
-
-    The translation vectors are stored in the :pycode:`T1` and :pycode:`T2`
-    attributes.
-
-    Parameters:
-        elem:           Element to be shifted
-        deltax:         Horizontal displacement [m]
-        deltaz:         Vertical displacement [m]
-        relative:       If :py:obj:`True`, the translation is added to the
-          existing one
-    """
-    tr = numpy.array([deltax, 0.0, deltaz, 0.0, 0.0, 0.0])
-    if relative and hasattr(elem, 'T1') and hasattr(elem, 'T2'):
-        elem.T1 -= tr
-        elem.T2 += tr
-    else:
-        elem.T1 = -tr
-        elem.T2 = tr
 
 
 Lattice.uint32_refpts = get_uint32_index

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -452,38 +452,6 @@ class Element:
         """:py:obj:`True` if the element involves collective effects"""
         return self._get_collective()
 
-    def _getshift(self, idx: int):
-        t1 = getattr(self, "T1", _zero6)
-        t2 = getattr(self, "T2", _zero6)
-        return 0.5 * float(t2[idx] - t1[idx])
-
-    def _setshift(self, value: float, idx: int) -> None:
-        t1 = getattr(self, "T1", _zero6.copy())
-        t2 = getattr(self, "T2", _zero6.copy())
-        sm = 0.5 * (t2[idx] + t1[idx])
-        t2[idx] = sm + value
-        t1[idx] = sm - value
-        self.T1 = t1
-        self.T2 = t2
-
-    @property
-    def dx(self) -> float:
-        """Horizontal element shift"""
-        return self._getshift(0)
-
-    @dx.setter
-    def dx(self, value: float) -> None:
-        self._setshift(value, 0)
-
-    @property
-    def dy(self) -> float:
-        """Vertical element shift"""
-        return self._getshift(2)
-
-    @dy.setter
-    def dy(self, value: float) -> None:
-        self._setshift(value, 2)
-
     @property
     def tilt(self) -> float:
         """Element tilt"""

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -452,28 +452,6 @@ class Element:
         """:py:obj:`True` if the element involves collective effects"""
         return self._get_collective()
 
-    @property
-    def tilt(self) -> float:
-        """Element tilt"""
-        r1 = getattr(self, "R1", _eye6)
-        r2 = getattr(self, "R2", _eye6)
-        c = float(r2[0, 0] + r1[0, 0])
-        s = float(r2[2, 0] - r1[2, 0])
-        return math.atan2(s, c)
-
-    @tilt.setter
-    def tilt(self, value: float) -> None:
-        r1 = getattr(self, "R1", _eye6.copy())
-        r2 = getattr(self, "R2", _eye6.copy())
-        ct, st = math.cos(value), math.sin(value)
-        r44 = np.diag([ct, ct, ct, ct])
-        r44[0, 2] = r44[1, 3] = st
-        r44[2, 0] = r44[3, 1] = -st
-        r1[:4, :4] = r44
-        r2[:4, :4] = r44.T
-        self.R1 = r1
-        self.R2 = r2
-
 
 class LongElement(Element):
     """Base class for long elements"""

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import abc
 import re
-import math
 from abc import ABC
 from collections.abc import Generator, Iterable
 from copy import copy, deepcopy
@@ -53,7 +52,7 @@ class LongtMotion(ABC):
     """Abstract Base class for all Element classes whose instances may modify
     the particle momentum
 
-    Allows to identify elements potentially inducing longitudinal motion.
+    Allows identifying elements potentially inducing longitudinal motion.
 
     Subclasses of :py:class:`LongtMotion` must provide two methods for
     enabling longitudinal motion:
@@ -467,7 +466,7 @@ class LongElement(Element):
         Other arguments and keywords are given to the base class
         """
         kwargs.setdefault("Length", length)
-        # Ancestor may be either Element of ThinMultipole
+        # Ancestor may be either Element or ThinMultipole
         # noinspection PyArgumentList
         super().__init__(family_name, *args, **kwargs)
 
@@ -562,7 +561,7 @@ class BeamMoments(Element):
 
 
 class SliceMoments(Element):
-    """Element to compute slices mean and std"""
+    """Element computing the mean and std of slices"""
 
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["nslice"]
     _conversions = dict(Element._conversions, nslice=int)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -46,7 +46,8 @@ from .utils import get_s_pos, get_elements, get_value_refpts, set_value_refpts
 
 # noinspection PyProtectedMember
 from .utils import get_uint32_index, get_bool_index, _refcount, Uint32Refpts
-from .utils import refpts_iterator, checktype, set_shift, set_tilt, get_geometry
+from .utils import refpts_iterator, checktype, get_geometry
+from .transformation import set_rotation, set_tilt, set_shift
 from ..constants import clight, e_mass
 
 _TWO_PI_ERROR = 1.0e-4
@@ -1580,6 +1581,7 @@ Lattice.get_bool_index = get_bool_index
 Lattice.refcount = _refcount
 Lattice.set_shift = set_shift
 Lattice.set_tilt = set_tilt
+Lattice.set_rotation = set_rotation
 Lattice.get_elements = get_elements
 Lattice.get_s_pos = get_s_pos
 Lattice.select = refpts_iterator

--- a/pyat/at/lattice/transformation.py
+++ b/pyat/at/lattice/transformation.py
@@ -13,6 +13,7 @@ _y_axis = np.array([0.0, 1.0, 0.0])
 _z_axis = np.array([0.0, 0.0, 1.0])
 
 
+# noinspection PyPep8Naming
 def _rotation(rotations):
     """
     The implementation follows the one described in:
@@ -48,6 +49,7 @@ def _rotation(rotations):
     return R_x @ R_y @ R_z
 
 
+# noinspection PyPep8Naming
 def _translation_vector(ld, r3d, offsets, X_axis, Y_axis):
     """
     The implementation follows the one described in:
@@ -55,7 +57,7 @@ def _translation_vector(ld, r3d, offsets, X_axis, Y_axis):
     All the comments featuring 'Eq' points to the paper's equations.
 
     Translation vector resulting from the joint effect of a longitudinal
-    displacement (in the rotated frame), 3D offsets and the 3D rotation matrix.
+    displacement (in the rotated frame), 3D offsets, and the 3D rotation matrix.
     Corresponds to Eqs. (8-11)
     ld: Longitudinal displacement [m]
     r3d: 3D rotation matrix
@@ -77,6 +79,7 @@ def _translation_vector(ld, r3d, offsets, X_axis, Y_axis):
     return T0 + tD0
 
 
+# noinspection PyPep8Naming
 def _offsets_from_translation_vector(T, ld, r3d, X_axis, Y_axis, Z_axis):
     """
     Retrieve the 3D offsets from the T1 translation vector.
@@ -172,6 +175,7 @@ class ReferencePoint(Enum):
     ENTRANCE = "ENTRANCE"
 
 
+# noinspection PyPep8Naming
 def get_offsets_rotations(
     elem: Element,
     reference: ReferencePoint = ReferencePoint.CENTRE,
@@ -243,6 +247,7 @@ def get_offsets_rotations(
     return offsets, tilt, yaw, pitch
 
 
+# noinspection PyPep8Naming
 def transform_elem(
     elem: Element,
     reference: ReferencePoint = ReferencePoint.CENTRE,
@@ -255,38 +260,35 @@ def transform_elem(
     *,
     relative: bool = False,
 ) -> None:
-    r"""Set the tilt, pitch and yaw angle of an :py:class:`.Element`.
+    r"""Set the displacements and angles of an :py:class:`.Element`.
+
     The tilt is a rotation around the *s*-axis, the pitch is a
-    rotation around the *x*-axis and the yaw is a rotation around
-    the *y*-axis.
+    rotation around the *x*-axis, and the yaw is a rotation around the *y*-axis.
 
     A positive angle represents a clockwise rotation when
     looking in the direction of the rotation axis.
 
-    The transformations are not all commmutative. The translations are appled before
+    The transformations are not all commutative. The translations are applied before
     the rotations. The rotations are applied in the order *Z* -> *Y* -> *X*
     (tilt -> yaw -> pitch). The element is rotated around its mid-point. The mid-point
     can either be the element entrance or its centre (axis joining the entry and exit
     points of the element).
 
-    If *relative* is :py:obj:`True`, the previous angles are rebuilt from the
-    *r3d* matrix and incremented by the input arguments.
-    *relative* only allows to add the previous angles, not the transverse
-    shifts.
-    The shift is always absolute regardless of the value of *relative*.
+    If *relative* is :py:obj:`True`, the previous translations and angles are rebuilt
+    from the *r3d* matrix and incremented by the input arguments.
 
-    pyAT describes the ultra-relativistic beam dynamics in 6D phase space
+    PyAT describes the ultra-relativistic beam dynamics in 6D phase space
     coordinates, which differ from 3D spatial angles in an expansion with
-    respect to the energy to first order by a factor :math:`(1 + \delta)` , where
-    :math:`\delta` is the relative energy offset. This introduces
-    a spurious dispersion (angle proportional to :math:`\delta`).
+    respect to the energy to first order by a factor :math:`(1 + \delta)`, where
+    :math:`\delta` is the relative momentum deviation. This introduces
+    spurious dispersion (angle proportional to :math:`\delta`).
 
     The implementation follows the one described in:
     https://doi.org/10.1016/j.nima.2022.167487
-    All the comments featuring 'Eq' points to the paper's equations.
+    All the comments featuring 'Eq' point to the paper's equations.
 
     Parameters:
-        elem:           Element to be ytansformed.
+        elem:           Element to be transformed.
         reference:      Transformation reference, either
                         :py:obj:`ReferencePoint.CENTRE` or
                         :py:obj:`ReferencePoint.ENTRANCE`.
@@ -296,11 +298,11 @@ def transform_elem(
         tilt:           Tilt angle [rad]. Default: no change.
         pitch:          Pitch angle [rad]. Default: no change.
         yaw:            Yaw angle [rad]. Default: no change
-        relative:       If :py:obj:`True`, the rotation is added to. the
-          previous one.
+        relative:       If :py:obj:`True`, the input values are added to the
+          previous ones.
 
     See Also:
-        :py:func':`get_offsets_rotations`:
+        :py:func:`get_offsets_rotations`
     """
     if relative:
 
@@ -413,7 +415,7 @@ def _set_dx(elem: Element, value: float) -> None:
 
 
 def _get_dy(elem: Element) -> float:
-    """Horizontal element shift"""
+    """Vertical element shift"""
     offsets, _, _, _ = get_offsets_rotations(elem, ReferencePoint.CENTRE)
     return offsets[1]
 
@@ -423,7 +425,7 @@ def _set_dy(elem: Element, value: float) -> None:
 
 
 def _get_dz(elem: Element) -> float:
-    """Horizontal element shift"""
+    """Longitudinal element shift"""
     offsets, _, _, _ = get_offsets_rotations(elem, ReferencePoint.CENTRE)
     return offsets[2]
 
@@ -433,7 +435,7 @@ def _set_dz(elem: Element, value: float) -> None:
 
 
 def _get_tilt(elem: Element) -> float:
-    """Horizontal element shift"""
+    """Element tilt"""
     _, tilt, _, _ = get_offsets_rotations(elem, ReferencePoint.CENTRE)
     return tilt
 
@@ -442,6 +444,7 @@ def _set_tilt(elem: Element, value: float) -> None:
     transform_elem(elem, ReferencePoint.CENTRE, tilt=value)
 
 
+Element.transform = transform_elem
 Element.dx = property(_get_dx, _set_dx)
 Element.dy = property(_get_dy, _set_dy)
 Element.dz = property(_get_dz, _set_dz)

--- a/pyat/at/lattice/transformation.py
+++ b/pyat/at/lattice/transformation.py
@@ -2,7 +2,7 @@
 
 .. Caution::
 
-    The geometrical transformation are not commutative. When combining several
+    The geometrical transformations are not commutative. When combining several
     transformations on the same element by using multiple function calls, the
     transformations are applied in a fixed order, independent of the order of the
     function calls:

--- a/pyat/at/lattice/transformation.py
+++ b/pyat/at/lattice/transformation.py
@@ -1,4 +1,14 @@
-"""Element translations and rotations."""
+"""Element translations and rotations.
+
+.. Caution::
+
+    The geometrical transformation are not commutative. When combining several
+    transformations on the same element by using multiple function calls, the
+    transformations are applied in a fixed order, independent of the order of the
+    function calls:
+
+    .. centered:: translations -> tilt (z-axis) -> yaw (y-axis) -> pitch (x-axis)
+"""
 
 from __future__ import annotations
 
@@ -508,6 +518,9 @@ def set_rotation(
           See ":ref:`Selecting elements in a lattice <refpts>`"
         relative:   If :py:obj:`True`, the rotations are added to the existing ones.
 
+    .. versionadded:: 0.7.0
+       The *refpts* argument
+
     See Also:
         :py:func:`set_tilt`
         :py:func:`set_shift`
@@ -532,6 +545,9 @@ def set_tilt(
         refpts:     Element selection key.
           See ":ref:`Selecting elements in a lattice <refpts>`"
         relative:   If :py:obj:`True`, the rotation is added to the existing one.
+
+    .. versionadded:: 0.7.0
+       The *refpts* argument
 
     See Also:
         :py:func:`set_rotation`
@@ -560,6 +576,9 @@ def set_shift(
           See ":ref:`Selecting elements in a lattice <refpts>`"
         relative:   If :py:obj:`True`, the translation is added to the
           existing one.
+
+    .. versionadded:: 0.7.0
+       The *refpts* argument
 
     See Also:
         :py:func:`set_rotation`

--- a/pyat/at/lattice/transformation.py
+++ b/pyat/at/lattice/transformation.py
@@ -304,11 +304,11 @@ def transform_elem(
     """
     if relative:
 
-        def set(ini, val):
+        def _set(ini, val):
             return ini if val is None else ini + val
     else:
 
-        def set(ini, val):
+        def _set(ini, val):
             return ini if val is None else val
 
     elem_length = getattr(elem, "Length", 0)
@@ -324,12 +324,8 @@ def transform_elem(
     )
 
     # Apply new offsets and rotations (XYZ intrinsic order)
-    offsets = np.array([set(v0, v) for v0, v in zip(offsets0, [dx, dy, dz])])
-    rotations = [
-        set(pitch0, pitch),
-        set(yaw0, yaw),
-        set(tilt0, tilt),
-    ]
+    offsets = np.array([_set(v0, v) for v0, v in zip(offsets0, [dx, dy, dz])])
+    rotations = [_set(pitch0, pitch), _set(yaw0, yaw), _set(tilt0, tilt)]
 
     if reference is ReferencePoint.CENTRE:
         # Compute entrance rotation matrix in the rotated frame

--- a/pyat/at/lattice/transformation.py
+++ b/pyat/at/lattice/transformation.py
@@ -1,3 +1,5 @@
+"""Element translations and rotations."""
+
 from __future__ import annotations
 
 __all__ = [
@@ -180,10 +182,10 @@ def _ld_and_r3d_from_r_matrix(r_matrix):
 
 
 class ReferencePoint(Enum):
-    """Enum class for reference option"""
+    """Definition of the reference point for the geometric transformations."""
 
-    CENTRE = "CENTRE"
-    ENTRANCE = "ENTRANCE"
+    CENTRE = "CENTRE"  #: Origin at the centre of the element.
+    ENTRANCE = "ENTRANCE"  #: Origin at the entrance of the element.
 
 
 # noinspection PyPep8Naming
@@ -193,8 +195,7 @@ def get_offsets_rotations(
     *,
     RB_half: np.ndarray = None,
 ):
-    """
-    Return the offsets and rotations of a given element.
+    r"""Return the offsets and rotations of a given element.
 
     This function returns the offsets [dx, dy, dz] and angular rotations (tilt, yaw,
     pitch) of the element.

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -163,7 +163,7 @@ def _type_error(refpts, types):
 
 
 # setval and getval return pickleable functions: no inner, nested function
-# are allowed. So nested functions are replaced be module-level callable
+# is allowed. So nested functions are replaced be module-level callable
 # class instances
 class _AttrItemGetter:
     __slots__ = ["attrname", "index"]
@@ -620,7 +620,7 @@ def checkattr(attrname: str, attrvalue=None) -> ElementFilter:
 
         >>> elts = filter(checkattr("K", 0.0), ring)
 
-        Returns an iterator over all elements in ring that have a
+        Returns an iterator over all elements of ring that have a
         :pycode:`K` attribute equal to 0.0
     """
     if attrvalue is None:
@@ -675,7 +675,7 @@ def checkname(pattern: str, regex: bool = False) -> ElementFilter:
 
         >>> qps = filter(checkname("QF*"), ring)
 
-        Returns an iterator over all with name starting with ``QF``.
+        Returns an iterator over all the elements with name starting with ``QF``.
     """
     if regex:
         return functools.partial(_chkregex, pattern)
@@ -1107,7 +1107,7 @@ def get_geometry(
         start_coordinates:  *x*, *y*, *angle* at starting point. *x*
           and *y* are ignored if *centered* is :py:obj:`True`.
         centered:           if :py:obj:`True` the coordinates origin is the
-          center of the ring.
+          centre of the ring.
         regex: Use regular expression for *refpts* string matching instead of
           Unix shell-style wildcards.
 


### PR DESCRIPTION
This is a follow-up of #921 and is based on @SebastienJoly's work.
As [mentioned previously](https://github.com/atcollab/at/pull/921#issuecomment-2853699215), the fact that element translations and rotations are handled simultaneously induced some problems, which are solved here:

#### Reorganisation
- the function getting back the translations and rotations from R1 and T1 is extracted and brought to the top level so that it can be used by element properties like `Element.tilt` (or anyone else),
- all functions (`shift_elem`,…) and properties (`Element.dx`,…) now use `transform_elem` and work consistently,
- all functions (`shift_elem`,…) and properties (`Element.dx`,…) have been moved from `utils.py` to `transformation.py.` This minimises inter-module references,
- The default for the arguments of `transform_elem` is set to `None`, indicating the previous value must be kept. This allows to set or increment some parameters while keeping the others unchanged, rather that setting them to zero,
- nothing is changed in the computations.

#### New features
- The value `None` can be used wherever a displacement or rotation is expected and means "Keep the value unchanged", including where the default is 0.0 like in `set_shift`,
- The lattice functions `set_tilt`, `set_shift`, `set_rotation` have now a `refpts` keyword argument. This was proposed in #925 and allows to set errors of specific elements of a lattice. The default is `All`, to be compatible with the present behaviour.

#### Conclusion
With this PR, multiple function calls for displacing a given element can be used to combine transformations, with the following precautions:
1. The order in which the transformations are applied is fixed, and is independent of the order of function calls,
2. All function calls must use the same reference point. That's why I did not propagate the _reference_ argument to the high level functions `set_shift`, `set_tilt`, `set_rotation`: I think it's safer there to stick to the default of `ReferencePoint.CENTRE`.

These precautions are mentioned in the module documentation.