### PR TITLE
atplot with twiss_in and dpp

### DIFF
--- a/atmat/atplot/atplot.m
+++ b/atmat/atplot/atplot.m
@@ -119,7 +119,11 @@ args=getdparg(args(1:funcarg-1));
 
         function [s,plotdata]=ringplot(ring,dpp,plotfun,varargin)
             [linargs,vargs] = opticsoptions(varargin);
-            [ringdata,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:}); %#ok<ASGLU>
+            if check_6d(ring)
+                [~,lindata]=atlinopt6(ring,1:length(ring)+1,linargs{:});
+            else
+                [~,lindata]=atlinopt4(ring,1:length(ring)+1,linargs{:});
+            end
             s=cat(1,lindata.SPos);
             plotdata=plotfun(lindata,ring,dpp,vargs{:});
         end


### PR DESCRIPTION
Dear all,
this is a workaround to issue #1008 where the `atplot` of a transport line does not change with the parameter dpp.

This PR proposes to check if the ring is 6D, and use atlinopt4 if the ring is not 6D.

PR #1007 needs to be solved before this one.