### PR TITLE
Reorgnize magnet elements and passmethods

### DIFF
--- a/atintegrators/StrMPoleSymplectic4QuantPass.c
+++ b/atintegrators/StrMPoleSymplectic4QuantPass.c
@@ -205,6 +205,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->RApertures=RApertures;
         Elem->KickAngle=KickAngle;
     }
+
+    if(Elem->Length==0.0){
+        atError("Quantum diffusion not available in thin elements.");
+    }
+
     energy = atEnergy(Param->energy, Elem->Energy);
 
     StrMPoleSymplectic4QuantPass(r_in, Elem->Length, Elem->PolynomA, Elem->PolynomB,

--- a/pyat/at/lattice/elements/basic_elements.py
+++ b/pyat/at/lattice/elements/basic_elements.py
@@ -105,6 +105,18 @@ class LongElement(Element):
         self.Length += other.Length
 
 
+class _ThinElement(Element):
+    """Mixing class for long elements"""
+    
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
+
+    def divide(self, frac) -> list[Element]:
+        pass
+
+    def merge(self, other) -> None:
+        pass
+
+
 class Marker(Element):
     """Marker element"""
 


### PR DESCRIPTION
The default passmethods for thick multipole now accept zero length elements in thin lens approximation.
`ThinMpolePass` is not needed anymore.
The python interface to magnet elements is re-organize to threat thin elements.