### PR TITLE
Fix MAD-X tilt parameter

### DIFF
--- a/pyat/at/load/madx.py
+++ b/pyat/at/load/madx.py
@@ -148,7 +148,7 @@ from .file_input import AnyDescr, ElementDescr, SequenceDescr, BaseParser
 from .file_input import LowerCaseParser, UnorderedParser
 from .file_input import set_argparser, ignore_names
 from .file_output import Exporter
-from ..lattice import Lattice, Particle, elements as elt, tilt_elem
+from ..lattice import Lattice, Particle, elements as elt
 
 _separator = re.compile(r"(?<=[\w.)])\s+(?=[\w.(])")
 
@@ -247,9 +247,19 @@ def sinc(x: float) -> float:
 #  Utility functions
 # -------------------
 
-
 def mad_element(func):
     """Decorator for AT elements"""
+
+    def tilt_elem(elem: elt.Element, rots: float) -> None:
+        cs = np.cos(rots)
+        sn = np.sin(rots)
+        rm = np.asfortranarray(np.diag([cs, cs, cs, cs, 1.0, 1.0]))
+        rm[0, 2] = sn
+        rm[1, 3] = sn
+        rm[2, 0] = -sn
+        rm[3, 1] = -sn
+        elem.R1 = rm
+        elem.R2 = rm.T
 
     @functools.wraps(func)
     def wrapper(self, *args, tilt=0.0, ktap=0.0, **kwargs):


### PR DESCRIPTION
The MAD-X parser now respects the MAD-X convention for tilts: a MAD-X tilt parameter is converted into a z-rotation at entrance of the element and the opposite rotation at exit, instead of a PyAT element tilt.

This makes a difference for curved elements.

This solves #987.