### PR TITLE
Add buffer to cavity feedback

### DIFF
--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -403,7 +403,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
         vbi[ib] = 0.0;
         totalWb[ib] = 0.0;
     }
-    
+
     for(i=sliceperturn*(nturns-1);i<sliceperturn*nturns;i++){
         ib = (int)((i-sliceperturn*(nturns-1))/nslice);
         wi = turnhistoryW[i];
@@ -439,7 +439,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     vbeamkc /= (totalW);
     vbeamk[0] = cabs(vbeamkc);
     vbeamk[1] = carg(vbeamkc);   
-    
+
     for(i=0;i<nbunch;i++){
         double vr = vbr[i]/totalWb[i];
         double vi = vbi[i]/totalWb[i];

--- a/pyat/at/collective/beam_loading.py
+++ b/pyat/at/collective/beam_loading.py
@@ -163,7 +163,9 @@ class BeamLoadingElement(RFCavity, Collective):
                 RF system [m]. If not specified, it will be calculated using 
                 get_timelag_fromU0. Defines the expected position of the beam to be
                 used for the beam loading setpoints.        
-            
+            use_buffer (bool): If True, then the vgen and vbeam used for the feedback
+                is taken to be the mean value of the respective buffer.
+                
         Returns:
             bl_elem (Element): beam loading element
         """
@@ -195,6 +197,7 @@ class BeamLoadingElement(RFCavity, Collective):
         self._turnhistory = None    # Defined here to avoid warning
         self._vbunch = None
         self._buffersize = buffersize
+        self._usebuffer = kwargs.pop('usebuffer', False) 
         self._vgen_buffer = numpy.zeros(1)
         self._vbeam_buffer = numpy.zeros(1)
         self._vbunch_buffer = numpy.zeros(1)
@@ -257,9 +260,11 @@ class BeamLoadingElement(RFCavity, Collective):
         else:
             vgen = self.Voltage
             psi = 0
-            
+
         self._vbeam = numpy.array([2*current*self.Rshunt*numpy.cos(psi),
-                                   numpy.pi-psi])
+                                   numpy.pi+psi])
+        self._vbeam_phasor = numpy.array([2*current*self.Rshunt*numpy.cos(psi),
+                                   numpy.pi+psi])                      
         self._vgen = numpy.array([vgen, psi])
 
     @property


### PR DESCRIPTION
There was already the possibility to store buffers for vbeam, vcav and vgen. But now I added a flag `usebuffer`. If it is set to true, the `vbeam `that will be used for the setpoint computation will be a mean of the `vbeam_buffer`.

While implementing and testing this, I noticed some other strange bugs that I have fixed. The main two bugs relating to the initial `vbeam`. Bug number 1 was that when using the phasor, whatever you put as the initial `vbeam `was irrelevant due to the fact that it requires a setting of `vbeam_phasor`. This is now duplicated in the python, probably there is a cleaner way to implement it.

The second was a sign error on the initial `psi`. With both of these fixed, I am completely smooth with the beam induced voltage at high current from turn 0.

I paste below a test script.

```
import numpy as np
import matplotlib.pyplot as plt
import at
from at.constants import clight

current = 400e-3
Vc = 1e6
    
ring_dict = {
            'circumference': 528,
            'harmonic_number': 176,
            'ac': 0.000306,
            'energy': 3e9,
            'sigma_e': 0.000769,
            'U0': 363.8e3
            }

QL = 3688
Rsl = 0.32e6
Nmain = 4

Nbunches = ring_dict['harmonic_number']



Nparts = ring_dict['harmonic_number']
   
Nturns = 50000

t0 = ring_dict['circumference'] / clight
tauz = 25.194e-3 / t0
    
simple_ring = at.simple_ring(ring_dict['energy'], ring_dict['circumference'], ring_dict['harmonic_number'], 0.1, 0.1, Vc, ring_dict['ac'], U0=ring_dict['U0'], tauz=tauz, espread=ring_dict['sigma_e'])
simple_ring.set_fillpattern(Nbunches)
simple_ring.set_beam_current(current)

#Setup main cavity
phi_s = np.pi - np.arcsin(ring_dict['U0']/Vc)
mc_elem = simple_ring[0]
tl_main = clight*(np.pi - phi_s)/(2*np.pi*mc_elem.Frequency)
mc_elem.TimeLag = tl_main


# copy the ring to see with the new buffer settings
newbuff_ring = simple_ring.deepcopy()
at.add_beamloading(newbuff_ring, QL, Nmain*Rsl, cavpts=[0], Nslice=1, blmode = at.BLMode.PHASOR, VoltGain=0.01, PhaseGain=0.01, cavitymode=at.CavityMode.ACTIVE, usebuffer=True, buffersize=2000)
    
print('Initial vbeam, 2000 turn buffer:', newbuff_ring[0]._vbeam)

parts = np.zeros((6, Nparts))
   
allvb_newbuff = np.zeros((Nturns,2))
for i in np.arange(Nturns):
    _ = newbuff_ring.track(parts, in_place=True, refpts=None, nturns=1)
    allvb_newbuff[i,:] = newbuff_ring[0]._vbeam

print('Final vbeam, 2000 turn buffer:', newbuff_ring[0]._vbeam)
    
    
# compare with old buffer
oldbuff_ring = simple_ring.deepcopy()
at.add_beamloading(oldbuff_ring, QL, Nmain*Rsl, cavpts=[0], Nslice=1, blmode = at.BLMode.PHASOR, VoltGain=0.001, PhaseGain=0.001, cavitymode=at.CavityMode.ACTIVE, usebuffer=False)
    
print('Initial vbeam, 1 turn buffer:', oldbuff_ring[0]._vbeam)

parts = np.zeros((6, Nparts))
allvb_oldbuff = np.zeros((Nturns,2))
for i in np.arange(Nturns):
    _ = oldbuff_ring.track(parts, in_place=True, refpts=None, nturns=1)
    allvb_oldbuff[i,:] = oldbuff_ring[0]._vbeam
    
print('Final vbeam, 1 turn buffer:', oldbuff_ring[0]._vbeam)
    
plt.plot(allvb_newbuff[:,0], 'r', label='2000 turn buffer')
plt.plot(allvb_oldbuff[:,0], 'b', label='1 turn buffer')
plt.legend()
plt.xlabel('Turn')
plt.ylabel('Vb [V]')
plt.show()

plt.plot(allvb_newbuff[:,1], 'r', label='2000 turn buffer')
plt.plot(allvb_oldbuff[:,1], 'b', label='2000 turn buffer')
plt.legend()
plt.xlabel('Turn')
plt.ylabel('psi [rad]')
plt.show()


```
       

![image](https://github.com/user-attachments/assets/9268bad8-6fdb-4437-8119-e32bd3578d4b)
