### PR TITLE
Update macOS GitHub runners

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-15-intel, macos-latest, ubuntu-latest, windows-latest]
 
     steps:
 


### PR DESCRIPTION
The GitHub tests fail because of the deprecation of the macOS intel runner (`macos-13`). We replace it with the up-to-date `macos-15-runner`.