### PR TITLE
Improve docstrings

### DIFF
--- a/pyat/at/acceptance/touschek.py
+++ b/pyat/at/acceptance/touschek.py
@@ -288,14 +288,14 @@ def get_lifetime(
 
     args:
         ring:            ring use for tracking
-        emity:           verticla emittance
-        bunch_curr:      bunch current
+        emity:           vertical emittance [m]
+        bunch_curr:      bunch current [A]
 
     keyword args:
-        emitx=None:      horizontal emittance
-        sigs=None:       rms bunch length
+        emitx=None:      horizontal emittance [m]
+        sigs=None:       rms bunch length [m]
         sigp=None:       energy spread
-        zn=None:         full ring :math:`Z/n`
+        zn=None:         full ring :math:`Z/n` [Ohm]
         momap=None:      momentum aperture, has to be consistent with
                          ``refpts`` if provided the momentum aperture is
                          not calculated
@@ -304,7 +304,7 @@ def get_lifetime(
                          ring, ``len(refpts)>2`` is required
         resolution:      minimum distance between 2 grid points, default=1.0e-3
         amplitude:       max. amplitude for ``RADIAL`` and ``CARTESIAN`` or
-                         initial step in ``RECURSIVE``
+                         initial step in ``RECURSIVE`` [m]
                          default = 0.1
         nturns=1024:     Number of turns for the tracking
         dp=None:         static momentum offset

--- a/pyat/at/lattice/elements.py
+++ b/pyat/at/lattice/elements.py
@@ -1486,6 +1486,12 @@ class EnergyLoss(_DictLongtMotion, Element):
         generate any diffusion. This makes sense only if the losses summarised in
         the element occur in non-dispersive locations.
 
+        It is a single thin, straight non-focusing radiative element that does not contribute
+        to the diffusion. It's typical usage is to model the energy loss and contribution
+        to the damping times from a thin wiggler located in a non dispersive region.
+        More complex cases with focusing and / or  diffusion are not correctly handled by this
+        element.
+
         Args:
             family_name:    Name of the element
             energy_loss:    Energy loss [eV]

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -1279,7 +1279,9 @@ class Lattice(list):
         return self._set_6d(False, *args, **kwargs)
 
     def sbreak(self, break_s, break_elems=None, **kwargs):
-        """Insert elements at selected locations in the lattice
+        r"""
+        Insert elements at selected locations in the lattice.
+        In place modification not available for this function.
 
         Parameters:
             break_s:        location or array of locations of breakpoints
@@ -1288,6 +1290,9 @@ class Lattice(list):
                             duplicated as necessary). Default: Marker('sbreak')
         Returns:
             newring:    A new lattice with new elements inserted at breakpoints
+
+        Example:
+            >>> newring = ring.sbreak(spos, at.Marker('sbreak'))
         """
 
         def sbreak_iterator(_, itmk):

--- a/pyat/at/lattice/utils.py
+++ b/pyat/at/lattice/utils.py
@@ -841,6 +841,7 @@ def get_value_refpts(
         attrname:   Attribute name
         index:      index of the value to retrieve if *attrname* is
           an array. If :py:obj:`None` the full array is retrieved
+          In case *attrname* is a scalar index has to be None
         regex: Use regular expression for *refpts* string matching instead of
           Unix shell-style wildcards.
 
@@ -875,7 +876,8 @@ def set_value_refpts(
         attrvalues: Attribute values
         index:      index of the value to set if *attrname* is
           an array. if :py:obj:`None`, the full array is replaced by
-          *attrvalue*
+          *attrvalue*. 
+          In case *attrname* is a scalar index has to be None
         increment:  If :py:obj:`True`, *attrvalues* are added to the
           initial values.
         regex: Use regular expression for *refpts* string matching

--- a/pyat/at/physics/linear.py
+++ b/pyat/at/physics/linear.py
@@ -679,7 +679,10 @@ def linopt2(ring: Lattice, *args, **kwargs):
     **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
     **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
     **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
-                        (modulo :math:`2\pi`)
+                         Warning: if the sampling (number of refpts) is too
+                         sparse, i.e. if the phase advance is more than 2*pi
+                         between 2 points the integer part will not increment
+                         correclty
     **W**               :math:`\left[ W_x,W_y \right]` only if *get_w*
                         is :py:obj:`True`: chromatic amplitude function
     **Wp**              :math:`\left[ Wp_x,Wp_y \right]` only if *get_w*
@@ -792,7 +795,10 @@ def linopt4(ring: Lattice, *args, **kwargs):
     **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
     **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
     **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
-                        (modulo :math:`2\pi`)
+                         Warning: if the sampling (number of refpts) is too
+                         sparse, i.e. if the phase advance is more than 2*pi
+                         between 2 points the integer part will not increment
+                         correclty
     **gamma**           gamma parameter of the transformation to
                         eigenmodes [7]_
     **W**               :math:`\left[ W_x,W_y \right]` only if *get_w*
@@ -919,7 +925,10 @@ def linopt6(ring: Lattice, *args, **kwargs):
     **beta**            :math:`\left[ \beta_x,\beta_y \right]` vector
     **alpha**           :math:`\left[ \alpha_x,\alpha_y \right]` vector
     **mu**              :math:`\left[ \mu_x,\mu_y \right]`, betatron phase
-                        (modulo :math:`2\pi`)
+                         Warning: if the sampling (number of refpts) is too
+                         sparse, i.e. if the phase advance is more than 2*pi
+                         between 2 points the integer part will not increment
+                         correclty
     **W**               :math:`\left[ W_x,W_y \right]` only if *get_w*
                         is :py:obj:`True`: chromatic amplitude function
     **Wp**              :math:`\left[ Wp_x,Wp_y \right]` only if *get_w*
@@ -1147,7 +1156,11 @@ def linopt(
         dispersion      (4,) dispersion vector
         beta            [betax, betay] vector
         alpha           [alphax, alphay] vector
-        mu              [mux, muy], betatron phase (modulo 2*pi)
+        mu              [mux, muy], betatron phase
+                         Warning: if the sampling (number of refpts) is too
+                         sparse, i.e. if the phase advance is more than 2*pi
+                         between 2 points the integer part will not increment
+                         correclty
         W               (2,) chromatic amplitude function (only if get_w==True)
         All values given at the entrance of each element specified in refpts.
         In case coupled == :py:obj:`True` additional outputs are available:


### PR DESCRIPTION
This PR improve the docstring of several function in response to the following issues:
- #953 and #958 : units were added to the docstring
- #846 : the mention to modulo was remove and the behavior as function of sampling explained
- #666: Example usage was added
- #642: Additional text to explain usage was added
- #468: Additional text to avoid issue with scalar attribute added