### PR TITLE
atlinopt4 with twiss_in and dp

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt4.m
+++ b/atmat/atphysics/LinearOptics/atlinopt4.m
@@ -99,7 +99,7 @@ NE = length(ring);
 [get_w,varargs]=getflag(varargs,'get_w');
 [twiss_in,varargs]=getoption(varargs,'twiss_in',[]);
 [dp,varargs]=getoption(varargs,'dp',0.0);
-[dpargs,varargs]=getoption(varargs,{'orbit','dct','df'});
+[dpargs,varargs]=getoption(varargs,{'dct','df'});
 [orbitin,varargs]=getoption(varargs,'orbit',[]);
 [coupled,varargs]=getoption(varargs,'coupled',true);
 [mkey,varargs]=getoption(varargs,'mkey','M');
@@ -120,21 +120,32 @@ else
 end
 
 if isempty(twiss_in)        % Circular machine
-    [orbit,orbitin]=findorbit4(ring,dp,refpts,dpargs{:},'XYStep',XYStep, 'strict', -1);
+    [orbit,orbitin] = findorbit4(ring, dp, refpts, orbitin, ...
+                                dpargs{:}, ...
+                                'XYStep', XYStep, ...
+                                'strict', -1);
     dp=orbitin(5);
-    [orbitP,o1P]=findorbit4(ring,dp+0.5*DPStep,refpts,orbitin,'XYStep',XYStep, 'strict', -1);
-    [orbitM,o1M]=findorbit4(ring,dp-0.5*DPStep,refpts,orbitin,'XYStep',XYStep, 'strict', -1);
+    [orbitP,o1P] = findorbit4(ring, dp+0.5*DPStep, refpts, orbitin, ...
+                              'XYStep',XYStep, ...
+                              'strict', -1);
+    [orbitM,o1M] = findorbit4(ring, dp-0.5*DPStep, refpts, orbitin, ...
+                              'XYStep',XYStep, ...
+                              'strict', -1);
 else                        % Transfer line
-    if ~isempty(orbitin), orbitin=zeros(6,1); end
-    orbit=linepass(ring,orbitin,refpts);
+    if isempty(orbitin)
+        orbitaux = zeros(6,1);
+    else
+        orbitaux = orbitin;
+    end
+    orbit=linepass(ring,orbitaux,refpts);
     try
         disp0=twiss_in.Dispersion;
     catch
         disp0=zeros(4,1);
     end
     dorbit=0.5*[DPStep*disp0;DPStep;0];
-    orbitP=linepass(ring,orbitin+dorbit,refpts);
-    orbitM=linepass(ring,orbitin-dorbit,refpts,'KeepLattice');
+    orbitP=linepass(ring,orbitaux+dorbit,refpts);
+    orbitM=linepass(ring,orbitaux-dorbit,refpts,'KeepLattice');
 end
 dispersion = (orbitP-orbitM)/DPStep;
 

--- a/atmat/atphysics/LinearOptics/atlinopt4.m
+++ b/atmat/atphysics/LinearOptics/atlinopt4.m
@@ -50,7 +50,7 @@ function [ringdata,elemdata] = atlinopt4(ring,varargin)
 %
 % [...] = ATLINOPT4(...,'dp',DPP)
 %   Analyses the off-momentum lattice by specifying the central
-%   off-momentum value
+%   off-momentum value. It is ignored when using the option 'orbit'.
 %
 % [...] = ATLINOPT4(...,'ct',DCT)
 %   Analyses the off-momentum lattice by specifying the path lengthening
@@ -59,7 +59,8 @@ function [ringdata,elemdata] = atlinopt4(ring,varargin)
 %
 % [...] = ATLINOPT4(...,'df',DF)
 %   Analyses the off-momentum lattice by specifying the RF frequency shift.
-%   The resulting deltap/p is returned in the 5th component of the ClosedOrbit field.
+%   The resulting deltap/p is returned in the 5th component of the
+%   ClosedOrbit field.
 %
 % [...] = ATLINOPT4(...,'orbit',ORBITIN)
 %   Do not search for closed orbit. Instead ORBITIN,a 6x1 vector
@@ -67,16 +68,16 @@ function [ringdata,elemdata] = atlinopt4(ring,varargin)
 %   The sixth component is ignored.
 %   This syntax is useful to specify the entrance orbit if RING is not a
 %   ring or to avoid recomputing the closed orbit if is already known.
+%   DP sets the energy offset, and the option 'dp' is ignored.
 %
 % [...] = ATLINOPT4(...,'twiss_in',TWISSIN)
 %   Computes the optics for a transfer line.
 %
 % TWISSIN is a scalar structure with fields:
-%   ClosedOrbit - 4x1 initial closed orbit. Default: zeros(4,1)
-%   Dispersion  - 4x1 initial dispersion.   Default: zeros(4,1)
-%   mu          - [ mux, muy] horizontal and vertical betatron phase
 %   beta        - [betax0, betay0] vector
 %   alpha       - [alphax0, alphay0] vector
+%   mu          - [mux, muy] hor. and vert. betatron phase. Default [0,0]
+%   Dispersion  - 4x1 initial dispersion. Default: zeros(4,1)
 %
 %  REFERENCES
 %	[1] D.Edwards,L.Teng IEEE Trans.Nucl.Sci. NS-20, No.3, p.885-888, 1973
@@ -120,32 +121,30 @@ else
 end
 
 if isempty(twiss_in)        % Circular machine
-    [orbit,orbitin] = findorbit4(ring, dp, refpts, orbitin, ...
-                                dpargs{:}, ...
-                                'XYStep', XYStep, ...
-                                'strict', -1);
+    [orbit,orbitin] = findorbit4(ring,dp,refpts, ...
+                                'orbit',orbitin, dpargs{:}, ...
+                                'XYStep', XYStep,'strict', -1);
     dp=orbitin(5);
-    [orbitP,o1P] = findorbit4(ring, dp+0.5*DPStep, refpts, orbitin, ...
-                              'XYStep',XYStep, ...
-                              'strict', -1);
-    [orbitM,o1M] = findorbit4(ring, dp-0.5*DPStep, refpts, orbitin, ...
-                              'XYStep',XYStep, ...
-                              'strict', -1);
+    [orbitP,o1P] = findorbit4(ring,dp+0.5*DPStep,refpts, ...
+                              'orbit',orbitin,'XYStep',XYStep,'strict',-1);
+    [orbitM,o1M] = findorbit4(ring,dp-0.5*DPStep,refpts, ...
+                              'orbit',orbitin,'XYStep',XYStep,'strict',-1);
 else                        % Transfer line
     if isempty(orbitin)
-        orbitaux = zeros(6,1);
+        orbitin = zeros(6,1);
+        orbitin(5) = dp;
     else
-        orbitaux = orbitin;
+        dp = orbitin(5);
     end
-    orbit=linepass(ring,orbitaux,refpts);
-    try
+    orbit=linepass(ring,orbitin,refpts);
+    if isfield(twiss_in,'Dispersion')
         disp0=twiss_in.Dispersion;
-    catch
+    else
         disp0=zeros(4,1);
     end
     dorbit=0.5*[DPStep*disp0;DPStep;0];
-    orbitP=linepass(ring,orbitaux+dorbit,refpts);
-    orbitM=linepass(ring,orbitaux-dorbit,refpts,'KeepLattice');
+    orbitP=linepass(ring,orbitin+dorbit,refpts);
+    orbitM=linepass(ring,orbitin-dorbit,refpts,'KeepLattice');
 end
 dispersion = (orbitP-orbitM)/DPStep;
 
@@ -202,6 +201,10 @@ end
 [BY,AY,MY]=lop(reshape(MSB,2,2,[]),beta0_b,alpha0_b);
 
 %tunes = [MX(end),MY(end)]/2/pi;
+if isfield(twiss_in,'mu')
+    MX = MX + twiss_in.mu(1);
+    MY = MY + twiss_in.mu(2);
+end
 
 ringdata=struct('tune',{[tune_a tune_b]});
 


### PR DESCRIPTION
Dear all,

this is a possible work around issue #1006 where the twiss functions of a transport line at different energies did not change when changing the energy using `dp`.

The issue is the variable `orbitin`, which is overwritten several times along the calculation.

- The parameter orbit was read twice (by dpargs and orbitin). This duplication is now removed.
- For a circular machine (no twiss_in) the orbit is now explicitly passed to findorbit4, and all other modifications are just to limit the maximum length of the line.
- For a transfer line (passing twiss_in) the orbit is unmodified. An auxiliary orbit is created to calculate the effect of dispersion. 

With this logic the call to findM44 is unchanged for circular machines or transfer lines.
https://github.com/atcollab/at/blob/a22c9b19acff5b0a6311bcbe2057186b0d9ef003/atmat/atphysics/LinearOptics/atlinopt4.m#L141