### PR TITLE
FIx .mat files for sextupoles

### DIFF
--- a/pyat/at/lattice/elements/magnet_elements.py
+++ b/pyat/at/lattice/elements/magnet_elements.py
@@ -430,10 +430,6 @@ class Sextupole(Multipole):
         kwargs.setdefault("PassMethod", "StrMPoleSymplectic4Pass")
         super().__init__(family_name, length, [], [0.0, 0.0, h], **kwargs)
 
-    def items(self) -> Generator[tuple[str, Any], None, None]:
-        yield from super().items()
-        yield "H", self.H
-
 
 class Octupole(Multipole):
     """Octupole element, with no changes from multipole at present"""


### PR DESCRIPTION
This fixes #973. The new warning introduced in #950 revealed a minor bug in .mat files generated by PyAT. The sextupoles in .mat files, and consequently in Matlab elements, have a redundant "H" field. When written back in .m files, this field triggers the warning in PyAT.

This warning has no consequence on the resulting lattice elements: they are all correct.

This PR removes this undesirable "H" field