### PR TITLE
Switch to the AT convention for the multipole K properties

### DIFF
--- a/pyat/at/lattice/elements/magnet_elements.py
+++ b/pyat/at/lattice/elements/magnet_elements.py
@@ -1,4 +1,4 @@
-r""":py:class:`.Element` classes for magnets
+r""":py:class:`.Element` classes for magnets.
 
 .. _at-field-expansion:
 
@@ -31,14 +31,14 @@ The :math:`a_n` coefficients describe the "skew" magnetic field and are given in
 from __future__ import annotations
 
 __all__ = [
-    "ThinMultipole",
-    "Multipole",
-    "Dipole",
     "Bend",
+    "Corrector",
+    "Dipole",
+    "Multipole",
+    "Octupole",
     "Quadrupole",
     "Sextupole",
-    "Octupole",
-    "Corrector",
+    "ThinMultipole",
     "Wiggler",
 ]
 
@@ -61,7 +61,7 @@ warnings.filterwarnings("always", category=AtWarning, module=__name__)
 
 
 def _warn(doc: str) -> str:
-    """Add a notice on AT / PALS field expansion"""
+    """Add a notice on AT / PALS field expansion."""
     return "\n".join(
         (
             doc,
@@ -134,10 +134,10 @@ class _LinkedArray(np.ndarray):
 
 
 class ThinMultipole(Element):
-    """Thin multipole element"""
+    """Thin multipole element."""
 
     # Class attributes
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["PolynomA", "PolynomB"]
+    _BUILD_ATTRIBUTES = [*Element._BUILD_ATTRIBUTES, "PolynomA", "PolynomB"]
     _conversions = dict(Element._conversions, K=float, H=float)
     _stacklevel = 4  # Stacklevel for warnings
 
@@ -151,7 +151,7 @@ class ThinMultipole(Element):
         Args:
             family_name:    Name of the element
             poly_a:         Array of integrated skew multipole components
-            poly_b:         Array of integrated normal multipole components
+            poly_b:         Array of integrated normal multipole components.
 
         Keyword arguments:
             MaxOrder:       Number of desired multipoles. Default: highest
@@ -264,23 +264,25 @@ class ThinMultipole(Element):
         self.PolynomB = lengthen(prmpolb, len_ab - len_b)
 
     def __setattr__(self, key, value):
-        """Check the compatibility of MaxOrder, PolynomA and PolynomB"""
+        """Check the compatibility of MaxOrder, PolynomA and PolynomB."""
         polys = ("PolynomA", "PolynomB")
         if key in polys:
             lmin = self.MaxOrder
             if not len(value) > lmin:
-                raise ValueError(f"Length of {key} must be larger than {lmin}")
+                msg = f"Length of {key} must be larger than {lmin}"
+                raise ValueError(msg)
         elif key == "MaxOrder":
             intval = int(value)
             lmax = min(len(getattr(self, k)) for k in polys)
             if not intval < lmax:
-                raise ValueError(f"MaxOrder must be smaller than {lmax}")
+                msg = f"MaxOrder must be smaller than {lmax}"
+                raise ValueError(msg)
         super().__setattr__(key, value)
 
     # noinspection PyPep8Naming
     @property
     def K(self) -> float:
-        """Focusing strength [mˆ-2]"""
+        """Focusing strength [m^-2]."""
         arr = self.PolynomB
         return 0.0 if len(arr) < 2 else float(arr[1])
 
@@ -292,7 +294,7 @@ class ThinMultipole(Element):
     # noinspection PyPep8Naming
     @property
     def H(self) -> float:
-        """Sextupolar strength [mˆ-3]"""
+        """Sextupolar strength [m^-3]."""
         arr = self.PolynomB
         return 0.0 if len(arr) < 3 else float(arr[2])
 
@@ -370,10 +372,10 @@ class ThinMultipole(Element):
 
 
 class Multipole(_Radiative, LongElement, ThinMultipole):
-    """Multipole element"""
+    """Multipole element."""
 
     # Class attributes
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["PolynomA", "PolynomB"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "PolynomA", "PolynomB"]
     _stacklevel = 6  # Stacklevel for warnings
 
     # Instance attributes
@@ -388,7 +390,7 @@ class Multipole(_Radiative, LongElement, ThinMultipole):
             family_name:    Name of the element
             length:         Element length [m]
             poly_a:         Array of skew multipole components
-            poly_b:         Array of normal multipole components
+            poly_b:         Array of normal multipole components.
 
         Keyword arguments:
             MaxOrder:       Number of desired multipoles. Default: highest
@@ -455,9 +457,9 @@ class Multipole(_Radiative, LongElement, ThinMultipole):
 
 
 class Dipole(Radiative, Multipole):
-    """Dipole element"""
+    """Dipole element."""
 
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["BendingAngle", "K"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "BendingAngle", "K"]
     _conversions = dict(
         Multipole._conversions,
         EntranceAngle=float,
@@ -471,13 +473,15 @@ class Dipole(Radiative, Multipole):
     )
     _stacklevel = 7  # Stacklevel for warnings
 
-    _entrance_fields = Multipole._entrance_fields + [
+    _entrance_fields = [
+        *Multipole._entrance_fields,
         "EntranceAngle",
         "FringeInt1",
         "FringeBendEntrance",
         "FringeQuadEntrance",
     ]
-    _exit_fields = Multipole._exit_fields + [
+    _exit_fields = [
+        *Multipole._exit_fields,
         "ExitAngle",
         "FringeInt2",
         "FringeBendExit",
@@ -499,7 +503,7 @@ class Dipole(Radiative, Multipole):
             family_name:    Name of the element
             length:         Element length [m]
             bending_angle:  Bending angle [rd]
-            k:              Focusing strength [m^-2]
+            k:              Focusing strength [m^-2].
 
         Keyword arguments:
             EntranceAngle=0.0:  entrance angle
@@ -574,26 +578,25 @@ Bend = Dipole
 
 
 class Quadrupole(Radiative, Multipole):
-    """Quadrupole element"""
+    """Quadrupole element."""
 
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["K"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "K"]
     _conversions = dict(
         Multipole._conversions, FringeQuadEntrance=int, FringeQuadExit=int
     )
     _stacklevel = 7  # Stacklevel for warnings
 
-    _entrance_fields = Multipole._entrance_fields + ["FringeQuadEntrance"]
-    _exit_fields = Multipole._exit_fields + ["FringeQuadExit"]
+    _entrance_fields = [*Multipole._entrance_fields, "FringeQuadEntrance"]
+    _exit_fields = [*Multipole._exit_fields, "FringeQuadExit"]
 
     DefaultOrder = 1
 
     def __init__(self, family_name: str, length: float, k: float = 0.0, **kwargs):
-        """Quadrupole(FamName, Length, Strength=0, **keywords)
-
+        """
         Args:
             family_name:    Name of the element
             length:         Element length [m]
-            k:              Focusing strength [mˆ-2]
+            k:              Focusing strength [m^-2]
 
         Keyword Arguments:
             PolynomB:           normal multipoles
@@ -623,9 +626,9 @@ class Quadrupole(Radiative, Multipole):
 
 
 class Sextupole(Multipole):
-    """Sextupole element"""
+    """Sextupole element."""
 
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["H"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "H"]
     _stacklevel = 7  # Stacklevel for warnings
 
     DefaultOrder = 2
@@ -635,7 +638,7 @@ class Sextupole(Multipole):
         Args:
             family_name:    Name of the element
             length:         Element length [m]
-            h:              Sextupolar strength [mˆ-3]
+            h:              Sextupolar strength [m^-3].
 
         Keyword Arguments:
             PolynomB:           normal multipoles
@@ -653,7 +656,7 @@ class Sextupole(Multipole):
 
 
 class Octupole(Multipole):
-    """Octupole element, with no changes from multipole at present"""
+    """Octupole element, with no changes from multipole at present."""
 
     _BUILD_ATTRIBUTES = Multipole._BUILD_ATTRIBUTES
 
@@ -661,10 +664,10 @@ class Octupole(Multipole):
 
 
 class Corrector(LongElement):
-    """Corrector element"""
+    """Corrector element."""
 
     # Class attributes
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["KickAngle"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "KickAngle"]
 
     # Instance attributes
     KickAngle: np.ndarray  #: (H, V) deviation angles
@@ -674,7 +677,7 @@ class Corrector(LongElement):
         Args:
             family_name:    Name of the element
             length:         Element length [m]
-            KickAngle:      Correction deviation angles (H, V)
+            KickAngle:      Correction deviation angles (H, V).
 
         Keyword Args:
             FieldScaling:   Scaling factor applied to the magnetic field
@@ -705,12 +708,12 @@ class Corrector(LongElement):
 
 
 class Wiggler(Radiative, LongElement):
-    """Wiggler element
+    """Wiggler element.
 
     See atwiggler.m
     """
 
-    _BUILD_ATTRIBUTES = LongElement._BUILD_ATTRIBUTES + ["Lw", "Bmax"]
+    _BUILD_ATTRIBUTES = [*LongElement._BUILD_ATTRIBUTES, "Lw", "Bmax"]
     _conversions = dict(
         Element._conversions,
         Lw=_float,
@@ -750,23 +753,25 @@ class Wiggler(Radiative, LongElement):
             Bx:             harmonics for horizontal wiggler: (6, nHharm)
                               array-like object
             By:             harmonics for vertical wiggler (6, nHharm)
-                              array-like object
+                              array-like object.
 
         Default PassMethod: ``GWigSymplecticPass``
         """
         kwargs.setdefault("PassMethod", "GWigSymplecticPass")
         n_wiggles = length / wiggle_period
         if abs(round(n_wiggles) - n_wiggles) > 1e-6:
-            raise ValueError(
+            msg = (
                 "Wiggler: length / wiggle_period is not an "
                 f"integer. ({length}/{wiggle_period}={n_wiggles})"
             )
+            raise ValueError(msg)
         if energy:
             warnings.warn(
                 AtWarning(
                     f"Wiggler: positional argument energy={energy} has been ignored as "
                     "lattice.Energy is always used instead."
-                )
+                ),
+                stacklevel=2
             )
         super().__init__(
             family_name,
@@ -783,12 +788,14 @@ class Wiggler(Radiative, LongElement):
         for i, b in enumerate(self.By.T):
             dk = abs(b[3] ** 2 - b[4] ** 2 - b[2] ** 2) / abs(b[4])
             if dk > 1e-6:
-                raise ValueError(f"Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = {i}")
+                msg = f"Wiggler(H): kx^2 + kz^2 -ky^2 !=0, i = {i}"
+                raise ValueError(msg)
 
         for i, b in enumerate(self.Bx.T):
             dk = abs(b[2] ** 2 - b[4] ** 2 - b[3] ** 2) / abs(b[4])
             if dk > 1e-6:
-                raise ValueError(f"Wiggler(V): ky^2 + kz^2 -kx^2 !=0, i = {i}")
+                msg = f"Wiggler(V): ky^2 + kz^2 -kx^2 !=0, i = {i}"
+                raise ValueError(msg)
 
         self.NHharm = self.By.shape[1]
         self.NVharm = self.Bx.shape[1]


### PR DESCRIPTION
Following @swhite2401's remark in https://github.com/atcollab/at/pull/1001#issuecomment-3467129842, this PR sets the AT convention for the `Kn` and `Ks` magnet properties.