### PR TITLE
Drop old python versions, upgrade build tools

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -13,22 +13,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Necessary to fetch tags and allow setuptools_scm
           # see: https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.2
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -38,19 +38,19 @@ jobs:
           if-no-files-found: error
 
   build_sdist:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Necessary to fetch tags and allow setuptools_scm
           # see: https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install build tools
         run: python -m pip install build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Necessary to fetch tags and allow setuptools_scm
           # see: https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: pip
@@ -49,7 +49,7 @@ jobs:
         working-directory: docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'docs/_build/html'
           

--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -20,22 +20,22 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: pip
 
     - name: Set up MATLAB
       uses: matlab-actions/setup-matlab@v2
       with:
-        release: R2024a
+        release: R2025b
 
     - name: Atmexall
       uses: matlab-actions/run-command@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,27 +15,15 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
-        include:
-          - os: macos-13
-            python-version: '3.7'
-          - os: macos-13
-            python-version: '3.8'
-          - os: ubuntu-22.04
-            python-version: '3.7'
-          - os: ubuntu-22.04
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.8'
-
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 requires = [
     "setuptools >= 64",
     "setuptools_scm >= 7",
-    "oldest-supported-numpy; python_version <= '3.8'",
-    "numpy >= 2.0; python_version >= '3.9'",
+    "numpy >= 2.0",
     "wheel",
 ]
 # build-backend = "setuptools.build_meta"
@@ -16,31 +15,25 @@ name = "accelerator-toolbox"
 authors = [{ name = "The AT collaboration", email = "atcollab-general@lists.sourceforge.net" }]
 description = "Accelerator Toolbox"
 readme = "pyat/README.rst"
-license = { file = "LICENSE.txt" }
+license = "Apache-2.0"
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering :: Physics",
+    "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "importlib-resources;python_version<'3.9'",
-    "numpy >=1.16.6, <2.0; python_version <= '3.8'",
-    "numpy >= 1.23.5; python_version >= '3.9'",
-    "scipy>=1.4.0"
+    "numpy >= 1.23.5",
+    "scipy >= 1.10.0"
 ]
 
 [project.urls]
@@ -70,11 +63,9 @@ machine_data = ["*.m", "*.mat"]
 [tool.cibuildwheel]
 build = ["*"]
 # Pypy does not have Scipy so we cannot support it.
-skip = ["pp*", "cp3{7,8}-musllinux_*"]
+skip = ["cp3{7,8,9}*", "cp314t*"]
 archs = ["auto64"]
 build-verbosity = "1"
-# "build" frontend fails on windows
-# build-frontend = "build"
 
 #[tool.cibuildwheel.linux]
 ## Pass the detected PyAT version to the linux docker containers


### PR DESCRIPTION
Given the problem encountered in #995 and according to [this discussion](https://github.com/atcollab/at/discussions/994), python versions 3.7, 3.8 and 3.9 (declared end-of-life) are not supported any more and removed from the test set.

This is based on the strategy proposed in [SPEC 0](https://scientific-python.org/specs/spec-0000/), based on the fact that with virtual environments becoming commonplace, users should not be blocked on the possibly old system-provided python version.

This reduces a lot the number of combinations to be tested and allows to take benefit from the new features introduced in recent python, numpy and scipy versions.

So PyAt will support python 3.10, 3.11, 3.12 and 3.13. Python 3.14 will be added to the test set as soon as it is released, normally on October 7th.

The scipy minimum version is raised to 1.10, the minimum required for #995.

All GitHub Actions are upgraded with the most recent actions.

Note: if useful, python 3.9 could be kept without drawback.

