### PR TITLE
Remove the test directories from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,4 @@ athelp.mat
 # octave files
 octave-workspace
 
-# Test dir
-test/
+


### PR DESCRIPTION
This is to remove the test directory in pyat from .gitignore, as discussed in #952.