### PR TITLE
Passive Cavity Voltage Loop BugFix

### DIFF
--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -90,7 +90,7 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
     double feedback_angle_offset = Elem->feedback_angle_offset;
 
 
-    double vbeam_set[] = {vbeam_phasor[0], vbeam_phasor[1]};
+    double vbeam_set[] = {vbeamk[0], vbeamk[1]};
     double tot_current = 0.0;
     int i;
     size_t sz = nslice*nbunch*sizeof(double) + num_particles*sizeof(int);
@@ -104,7 +104,6 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
     for(i=0;i<nbunch;i++){
         tot_current += bunch_currents[i];
     }
-    double vbr=2*tot_current*rshunt;
 
     /*Track RF cavity is always done. */
     trackRFCavity(r_in,le,vgen/energy,rffreq,harmn,tlag,-psi+feedback_angle_offset,nturn,circumference/C0,num_particles);
@@ -159,7 +158,7 @@ void BeamLoadingCavityPass(double *r_in,int num_particles,int nbunch,
             update_vgen(vbeam_set,vcavk,vgenk,phasegain,voltgain,feedback_angle_offset); 
 
         }else if(cavitymode==3){     
-            update_passive_frequency(vbeam_set, vcavk, vgenk, phasegain, vbr);
+            update_passive_frequency(vbeam_set, vcavk, vgenk, phasegain);
         }
 
         

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -465,14 +465,14 @@ static void update_vgen(double *vbeam,double *vcav,double *vgen,double voltgain,
 }
 
 
-static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, double phasegain, double Vbr){
+static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, double phasegain){
     /* The cavity voltage is
     V(t) = 2*I0*rs*cos(psi)*exp(i(wt+psi))
     We save the amplitude of vbeam, so the exponent goes to 1.
     Therefore vbeam[0] = 2*I0*rs*cos(psi) which is the cavity voltage.
     */
     double vset = vcav[0];
-    double psi = vbeam[1] - TWOPI/2;
+    double psi = vgen[1];
     double vpeak = vbeam[0]; /* Peak amplitude of cavity voltage */
     double delta_v = vset - vpeak;
     double grad = vbeam[0]*sin(psi)/cos(psi); 
@@ -488,7 +488,7 @@ static void update_passive_frequency(double *vbeam, double *vcav, double *vgen, 
     the voltage.
     */
         
-    int sg = (psi>0) - (psi<0);
+    int sg = (psi<0) - (psi>0);
 
     /* This is to avoid setting a value if grad is 0, as then
     delta_psi is inf, which even when multiplied by 0 gives nan


### PR DESCRIPTION
When I first wrote the voltage feedback for the passive loop, there was a small bug.

The bug had very little impact when the simulation was stable, but a large impact when unstable. 

Basically, I was incorrectly using the `vbeam_phasor `parameter to compute the frequency shift needed. This was wrong because `vbeam_phasor `is the parameter that saves the running total of the vbeam phasor. We also do some weird manipulations at the end of each turn (where we revert to the beginning of the turn after the last slice in order to 'save' the slice position ready for the next turn). 

The actual needed parameter is `vbeamk`, which is the average voltage seen by the beam. 

I also tidied up the other parameters that I noticed, i.e. I removed `Vbr `computation and a few other things.

See below for a plot, the same plot I showed in the #948 . In the previous PR, on closer inspection, we had 99.8 kV for a 100 kV setpoint. This was weird, and was due to the problem mentioned above. Now you can see we feedback correctly.

<img width="605" height="447" alt="image" src="https://github.com/user-attachments/assets/93e32054-6807-461a-a4f1-fa5116615f12" />

<img width="626" height="451" alt="image" src="https://github.com/user-attachments/assets/8fa7126a-19af-428e-83e0-01e60855ef94" />

