### PR TITLE
bugfix: switch to BndMPoleSymplectic4RadPass in ohmi envelope

### DIFF
--- a/pyat/at/physics/radiation.py
+++ b/pyat/at/physics/radiation.py
@@ -71,7 +71,7 @@ def _dmatr(ring: Lattice, orbit: Orbit = None, keep_lattice: bool = False):
     def substitute(elem):
         if elem.PassMethod not in _new_methods:
             elem = elem.copy()
-            elem.PassMethod = "StrMPoleSymplectic4RadPass"
+            elem.PassMethod = "BndMPoleSymplectic4RadPass"
         return elem
 
     def elem_diffusion(elem: Element, elemorb):


### PR DESCRIPTION
Presently the pass methods not implemented for ohmi envelope (exact bends) switch to StrMPoleSymplectic4RadPass, this is not correct as it transforms dipoles into multipoles resulting in wrong radiation parameters returned by ohmi_envelope()
Now the passmethods are correctly switched to BndMPoleSymplectic4RadPass.