### PR TITLE
Fix bug wiggler rounding

### DIFF
--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -25,6 +25,7 @@
 #include "atlalib.c"
 #include "gwig.c"
 
+
 struct elem {
     double Energy;
     double Length;
@@ -119,6 +120,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 
 {
     double gamma;
+    double wig_l_ratio, len_tolerance;
 
     if (!Elem) {
         double *R1, *R2, *T1, *T2;
@@ -161,6 +163,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->T2=T2;
     }
     gamma = atGamma(Param->energy, Elem->Energy, Param->rest_energy);
+    /* Check wiggle total lenth and period length */
+    wig_l_ratio = Elem->Length/Elem->Lw;
+    len_tolerance = 1e-9;
+    if (fabs(wig_l_ratio - round(wig_l_ratio) >= len_tolerance))
+      atError("Wiggler total length is not a multiple of a period length.");
 
     GWigSymplecticPass(r_in, gamma, Elem->Length, Elem->Lw, Elem->Bmax,
             Elem->Nstep, Elem->Nmeth, Elem->NHharm, Elem->NVharm,

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -121,6 +121,14 @@ void GWigSymplecticPass(double *r, double gamma, double Ltot, double Lw,
 /*****************************************************************************/
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
+#if defined(MATLAB_MEX_FILE)
+#define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
+#endif
+
+
+#if defined(PYAT)
+#define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
+#endif
 
 #if defined(MATLAB_MEX_FILE) || defined(PYAT)
 ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -6,7 +6,7 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
- * .05  205-11-07      O. Blanco
+ * .05  205-11-07      O. Blanco, ALBA
  *                     Check if gamma is well defined
  * .03  2024-05-06     J. Arenillas, ALBA, jarenillas@axt.email
  *              Adding rotations and translations to wiggler.

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -163,11 +163,6 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->T2=T2;
     }
     gamma = atGamma(Param->energy, Elem->Energy, Param->rest_energy);
-    /* Check wiggle total lenth and period length */
-    wig_l_ratio = Elem->Length/Elem->Lw;
-    len_tolerance = 1e-9;
-    if (fabs(wig_l_ratio - round(wig_l_ratio) >= len_tolerance))
-      atError("Wiggler total length is not a multiple of a period length.");
 
     GWigSymplecticPass(r_in, gamma, Elem->Length, Elem->Lw, Elem->Bmax,
             Elem->Nstep, Elem->Nmeth, Elem->NHharm, Elem->NVharm,

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -120,7 +120,6 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 
 {
     double gamma;
-    double wig_l_ratio, len_tolerance;
 
     if (!Elem) {
         double *R1, *R2, *T1, *T2;

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -130,7 +130,7 @@ typedef mxArray atElem;
 
 #if defined(PYAT)
 typedef PyObject atElem;
-#define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
+#define atError(...) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
 #endif
 
 #if defined(MATLAB_MEX_FILE) || defined(PYAT)

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -6,8 +6,6 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
- * .05  205-11-07      O. Blanco, ALBA
- *                     Check if gamma is well defined
  * .03  2024-05-06     J. Arenillas, ALBA, jarenillas@axt.email
  *              Adding rotations and translations to wiggler.
  *				Bug fix in wiggler initialisation.
@@ -23,7 +21,6 @@
  *  Accelerator Physics Group, Duke FEL Lab, www.fel.duke.edu  
  */
 
-#include "atcommon.h"
 #include "atelem.c"
 #include "atlalib.c"
 #include "gwig.c"
@@ -84,13 +81,6 @@ void GWigSymplecticPass(double *r, double gamma, double Ltot, double Lw,
     int c;
     double *r6;
     struct gwig pWig;
-
-    /* when element is tracked alone.*/
-    if (isnan(gamma) || gamma == 0){
-      atError("GWigSymplecticPass: Energy  not defined.");
-      return;
-    }
-
     /* Energy is defined in the lattice in eV but GeV is used by the gwig code. */
     GWigInit2(&pWig, gamma,Ltot, Lw, Bmax, Nstep, Nmeth, NHharm, NVharm,0, 0, By,Bx,T1,T2,R1,R2);
 
@@ -122,16 +112,6 @@ void GWigSymplecticPass(double *r, double gamma, double Ltot, double Lw,
 /*****************************************************************************/
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
-#if defined(MATLAB_MEX_FILE)
-typedef mxArray atElem;
-#define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
-#endif
-
-
-#if defined(PYAT)
-typedef PyObject atElem;
-#define atError(...) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
-#endif
 
 #if defined(MATLAB_MEX_FILE) || defined(PYAT)
 ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -6,6 +6,8 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
+ * .05  205-11-07      O. Blanco
+ *                     Check if gamma is well defined
  * .03  2024-05-06     J. Arenillas, ALBA, jarenillas@axt.email
  *              Adding rotations and translations to wiggler.
  *				Bug fix in wiggler initialisation.
@@ -81,6 +83,13 @@ void GWigSymplecticPass(double *r, double gamma, double Ltot, double Lw,
     int c;
     double *r6;
     struct gwig pWig;
+
+    /* when element is tracked alone.*/
+    if (isnan(gamma) || gamma == 0){
+      atError("GWigSymplecticPass: Energy  not defined.");
+      return;
+    }
+
     /* Energy is defined in the lattice in eV but GeV is used by the gwig code. */
     GWigInit2(&pWig, gamma,Ltot, Lw, Bmax, Nstep, Nmeth, NHharm, NVharm,0, 0, By,Bx,T1,T2,R1,R2);
 

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -23,6 +23,7 @@
  *  Accelerator Physics Group, Duke FEL Lab, www.fel.duke.edu  
  */
 
+#include "atcommon.h"
 #include "atelem.c"
 #include "atlalib.c"
 #include "gwig.c"

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -122,11 +122,13 @@ void GWigSymplecticPass(double *r, double gamma, double Ltot, double Lw,
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
 #if defined(MATLAB_MEX_FILE)
+typedef mxArray atElem;
 #define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
 #endif
 
 
 #if defined(PYAT)
+typedef PyObject atElem;
 #define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
 #endif
 

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -246,6 +246,14 @@ void GWigSymplecticRadPass(double *orbit_in, double gamma, double le, double Lw,
 
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
+#if defined(MATLAB_MEX_FILE)
+#define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
+#endif
+
+#if defined(PYAT)
+#define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
+#endif
+
 
 #if defined(MATLAB_MEX_FILE) || defined(PYAT)
 ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -245,6 +245,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 
 {
     double gamma;
+    double wig_l_ratio, len_tolerance;
     double *bdiff = Param->bdiff;
 
     if (!Elem) {
@@ -288,6 +289,11 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->T2=T2;
     }
     gamma = atGamma(Param->energy, Elem->Energy, Param->rest_energy);
+    /* Check wiggle total lenth and period length */
+    wig_l_ratio = Elem->Length/Elem->Lw;
+    len_tolerance = 1e-9;
+    if (fabs(wig_l_ratio - round(wig_l_ratio) >= len_tolerance))
+      atError("Wiggler total length is not a multiple of a period length.");
 
     GWigSymplecticRadPass(r_in, gamma, Elem->Length, Elem->Lw, Elem->Bmax,
             Elem->Nstep, Elem->Nmeth, Elem->NHharm, Elem->NVharm,

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -6,6 +6,8 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
+ * .05  205-11-07      O. Blanco
+ *                     Check if gamma is well defined
  * .04  2024-10-21     L. Farvacque
  *              Merged tracking and diffusion matrices
  * .03  2024-05-06     J. Arenillas, ALBA, jarenillas@axt.email
@@ -174,6 +176,12 @@ void GWigSymplecticRadPass(double *orbit_in, double gamma, double le, double Lw,
 	double dl1 = SL*KICK1;
     double dl0 = SL*KICK2;
 	int Niter = Nstep*(le/Lw);
+
+    /* when element is tracked alone.*/
+    if (isnan(gamma) || gamma == 0){
+      atError("GWigSymplecticRadPass: Energy  not defined.");
+      return;
+    }
 
     GWigInit2(&pWig, gamma,le, Lw, Bmax, Nstep, Nmeth, NHharm, NVharm,0,0,By,Bx,T1,T2,R1,R2);
 

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -289,11 +289,6 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         Elem->T2=T2;
     }
     gamma = atGamma(Param->energy, Elem->Energy, Param->rest_energy);
-    /* Check wiggle total lenth and period length */
-    wig_l_ratio = Elem->Length/Elem->Lw;
-    len_tolerance = 1e-9;
-    if (fabs(wig_l_ratio - round(wig_l_ratio) >= len_tolerance))
-      atError("Wiggler total length is not a multiple of a period length.");
 
     GWigSymplecticRadPass(r_in, gamma, Elem->Length, Elem->Lw, Elem->Bmax,
             Elem->Nstep, Elem->Nmeth, Elem->NHharm, Elem->NVharm,

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -247,10 +247,12 @@ void GWigSymplecticRadPass(double *orbit_in, double gamma, double le, double Lw,
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
 #if defined(MATLAB_MEX_FILE)
+typedef mxArray atElem;
 #define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
 #endif
 
 #if defined(PYAT)
+typedef PyObject atElem;
 #define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
 #endif
 

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -24,6 +24,7 @@
  *  Accelerator Physics Group, Duke FEL Lab, www.fel.duke.edu
  */
 
+#include "atcommon.h"
 #include "atelem.c"
 #include "atlalib.c"
 #include "wigrad.c"

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -6,8 +6,6 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
- * .05  205-11-07      O. Blanco, ALBA
- *                     Check if gamma is well defined
  * .04  2024-10-21     L. Farvacque
  *              Merged tracking and diffusion matrices
  * .03  2024-05-06     J. Arenillas, ALBA, jarenillas@axt.email
@@ -24,7 +22,6 @@
  *  Accelerator Physics Group, Duke FEL Lab, www.fel.duke.edu
  */
 
-#include "atcommon.h"
 #include "atelem.c"
 #include "atlalib.c"
 #include "wigrad.c"
@@ -178,12 +175,6 @@ void GWigSymplecticRadPass(double *orbit_in, double gamma, double le, double Lw,
     double dl0 = SL*KICK2;
 	int Niter = Nstep*(le/Lw);
 
-    /* when element is tracked alone.*/
-    if (isnan(gamma) || gamma == 0){
-      atError("GWigSymplecticRadPass: Energy  not defined.");
-      return;
-    }
-
     GWigInit2(&pWig, gamma,le, Lw, Bmax, Nstep, Nmeth, NHharm, NVharm,0,0,By,Bx,T1,T2,R1,R2);
 
     for (int c = 0; c<num_particles; c++) { /* Loop over particles */
@@ -247,16 +238,6 @@ void GWigSymplecticRadPass(double *orbit_in, double gamma, double le, double Lw,
 
 /********** END PHYSICS SECTION **********************************************/
 /*****************************************************************************/
-#if defined(MATLAB_MEX_FILE)
-typedef mxArray atElem;
-#define atError(...) mexErrMsgIdAndTxt("AT:PassError", __VA_ARGS__)
-#endif
-
-#if defined(PYAT)
-typedef PyObject atElem;
-#define atError(...) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
-#endif
-
 
 #if defined(MATLAB_MEX_FILE) || defined(PYAT)
 ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -245,7 +245,6 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 
 {
     double gamma;
-    double wig_l_ratio, len_tolerance;
     double *bdiff = Param->bdiff;
 
     if (!Elem) {

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -254,7 +254,7 @@ typedef mxArray atElem;
 
 #if defined(PYAT)
 typedef PyObject atElem;
-#define atError(...) return (struct elem *) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
+#define atError(...) PyErr_Format(PyExc_ValueError, __VA_ARGS__)
 #endif
 
 

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -6,7 +6,7 @@
  *---------------------------------------------------------------------------
  * Modification Log:
  * -----------------
- * .05  205-11-07      O. Blanco
+ * .05  205-11-07      O. Blanco, ALBA
  *                     Check if gamma is well defined
  * .04  2024-10-21     L. Farvacque
  *              Merged tracking and diffusion matrices

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -2,6 +2,9 @@
  *----------------------------------------------------------------------------
  * Modification Log:
  * -----------------
+ * .05  205-11-07       O. Blanco
+ *                      Define Wig->Nw using round()
+ *
  * .04  2003-04-29      YK Wu, Duke University
  *			using scientific notation for constants. 
  *                      Checked with TRACY pascal code.

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -45,7 +45,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
     Wig->Po = sqrt(gamma*gamma - 1.0);
     Wig->Pmethod = Nmeth;
     Wig->PN = Nstep;
-    Wig->Nw = round(Ltot/Lw);
+    Wig->Nw = round(Ltot / Lw);
     Wig->NHharm = NHharm;
     Wig->NVharm = NVharm;
     Wig->PB0 = Bmax;

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -3,7 +3,7 @@
  * Modification Log:
  * -----------------
  * .05  205-11-07       O. Blanco, ALBA
- *                      Define Wig->Nw using round()
+ *                      Define Wig->Nw without cast to int.
  *
  * .04  2003-04-29      YK Wu, Duke University
  *			using scientific notation for constants. 
@@ -31,6 +31,8 @@
 #include <math.h>
 #include <stdio.h>
 
+
+
 static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
             double Bmax, int Nstep, int Nmeth, int NHharm, int NVharm,
             int HSplitPole, int VSplitPole, double *By, double *Bx,
@@ -43,7 +45,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
     Wig->Po = sqrt(gamma*gamma - 1.0);
     Wig->Pmethod = Nmeth;
     Wig->PN = Nstep;
-    Wig->Nw = round(Ltot / Lw);
+    Wig->Nw = round(Ltot/Lw);
     Wig->NHharm = NHharm;
     Wig->NVharm = NVharm;
     Wig->PB0 = Bmax;

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -2,7 +2,7 @@
  *----------------------------------------------------------------------------
  * Modification Log:
  * -----------------
- * .05  205-11-07       O. Blanco
+ * .05  205-11-07       O. Blanco, ALBA
  *                      Define Wig->Nw using round()
  *
  * .04  2003-04-29      YK Wu, Duke University

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -40,7 +40,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
     Wig->Po = sqrt(gamma*gamma - 1.0);
     Wig->Pmethod = Nmeth;
     Wig->PN = Nstep;
-    Wig->Nw = (int)(Ltot / Lw);
+    Wig->Nw = round(Ltot / Lw);
     Wig->NHharm = NHharm;
     Wig->NVharm = NVharm;
     Wig->PB0 = Bmax;

--- a/atintegrators/gwigR.c
+++ b/atintegrators/gwigR.c
@@ -2,6 +2,9 @@
  *----------------------------------------------------------------------------
  * Modification Log:
  * -----------------
+ * .05  205-11-07       O. Blanco, ALBA
+ *                      Define Wig->Nw using round()
+ *
  * .07  2024-05-09      J. Arenillas, ALBA, jarenillas@axt.email
  *                      New expression for the comptation of radiation kicks.
  *						Adding new functions for the computation of wiggler diffusion matrix.

--- a/atintegrators/gwigR.c
+++ b/atintegrators/gwigR.c
@@ -3,7 +3,7 @@
  * Modification Log:
  * -----------------
  * .05  205-11-07       O. Blanco, ALBA
- *                      Define Wig->Nw using round()
+ *                      Define Wig->Nw without cast to int.
  *
  * .07  2024-05-09      J. Arenillas, ALBA, jarenillas@axt.email
  *                      New expression for the comptation of radiation kicks.

--- a/atintegrators/gwigR.c
+++ b/atintegrators/gwigR.c
@@ -417,7 +417,7 @@ static void GWigInit2(struct gwigR *Wig,double design_energy, double Ltot, doubl
     Wig->Po = Wig->E0/XMC2;
     Wig->Pmethod = Nmeth;
     Wig->PN = Nstep;
-    Wig->Nw = (int)(Ltot / Lw);
+    Wig->Nw = round(Ltot / Lw);
     Wig->NHharm = NHharm;
     Wig->NVharm = NVharm;
     Wig->PB0 = Bmax;

--- a/atmat/lattice/element_creation/atwiggler.m
+++ b/atmat/lattice/element_creation/atwiggler.m
@@ -48,10 +48,10 @@ function elem=atwiggler(fname,varargin)
 [By,rsrc] = getoption(rsrc,'By',[1;1;0;1;1;0]);
 [method,rsrc] = getoption(rsrc,'PassMethod',method);
 [cl,rsrc] = getoption(rsrc,'Class','Wiggler');
-GWIG_EPS = 1e-6;
+GWIG_EPS = 1e-9;
 dNw = Ltot/Lw-round(Ltot/Lw);
 if dNw > GWIG_EPS
-    error(' Wiggler: Ltot/Lw is not an integer.');
+    error(' Wiggler: LENGTH/LW is not an integer.');
 end
 
 By=reshape(By,6,[]);


### PR DESCRIPTION
Dear all,
this PR solves issue #1012 where there was in inconsistent behaviour of a wiggler set to Bmax=0 when compared to a drift of the same length.

The number of iterations is now calculated using `round`. The user must take into account that the ratio between total wiggler length and the wiggle_period should be an integer.

In addition, wiggler elements cannot be tracked alone. I include a check on the definition of gamma that is only set by the lattice, according to pull request #894 .



