### PR TITLE
Add ItemVariable and AttributeVariable

### DIFF
--- a/docs/p/notebooks/variables.ipynb
+++ b/docs/p/notebooks/variables.ipynb
@@ -24,7 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from at.future import VariableBase, ElementVariable, RefptsVariable, CustomVariable"
+    "from at.future import ElementVariable, RefptsVariable\n",
+    "from at import VariableBase, AttributeVariable, ItemVariable, CustomVariable"
    ]
   },
   {
@@ -405,8 +406,8 @@
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
       "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
       "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[14]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mlfbound\u001b[49m\u001b[43m.\u001b[49m\u001b[43mset\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m0.2\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/dev/libraries/at/pyat/at/lattice/variables.py:240\u001b[39m, in \u001b[36mVariableBase.set\u001b[39m\u001b[34m(self, value, **setkw)\u001b[39m\n\u001b[32m    228\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mset\u001b[39m(\u001b[38;5;28mself\u001b[39m, value: Number, **setkw) -> \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    229\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Set the variable value\u001b[39;00m\n\u001b[32m    230\u001b[39m \n\u001b[32m    231\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    238\u001b[39m \u001b[33;03m          They augment the keyword arguments given in the constructor.\u001b[39;00m\n\u001b[32m    239\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m240\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcheck_bounds\u001b[49m\u001b[43m(\u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    241\u001b[39m     kw = \u001b[38;5;28mself\u001b[39m.kwargs.copy()\n\u001b[32m    242\u001b[39m     kw.update(setkw)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/dev/libraries/at/pyat/at/lattice/variables.py:173\u001b[39m, in \u001b[36mVariableBase.check_bounds\u001b[39m\u001b[34m(self, value)\u001b[39m\n\u001b[32m    171\u001b[39m min_val, max_val = \u001b[38;5;28mself\u001b[39m._bounds\n\u001b[32m    172\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m min_val \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m value < min_val:\n\u001b[32m--> \u001b[39m\u001b[32m173\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mValue \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m must be larger or equal to \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmin_val\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m    174\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m max_val \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m value > max_val:\n\u001b[32m    175\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mValue \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m must be smaller or equal to \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmax_val\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/dev/libraries/at/pyat/at/lattice/variables.py:264\u001b[39m, in \u001b[36mVariableBase.set\u001b[39m\u001b[34m(self, value, **setkw)\u001b[39m\n\u001b[32m    252\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mset\u001b[39m(\u001b[38;5;28mself\u001b[39m, value: Number, **setkw) -> \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    253\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Set the variable value.\u001b[39;00m\n\u001b[32m    254\u001b[39m \n\u001b[32m    255\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    262\u001b[39m \u001b[33;03m          They augment the keyword arguments given in the constructor.\u001b[39;00m\n\u001b[32m    263\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m264\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcheck_bounds\u001b[49m\u001b[43m(\u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    265\u001b[39m     \u001b[38;5;28mself\u001b[39m._setfun(value, *\u001b[38;5;28mself\u001b[39m.args, **(\u001b[38;5;28mself\u001b[39m.kwargs | setkw))\n\u001b[32m    266\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m np.isnan(\u001b[38;5;28mself\u001b[39m._initial):\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/dev/libraries/at/pyat/at/lattice/variables.py:195\u001b[39m, in \u001b[36mVariableBase.check_bounds\u001b[39m\u001b[34m(self, value)\u001b[39m\n\u001b[32m    193\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m min_val \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m value < min_val:\n\u001b[32m    194\u001b[39m     msg = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mValue \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m must be larger or equal to \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmin_val\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m195\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(msg)\n\u001b[32m    196\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m max_val \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m value > max_val:\n\u001b[32m    197\u001b[39m     msg = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mValue \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m must be smaller or equal to \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmax_val\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n",
       "\u001b[31mValueError\u001b[39m: Value 0.2 must be larger or equal to 0.45"
      ]
     }
@@ -522,6 +523,223 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1e7a85a1-a8df-42aa-8459-5eccee342846",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## {py:class}`.AttributeVariable`\n",
+    "\n",
+    "An {py:class}`.AttributeVariable` drives an attribute of an object. For example, we can drive a Lattice attribute like its\n",
+    "{py:attr}`~.Lattice.energy`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "221a5ced-119d-4687-89c3-775c542aed38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_var = AttributeVariable(newring, \"energy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "4116fbc6-145a-4201-bbcf-4a9820291e33",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6000000000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(energy_var.value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "1f73acd3-cc67-45b7-94d2-161fac4a7894",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6100000000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "energy_var.value = 6.1e9\n",
+    "print(newring.energy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29750594-ecdc-4d6a-a8b0-751a59e826b8",
+   "metadata": {},
+   "source": [
+    "We can look at the history of the variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "cd2c1978-bb0a-4a77-8a80-7105e1be6dd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[6000000000.0, 6100000000.0]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "energy_var.history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f4ac68d-9558-41b1-90de-ccef4ffc7344",
+   "metadata": {},
+   "source": [
+    "and go back to the initial value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "45039857-dcc1-4ad6-978d-4c0b0fd3244e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_var.reset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ea0d109-514f-47a5-ada0-b72e7e2d0687",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## {py:class}`.ItemVariable`\n",
+    "\n",
+    "An {py:class}`.ItemVariable` drives an item of a directory or of a sequence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "3990183c-48d9-4aea-8ce3-b26788afcd8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dct = dict(key1=42.0, key2=21.0)\n",
+    "v1 = at.ItemVariable(dct, \"key1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72d03e68-3ebf-4613-8f5b-500a4edb4e3f",
+   "metadata": {},
+   "source": [
+    "*v1* is associated with the item \"key1\" of *dct* ({py:class}`dict`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "0d2c2e70-cd4c-4ef5-a4c6-0eb930b4b4b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst = [0.0, 1.0, 2.0, 3.0]\n",
+    "v2 = at.ItemVariable(lst, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ed5fee9-cde5-4ce3-9cad-9827b6191c06",
+   "metadata": {},
+   "source": [
+    "*v2* is associated with the 2nd item of *lst* ({py:class}`list`)\n",
+    "\n",
+    "We can look at v1, change its value and check *dct*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "8f15d987-27b1-46c7-83b0-9fdc8bf063f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42.0\n",
+      "{'key1': 0.5, 'key2': 21.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(v1.value)\n",
+    "v1.value = 0.5\n",
+    "print(dct)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "828736df-2d63-4c68-8753-89fbf95e012a",
+   "metadata": {},
+   "source": [
+    "We can also look at v2,change its value and check *lst*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "dfbfcbcc-bb2f-4f02-87a1-f4b6fca813e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0\n",
+      "[0.0, 10.0, 2.0, 3.0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(v2.value)\n",
+    "v2.value = 10.0\n",
+    "print(lst)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "204d24e6-1e9b-4838-a950-3a8e1df5cac4",
    "metadata": {
     "editable": true,
@@ -538,9 +756,10 @@
     "\n",
     "1. A variable accessing the {py:obj}`DPStep <.DConstant>` AT parameter used in chromaticity computations. It does not look like a very\n",
     "   useful variable, it's for demonstration purpose,\n",
-    "2. A variable accessing the {py:attr}`~.Lattice.energy` of a given lattice\n",
+    "2. A variable accessing the {py:attr}`~.Lattice.energy` of a given lattice. This can be done more easily by using an\n",
+    "   {py:class}`.AttributeVariable`, but it's also for demonstration.\n",
     "\n",
-    "### Using the {py:class}`~.variables.CustomVariable`\n",
+    "### Using the {py:class}`.CustomVariable`\n",
     "\n",
     "Using a {py:class}`~.variables.CustomVariable` makes it very easy to define simple variables: we just need\n",
     "to define two functions for the \"get\" and \"set\" actions, and give them to the {py:class}`~.variables.CustomVariable` constructor.\n",
@@ -552,7 +771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 28,
    "id": "55a35ed2-a93b-4611-8a57-d7bce36a39f3",
    "metadata": {},
    "outputs": [],
@@ -567,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 29,
    "id": "347abd5d-bfc9-469c-aae8-715fdfa11009",
    "metadata": {},
    "outputs": [
@@ -586,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 30,
    "id": "f563564d-a862-4a11-9e9d-2e8864fa082d",
    "metadata": {},
    "outputs": [
@@ -616,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 31,
    "id": "8b5235c9-089d-46d2-a761-1044b445e583",
    "metadata": {
     "editable": true,
@@ -647,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 32,
    "id": "957c8990-d5e8-435d-959d-31109ff7cd17",
    "metadata": {},
    "outputs": [
@@ -665,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 33,
    "id": "3db01f54-db31-4042-b8b3-ac3289591ccb",
    "metadata": {},
    "outputs": [
@@ -692,7 +911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 34,
    "id": "786e4424-8840-490c-8ac0-1db350c0ef00",
    "metadata": {},
    "outputs": [
@@ -702,7 +921,7 @@
        "[6000000000.0, 6100000000.0]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -721,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
    "id": "9df21be4-0cf4-4499-aa0f-0fd7014f8934",
    "metadata": {},
    "outputs": [],
@@ -734,7 +953,7 @@
    "id": "0dc64ddf-26fd-4c19-a76b-b55f79b89717",
    "metadata": {},
    "source": [
-    "### By derivation of the {py:class}`~.variables.VariableBase` class\n",
+    "### By derivation of the {py:class}`.VariableBase` class\n",
     "\n",
     "The derivation of {py:class}`~.variables.VariableBase` allows more control on the created variable by using\n",
     "the class constuctor and its arguments to setup the variable.\n",
@@ -746,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 36,
    "id": "7474764c-88ee-49df-9f85-b9e7f04aefbb",
    "metadata": {},
    "outputs": [],
@@ -762,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 37,
    "id": "d838c699-8f99-4eb7-8784-acd503731888",
    "metadata": {},
    "outputs": [
@@ -781,7 +1000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 38,
    "id": "13fcbedf-f2e8-46f5-ab01-5a8c80608c76",
    "metadata": {},
    "outputs": [
@@ -810,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 39,
    "id": "547bdb0a-c1ea-4861-88d3-407329478391",
    "metadata": {},
    "outputs": [],
@@ -837,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 40,
    "id": "2c61510b-3fab-4d1c-8dd3-5a0dc9e8659f",
    "metadata": {},
    "outputs": [],
@@ -855,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 41,
    "id": "2f75312e-c088-43fb-b7f8-d0179363167d",
    "metadata": {},
    "outputs": [
@@ -873,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 42,
    "id": "8fb40e51-9c5d-4f81-abfe-64e577a74656",
    "metadata": {},
    "outputs": [
@@ -892,7 +1111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 43,
    "id": "54d43d08-0480-43bc-a260-631cf44f800a",
    "metadata": {},
    "outputs": [],
@@ -917,7 +1136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/pyat/at/lattice/__init__.py
+++ b/pyat/at/lattice/__init__.py
@@ -9,10 +9,9 @@ from .exceptions import *
 from .axisdef import *
 from .options import *
 from .particle_object import Particle
-# from .variables import *
-from .variables import VariableList
 from .elements import *
 from .utils import *
+from .variables import *
 from .geometry import *
 from .transformation import *
 from .lattice_object import *

--- a/pyat/at/lattice/elements/element_object.py
+++ b/pyat/at/lattice/elements/element_object.py
@@ -13,8 +13,9 @@ import numpy as np
 
 from .conversions import _array, _array66, _int, _float
 
-# noinspection PyProtectedMember
-from ..variables import _nop
+
+def _nop(value):
+    return value
 
 
 class Element:


### PR DESCRIPTION
This PR adds 2 new general variable types:
- `AttributeVariable` drives an attribute of any object. Example:
  ```
  ring = at.Lattice.load("hmba.mat")
  v3 = at.AttributeVariable(ring, "energy")
  ```
- `ItemVariable` drives an item of a mapping (`dict`) or a sequence (`list`). Example:
  ```
  dct = dict(key1=42.0, key2=21.0)
  v1 = at.ItemVariable(dct, "key1") 
  ```
  or
  ```
  lst = [0.0, 1.0, 2.0, 3.0]
  v2 = at.ItemVariable(lst, 1)
  ```

This covers many cases where a `CustomVariable` would be used.

The documentation and example notebooks are updated.