### PR TITLE
New separatrix for longitudinal hamiltonian plot

### DIFF
--- a/pyat/at/plot/standalone.py
+++ b/pyat/at/plot/standalone.py
@@ -246,13 +246,16 @@ def plot_RF_bucket_hamiltonian(
         num_levels (int): Number of levels for contour plot. Odd number of
             levels allow to center the colorbar around 0. Default to 41.
         plot_separatrix (bool): Flag to plot the separatrix contour
-            (:math:`\mathcal{H}=0`).
+            (:math:`min(\mathcal{H}(ct_{UFP},0),\mathcal{H}(0,\delta_{UFP}))`).
 
     Returns:
         CT:   (num_points,num_points) array: ct grid
         DP:    (num_points,num_points) array: dp grid
         hamiltonian:   (num_points,num_points) array: Hamiltonian values
         along (CT,DP) grid
+        separatrix:   Hamiltonian value at the separatrix
+        ct_UFP:   Distance of arrival Unstable Fixed Point
+        delta_UFP:   Momentum deviation Unstable Fixed Point
     """
     # Momentum compaction/phase slip factors computed up to third order
     tmp_ring = ring.disable_6d(copy=True)


### PR DESCRIPTION
I have modified the longitudinal Hamiltonian plotting routine to correctly calculate the separatrix based on both Unstable Fixed Points (UFP). Until now, I considered the separatrix to be the isocontour H = 0, which is correct for the ct_UFP fixed point. However, when transitioning to an alpha bucket, it leads to an open separatrix as can be seen below: 

<img width="1111" height="874" alt="Screenshot from 2025-12-09 17-08-26" src="https://github.com/user-attachments/assets/e9e0bc97-2ae4-4d32-bac6-6330e2775b17" />

To fix the issue, I now set separatrix to min(H(0, delta_UFP), H(ct_UFP, 0)). Now, we obtain the right separatrix, delimiting the largest area for which particles remain trapped in the RF potential:

<img width="1111" height="874" alt="Screenshot from 2025-12-09 17-08-44" src="https://github.com/user-attachments/assets/70b904c2-0fd8-4e04-afaf-32105f021a38" />

I also return the separatrix, ct_UFP, and delta_UFP values in case it is relevant for the user.