### PR TITLE
Fix double assignment of xlabel in plot_acceptance of pyat

### DIFF
--- a/pyat/at/plot/standalone.py
+++ b/pyat/at/plot/standalone.py
@@ -102,7 +102,7 @@ def plot_acceptance(ring: Lattice, planes, *args, **kwargs):
         plt.plot(*boundary, label="Acceptance")
         plt.title(f"2D {pl0['label']}-{pl1['label']} acceptance")
         plt.xlabel(f"{pl0['label']}{pl0['unit']}")
-        plt.xlabel(f"{pl1['label']}{pl1['unit']}")
+        plt.ylabel(f"{pl1['label']}{pl1['unit']}")
     plt.legend()
     plt.show(block=block)
     return boundary, survived, grid


### PR DESCRIPTION
Hi everyone, I found and corrected a one-character-mistake in the plot_acceptance function within pyat, which led to incorrect axis labels in the resulting plot. (double assignment of xlabel)