### PR TITLE
cast lattice_object.nbunch to int()

### DIFF
--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -854,7 +854,8 @@ class Lattice(list):
     @property
     def nbunch(self) -> int:
         """Number of bunches"""
-        return np.count_nonzero(self._fillpattern)
+        # cast to int required from numpy version 2.3.0
+        return int(np.count_nonzero(self._fillpattern))
 
     @property
     def harmonic_number(self) -> int:

--- a/pyat/at/load/json.py
+++ b/pyat/at/load/json.py
@@ -27,6 +27,10 @@ class _AtEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, Particle):
             return obj.to_dict()
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)       
         else:
             return super().default(obj)
 


### PR DESCRIPTION
Problems appeared in the JSON encoder and lattice string representation due to the np.int64 type. This is related to the numpy version 2.3.0 where count_nonzero return np.int64 instead of int.
This function is used in lattice_object.nbunch the return value is now converted to int to allow string representation without errors