### PR TITLE
set hasSpare to false at initialization of random number generator 

### DIFF
--- a/atintegrators/atrandom.c
+++ b/atintegrators/atrandom.c
@@ -80,6 +80,7 @@ static void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate, uint64_t in
     pcg32_random_r(rng);
     rng->state += initstate;
     pcg32_random_r(rng);
+    rng->hasSpare = false;
 }
 
 static void pcg32_srandom(uint64_t seed, uint64_t seq)


### PR DESCRIPTION
This PR is a possible solution to issue #978 where the Buffer implementation for the WHITENOISE mode of the VariableThinMultipole (see #839 ) shows a cycle of 2 after repeated calls to track functions.

The bool variable `hasSpare` in the `pcg_state_setseq_64` struct was unset at initialization, leaving the next state in an alternate True/False value from subsequent calls.

This fix proposes to set `hasSpare` to `False` at initialization. I have done a test in pyat and the sequence behaves as expected, i.e. it repeats when a seed is given.
```python
>>> zout,*_ = thering.track(zin[:,0], nturns=5,seed=20)
>>> elewhitenoise.BufferA
array([-0.50023502, -0.71931482, -0.59066089,  0.29808669, -0.5266456 ])
>>> zout,*_ = thering.track(zin[:,0], nturns=5,seed=20)
>>> elewhitenoise.BufferA
array([-0.50023502, -0.71931482, -0.59066089,  0.29808669, -0.5266456 ])
>>> zout,*_ = thering.track(zin[:,0], nturns=5,seed=20)
>>> elewhitenoise.BufferA
array([-0.50023502, -0.71931482, -0.59066089,  0.29808669, -0.5266456 ])
>>> zout,*_ = thering.track(zin[:,0], nturns=5,seed=20)
>>> elewhitenoise.BufferA
array([-0.50023502, -0.71931482, -0.59066089,  0.29808669, -0.5266456 ])

```