### PR TITLE
Add tests on python 3.14

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/docs/p/howto/Installation.rst
+++ b/docs/p/howto/Installation.rst
@@ -9,7 +9,7 @@ methods are used by higher-level functions to provide physics results.
 Requirements
 ------------
 
-pyAT supports Python 3.7 to 3.12.
+pyAT supports Python 3.10 to 3.14.
 
 Installation
 ------------
@@ -19,7 +19,7 @@ From PyPI
 
 PyPI maintains PyAT versions for Linux, MacOS and Windows, and python versions:
 
-- CPython 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
+- CPython 3.10, 3.11, 3.12, 3.13, 3,14
 - PyPI does not support PyPy, because of the missing numpy and scipy libraries
 
 *Installation with minimal dependencies:*
@@ -64,8 +64,7 @@ From conda-forge
 
 conda-forge maintains PyAT versions for Linux, MacOS and Windows, and python versions:
 
-- CPython 3.8, 3.9, 3.10, 3.11, 3.12
-- PyPy 3.9
+- CPython 3.10, 3.11, 3.12, 3.13, 3.14
 
 PyAT can be installed in a conda environment with::
 

--- a/pyat/README.rst
+++ b/pyat/README.rst
@@ -16,7 +16,7 @@ higher-level functions to provide physics results.
 See the `pyAT website <https://atcollab.github.io/at/p/index.html>`_ for a
 more detailed introduction.
 
-pyAT supports Python 3.7 to 3.12.
+pyAT supports Python 3.10 to 3.14.
 
 Installation
 ------------

--- a/pyat/at/lattice/elements/idtable_element.py
+++ b/pyat/at/lattice/elements/idtable_element.py
@@ -1,4 +1,4 @@
-"""ID table :py:clas:`.Element`."""
+"""ID table :py:class:`.Element`."""
 
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",


### PR DESCRIPTION
This PR adds tests of AT on python 3.14 recently released.

In also includes several modification in the documentation, mostly linked with the list of python versions accepted by AT.

**No code modification**