### PR TITLE
BugFix: single refpts acceptance calculation

### DIFF
--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -125,16 +125,16 @@ def get_parts(config, offset):
     the offset from which the array can be reconstructed
     """
 
-    def get_part_grid_uniform(bnd, np, amp):
-        x = [np.linspace(*b, n) * a for a, b, n in zip(amp, bnd, np)]
+    def get_part_grid_uniform(bnd, npt, amp):
+        x = [np.linspace(*b, n) * a for a, b, n in zip(amp, bnd, npt)]
         try:
             g1, g2 = np.meshgrid(*x)
         except ValueError:
             g1, g2 = np.meshgrid(x, 0.0)
         return np.array([g1.flatten(), g2.flatten()])
 
-    def get_part_grid_radial(bnd, np, amp):
-        x = [np.linspace(*b, n) for b, n in zip(bnd, np)]
+    def get_part_grid_radial(bnd, npt, amp):
+        x = [np.linspace(*b, n) for b, n in zip(bnd, npt)]
         g1, g2 = np.meshgrid(*x)
         g1r = amp[0] * np.cos(g2) * g1
         g2r = amp[1] * np.sin(g2) * g1
@@ -142,15 +142,15 @@ def get_parts(config, offset):
 
     pind = config.planesi
     amp = config.amplitudes
-    np = config.shape
+    npt = config.shape
     bnd = config.bounds
     gm = config.mode
 
     if gm is GridMode.CARTESIAN:
-        g = get_part_grid_uniform(bnd, np, amp)
+        g = get_part_grid_uniform(bnd, npt, amp)
     elif gm is GridMode.RADIAL:
-        g = get_part_grid_radial(bnd, np, amp)
-    parts = np.zeros((6, np.prod(np)))
+        g = get_part_grid_radial(bnd, npt, amp)
+    parts = np.zeros((6, np.prod(npt)))
     parts[pind, :] = [g[i] for i in range(len(pind))]
     offset = np.array(offset) + config.shift_zero
     parts = (parts.T + offset).T

--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -73,14 +73,15 @@ def get_plane_index(planes):
 
 def set_ring_orbit(ring, dp, obspt, orbit):
     """
-    Returns initial closed orbit
+    Returns initial closed orbit and rotated ring
     """
     if obspt is not None:
         assert np.isscalar(obspt), "Scalar value needed for obspt"
+        ring = ring.rotate(obspt)
     if orbit is None:
         orbit0, orbit = ring.find_orbit(dp=dp, refpts=obspt)
         orbit = orbit0 if obspt is None else np.squeeze(orbit)
-    return orbit
+    return orbit, ring
 
 
 def grid_configuration(
@@ -341,7 +342,7 @@ def grid_boundary_search(
         offset = [None for _ in np.arange(len(obspt))]
 
     for i, obs, orbit in zip(np.arange(len(obspt)), obspt, offset):
-        orbit = set_ring_orbit(ring, dp, obs, orbit)
+        orbit, _ = set_ring_orbit(ring, dp, obs, orbit)
         parts, grid = get_parts(config, orbit)
         obs = 0 if obs is None else obs
         dpp = 0.0 if dp is None else dp

--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -73,17 +73,14 @@ def get_plane_index(planes):
 
 def set_ring_orbit(ring, dp, obspt, orbit):
     """
-    Returns a ring starting at obspt and initial
-    closed orbit
+    Returns initial closed orbit
     """
     if obspt is not None:
         assert numpy.isscalar(obspt), "Scalar value needed for obspt"
-        ring = ring.rotate(obspt)
-
     if orbit is None:
-        orbit = ring.find_orbit(dp=dp)[0]
-
-    return orbit, ring
+        orbit0, orbit = ring.find_orbit(dp=dp, refpts=obspt)
+        orbit = orbit0 if obspt is None else numpy.squeeze(orbit)
+    return orbit
 
 
 def grid_configuration(
@@ -320,7 +317,7 @@ def grid_boundary_search(
             if obspt[0] is None:
                 print("Element {0}, obspt={1}".format(ring[0].FamName, 0))
             else:
-                print("Element {0}, obspt={1}".format(ring[obspt].FamName, obspt))
+                print("Element {0}, obspt={1}".format(ring[obspt[0]].FamName, obspt))
         else:
             print(
                 "{0} Elements from {1}, obspt={2} to {3}, obspt={4}".format(
@@ -340,13 +337,11 @@ def grid_boundary_search(
     t0 = time.time()
     allparts = []
     grids = []
-
     if offset is None:
-        _, offsets = ring.find_orbit(dp=dp, refpts=obspt)
-    else:
-        offsets = offset
+        offset = [None for _ in numpy.arange(len(obspt))]
 
-    for i, obs, orbit in zip(numpy.arange(len(obspt)), obspt, offsets):
+    for i, obs, orbit in zip(numpy.arange(len(obspt)), obspt, offset):
+        orbit = set_ring_orbit(ring, dp, obs, orbit)
         parts, grid = get_parts(config, orbit)
         obs = 0 if obs is None else obs
         dpp = 0.0 if dp is None else dp

--- a/pyat/at/acceptance/boundary.py
+++ b/pyat/at/acceptance/boundary.py
@@ -77,11 +77,14 @@ def set_ring_orbit(ring, dp, obspt, orbit):
     """
     if obspt is not None:
         assert np.isscalar(obspt), "Scalar value needed for obspt"
-        ring = ring.rotate(obspt)
+        ringrot = ring.rotate(obspt)
+    else:
+        ringrot = ring
     if orbit is None:
-        orbit0, orbit = ring.find_orbit(dp=dp, refpts=obspt)
-        orbit = orbit0 if obspt is None else np.squeeze(orbit)
-    return orbit, ring
+        # need this call on ring to use keep_lattice=True in obs loop
+        orbit0, orbitobs = ring.find_orbit(dp=dp, refpts=obspt)
+        orbit = orbit0 if obspt is None else np.squeeze(orbitobs)
+    return orbit, ringrot
 
 
 def grid_configuration(


### PR DESCRIPTION
This PR fixes a bug introduce in #969 that prevented running single refpts acceptance calculation.
Most of the change are switch to `import numpy as np`.

Code changes are in:
-`set_ring_orbit` (l74->87)
-`grid_boundary_search` (l345->348)

