### PR TITLE
Passive cavity feedback

### DIFF
--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -88,7 +88,7 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
     double *vcavk = Elem->vcav;
     double *vgenk = Elem->vgen;    
     double feedback_angle_offset = Elem->feedback_angle_offset;
-    int bufferlengthnow = 0;
+
 
     double vbeam_set[] = {vbeam_phasor[0], vbeam_phasor[1]};
     double tot_current = 0.0;
@@ -104,7 +104,7 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
     for(i=0;i<nbunch;i++){
         tot_current += bunch_currents[i];
     }
-
+    double vbr=2*tot_current*rshunt;
 
     /*Track RF cavity is always done. */
     trackRFCavity(r_in,le,vgen/energy,rffreq,harmn,tlag,-psi+feedback_angle_offset,nturn,circumference/C0,num_particles);
@@ -158,8 +158,9 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
         if(cavitymode==1){
             update_vgen(vbeam_set,vcavk,vgenk,phasegain,voltgain,feedback_angle_offset); 
 
-        }     
-
+        }else if(cavitymode==3){     
+            update_passive_frequency(vbeam_set, vcavk, vgenk, phasegain, vbr);
+        }
 
         
         atFree(buffer);
@@ -268,7 +269,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     }else if (num_particles%Param->nbunch!=0){
         atWarning("Number of particles not a multiple of the number of bunches: uneven bunch load.");
     }
-    if(Elem->cavitymode==0 || Elem->cavitymode>=3){
+    if(Elem->cavitymode==0 || Elem->cavitymode>=4){
         atError("Unknown cavitymode provided.");    
     } 
     if(Elem->blmode==0 || Elem->blmode>=3){

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -465,6 +465,40 @@ static void update_vgen(double *vbeam,double *vcav,double *vgen,double voltgain,
 }
 
 
+static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, double phasegain, double Vbr){
+    double vset = vcav[0];
+    double psi = vbeam[1] - TWOPI/2;
+    double vpeak = vbeam[0]*cos(psi); /* Peak amplitude of cavity voltage */
+    double delta_v = vset - vpeak;
+
+    printf("Vset: %f \n",vset);
+    printf("psi: %f \n",psi);
+    printf("Vpeak: %f \n",vpeak);
+    double grad = vpeak*sin(psi);
+    double delta_psi = delta_v / grad; 
+    printf("grad: %f \n",grad);
+    printf("delta_psi: %f \n",delta_psi);
+    
+    /* If the cavity is detuned positively, the psi needs to
+    be increased to reduce the voltage. Likewise, if the cavity
+    is detuned negatively, the psi needs to be decreased to reduce
+    the voltage.
+    */
+    
+    int sg = 0;
+    if (psi > 0) {
+        sg = 1;
+    }else{
+        sg = -1;
+    }
+
+    /*double freqres = rffreq/(1-tan(vgenk[1])/(2*qfactor));
+    freqres += delta_freq;
+    */
+
+    vgen[1] += delta_psi*phasegain;
+}
+
 static void compute_buffer_mean(double *out_array, double *buffer, long windowlength, long buffersize, long numcolumns){
 
     int c,p,offset;

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -468,16 +468,11 @@ static void update_vgen(double *vbeam,double *vcav,double *vgen,double voltgain,
 static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, double phasegain, double Vbr){
     double vset = vcav[0];
     double psi = vbeam[1] - TWOPI/2;
-    double vpeak = vbeam[0]*cos(psi); /* Peak amplitude of cavity voltage */
+    double vpeak = vbeam[0]; /* Peak amplitude of cavity voltage */
     double delta_v = vset - vpeak;
-
-    printf("Vset: %f \n",vset);
-    printf("psi: %f \n",psi);
-    printf("Vpeak: %f \n",vpeak);
-    double grad = vpeak*sin(psi);
+    double grad = vbeam[0]*sin(psi);
     double delta_psi = delta_v / grad; 
-    printf("grad: %f \n",grad);
-    printf("delta_psi: %f \n",delta_psi);
+
     
     /* If the cavity is detuned positively, the psi needs to
     be increased to reduce the voltage. Likewise, if the cavity
@@ -491,12 +486,12 @@ static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, 
     }else{
         sg = -1;
     }
-
+    
     /*double freqres = rffreq/(1-tan(vgenk[1])/(2*qfactor));
     freqres += delta_freq;
     */
 
-    vgen[1] += delta_psi*phasegain;
+    vgen[1] += sg*delta_psi*phasegain;
 }
 
 static void compute_buffer_mean(double *out_array, double *buffer, long windowlength, long buffersize, long numcolumns){

--- a/pyat/at/collective/beam_loading.py
+++ b/pyat/at/collective/beam_loading.py
@@ -319,7 +319,7 @@ class BeamLoadingElement(RFCavity, Collective):
             vgen = self.Voltage*numpy.cos(psi) + \
                 vb*numpy.cos(psi)*numpy.sin(self._phis)
 
-        elif self._cavitymode == 2:
+        elif numpy.logical_or(self._cavitymode == 2, self._cavitymode == 3):
             vgen = 0
             psi = numpy.arctan(2*self.Qfactor*(1 - self.Frequency/(self.Frequency + self.detune)))
         else:


### PR DESCRIPTION
For passive cavities in real conditions, you may wish to set a voltage setpoint and tune the frequency of the cavity to match this condition.

This PR adds an additional cavitymode at.CavityMode.PASSIVEVOLTAGE where the cavity is detuned in order to satisfy the voltage condition.

The voltage is specified by setting the voltage of the RF cavity when it is initialised. I am not sure this is the best way, as it will interfere with the setpoint calculation of the main active cavity. Is it better to keep the passive cavity voltage zero and provide it as a kwarg?

```
import numpy as np
import matplotlib.pyplot as plt
from at.constants import clight
import at


volt_set = 1e5

parking_detune = -50e3
I0 = 400e-3
Vc = 1e6
ring_dict = {
            'circumference': 528,
            'harmonic_number': 176,
            'ac': 0.000306,
            'energy': 3e9,
            'sigma_e': 0.000769,
            'U0': 363.8e3
            }
            
beta_main = 1.9
QL = 3688
Rsl = 0.32e6
Nmain = 4


Nbunches = ring_dict['harmonic_number']
Nslice = 1

nparts_per_bunch = 100
Nparts = int(Nbunches * nparts_per_bunch) 

Nturns = 1000

sigma_matrix = at.sigma_matrix(betax=1, betay=1, alphax=0, alphay=0, emitx=100e-12, emity=10e-12, espread=ring_dict['sigma_e'], blength=20e-3)

t0 = ring_dict['circumference'] / clight
tauz = 25.194e-3 / t0
    
simple_ring = at.simple_ring(ring_dict['energy'], ring_dict['circumference'], ring_dict['harmonic_number'], 0.1, 0.1, Vc, ring_dict['ac'], U0=ring_dict['U0'], tauz=tauz, espread=ring_dict['sigma_e'])
simple_ring.set_fillpattern(Nbunches)
simple_ring.set_beam_current(I0)

simple_ring.cavpts = [0] #needed to avoid the break of the bunch_spos through the rf_frequency

#Setup main cavity
simple_ring.set_cavity_phase()
psi_parked = np.arctan(2*QL*(1 - simple_ring.rf_frequency/(simple_ring.rf_frequency + parking_detune)))

## setup parked cavity
parked_cav = at.RFCavity('parkyboi', 0.0, volt_set, simple_ring.rf_frequency, simple_ring.harmonic_number, simple_ring.energy)
simple_ring.insert(1, parked_cav)




# add beamloading
at.add_beamloading(simple_ring, QL, Nmain*Rsl, cavpts=[0], Nslice=Nslice, blmode = at.BLMode.PHASOR, VoltGain=0.001, PhaseGain=0.001, cavitymode=at.CavityMode.ACTIVE, fbmode=at.FeedbackMode.ONETURN)
at.add_beamloading(simple_ring, QL, Rsl, detune=parking_detune, cavpts=[1], Nslice=Nslice, blmode = at.BLMode.PHASOR, cavitymode=at.CavityMode.PASSIVEVOLTAGE, PhaseGain=0.005)


bmon = at.BeamMoments('bmon')
simple_ring.append(bmon)

all_z_means = np.zeros((Nbunches, Nturns))
all_dp_means = np.zeros((Nbunches, Nturns))
all_z_stds = np.zeros((Nbunches, Nturns))
all_dp_stds = np.zeros((Nbunches, Nturns))

all_Vg_main = np.zeros((2, Nturns))
all_Vb_main = np.zeros((2, Nturns))

all_Vb_park = np.zeros((2, Nturns))

all_resfreq_park = np.zeros((Nturns))

parts = at.beam(Nparts, sigma_matrix)
   
for iturn in np.arange(Nturns):
    if iturn % 100 == 0:
        print(iturn)
    tot_lost = np.sum(np.isnan(parts[0,:]))    

    if tot_lost > 0:

        all_z_means[:, iturn] = np.nan
        all_dp_means[:, iturn] = np.nan
        all_z_stds[:, iturn] = np.nan
        all_dp_stds[:, iturn] = np.nan

        all_Vg_main[:, iturn] = np.nan
        all_Vb_main[:, iturn] = np.nan
        
        all_Vb_park[:, iturn] = np.nan
    else:
        _ = simple_ring.track(parts, in_place=True, refpts=None, nturns=1)

        all_z_means[:, iturn] = bmon.means[5,:,0]
        all_dp_means[:, iturn] = bmon.means[4,:,0]
        all_z_stds[:, iturn] = bmon.stds[5,:,0]
        all_dp_stds[:, iturn] = bmon.stds[4,:,0]
        
        all_Vg_main[:, iturn] = simple_ring[0].Vgen
        all_Vb_main[:, iturn] = simple_ring[0].Vbeam

        all_Vb_park[:, iturn] = simple_ring[1].Vbeam
        all_resfreq_park[iturn] = simple_ring[1].ResFrequency

fig, (ax1,ax2) = plt.subplots(2,1)
ax1.plot(all_Vb_park[0,:]/1e3,'r',label='Parked Cavity Voltage')
ax1.axhline(volt_set/1e3, color='k', linestyle='dashed')
ax2.plot(all_resfreq_park/1e6, 'r')
ax2.set_ylabel('Res Freq [MHz]')
ax1.set_title('Vset={:.1f} kV'.format(volt_set/1e3))
ax2.set_xlabel('Turn')
ax1.set_ylabel('Parked Cavity Volt [kV]')
ax1.legend()
plt.show()



```
![image](https://github.com/user-attachments/assets/715f843e-aff1-42b7-8c71-583a9a3c5ebf)




