### PR TITLE
add Matrix66RadPass passmethod

### DIFF
--- a/atintegrators/Matrix66RadPass.c
+++ b/atintegrators/Matrix66RadPass.c
@@ -1,0 +1,97 @@
+#include "atelem.c"
+#include "atlalib.c"
+
+struct elem
+{
+    double *M66;
+    /* optional fields */
+    double *R1;
+    double *R2;
+    double *T1;
+    double *T2;
+};
+
+void Matrix66RadPass(double *r, const double *M,
+        const double *T1, const double *T2,
+        const double *R1, const double *R2, int num_particles)
+{
+    double *r6;
+    int c;
+    for (c = 0; c<num_particles; c++) {	/*Loop over particles  */
+        r6 = r+c*6;
+        if (!atIsNaN(r6[0])) {
+            if (T1 != NULL) ATaddvv(r6, T1);
+            if (R1 != NULL) ATmultmv(r6, R1);
+            ATmultmv(r6, M);
+            if (R2 != NULL) ATmultmv(r6, R2);
+            if (T2 != NULL) ATaddvv(r6, T2);
+        }
+    }
+}
+
+#if defined(MATLAB_MEX_FILE) || defined(PYAT)
+ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
+        double *r_in, int num_particles, struct parameters *Param)
+{
+    if (!Elem) {
+        double *M66;
+        double *R1, *R2, *T1, *T2;
+        M66=atGetDoubleArray(ElemData,"M66Rad"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        Elem = (struct elem*)atMalloc(sizeof(struct elem));
+        Elem->M66=M66;
+        /*optional fields*/
+        Elem->R1=R1;
+        Elem->R2=R2;
+        Elem->T1=T1;
+        Elem->T2=T2;
+        }   
+    Matrix66RadPass(r_in, Elem->M66, Elem->T1, Elem->T2, Elem->R1, Elem->R2, num_particles);
+    return Elem;
+}
+MODULE_DEF(Matrix66RadPass)        /* Dummy module initialisation */
+
+#endif /*defined(MATLAB_MEX_FILE) || defined(PYAT)*/
+
+#if defined(MATLAB_MEX_FILE)
+void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+    if (nrhs >= 2) {
+        double *r_in;
+        const mxArray *ElemData = prhs[0];
+        int num_particles = mxGetN(prhs[1]);
+        double *M66, *R1, *R2, *T1, *T2;
+        M66=atGetDoubleArray(ElemData,"M66Rad"); check_error();
+        /*optional fields*/
+        R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
+        R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        
+        /* ALLOCATE memory for the output array of the same size as the input  */
+        plhs[0] = mxDuplicateArray(prhs[1]);
+        r_in = mxGetDoubles(plhs[0]);
+        Matrix66RadPass(r_in, M66, T1, T2, R1, R2, num_particles);
+    }
+    else if (nrhs == 0) {
+        /* list of required fields */
+        plhs[0] = mxCreateCellMatrix(1,1);
+        mxSetCell(plhs[0],0,mxCreateString("M66Rad"));
+        if (nlhs>1) {
+            /* list of optional fields */
+            plhs[1] = mxCreateCellMatrix(4,1);
+            mxSetCell(plhs[1], 0,mxCreateString("T1"));
+            mxSetCell(plhs[1], 1,mxCreateString("T2"));
+            mxSetCell(plhs[1], 2,mxCreateString("R1"));
+            mxSetCell(plhs[1], 3,mxCreateString("R2"));
+        }
+    }
+    else {
+        mexErrMsgIdAndTxt("AT:WrongArg","Needs 0 or 2 arguments");
+    }
+}
+#endif /*MATLAB_MEX_FILE*/

--- a/atintegrators/Matrix66RadPass.c
+++ b/atintegrators/Matrix66RadPass.c
@@ -40,8 +40,8 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         /*optional fields*/
         R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
         R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
-        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
-        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1Rad"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2Rad"); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         Elem->M66=M66;
         /*optional fields*/
@@ -69,8 +69,8 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /*optional fields*/
         R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
         R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();
-        T1=atGetOptionalDoubleArray(ElemData,"T1"); check_error();
-        T2=atGetOptionalDoubleArray(ElemData,"T2"); check_error();
+        T1=atGetOptionalDoubleArray(ElemData,"T1Rad"); check_error();
+        T2=atGetOptionalDoubleArray(ElemData,"T2Rad"); check_error();
         
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
@@ -84,8 +84,8 @@ void mexFunction(	int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (nlhs>1) {
             /* list of optional fields */
             plhs[1] = mxCreateCellMatrix(4,1);
-            mxSetCell(plhs[1], 0,mxCreateString("T1"));
-            mxSetCell(plhs[1], 1,mxCreateString("T2"));
+            mxSetCell(plhs[1], 0,mxCreateString("T1Rad"));
+            mxSetCell(plhs[1], 1,mxCreateString("T2Rad"));
             mxSetCell(plhs[1], 2,mxCreateString("R1"));
             mxSetCell(plhs[1], 3,mxCreateString("R2"));
         }

--- a/atintegrators/Matrix66RadPass.c
+++ b/atintegrators/Matrix66RadPass.c
@@ -36,7 +36,10 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
     if (!Elem) {
         double *M66;
         double *R1, *R2, *T1, *T2;
-        M66=atGetDoubleArray(ElemData,"M66Rad"); check_error();
+        M66=atGetOptionalDoubleArray(ElemData,"M66Rad");
+        if (M66 == NULL) {
+            M66=atGetDoubleArray(ElemData,"M66");
+        }
         /*optional fields*/
         R1=atGetOptionalDoubleArray(ElemData,"R1"); check_error();
         R2=atGetOptionalDoubleArray(ElemData,"R2"); check_error();

--- a/atmat/attests/pytests.m
+++ b/atmat/attests/pytests.m
@@ -258,7 +258,6 @@ classdef pytests < matlab.unittest.TestCase
             function checkattr(rm, rp)
                 testCase.verifyEqual(rm{2}.Frequency, rp{1}.Frequency, RelTol=1.0e-20);
                 testCase.verifyEqual(rm{2}.Voltage, rp{1}.Voltage, RelTol=1.0e-20);
-                testCase.verifyEqual(rm{3}.I2, rp{2}.I2, RelTol=1.0e-15);
                 testCase.verifyEqual(rm{3}.Length, rp{2}.Length, RelTol=1.0e-20);
                 testCase.verifyEqual(rm{3}.M66, double(rp{2}.M66), AbsTol=1.0e-7);
                 testCase.verifyEqual(rm{end}.A1, rp{3}.A1, RelTol=0.01);

--- a/atmat/lattice/element_creation/atM66.m
+++ b/atmat/lattice/element_creation/atM66.m
@@ -1,8 +1,11 @@
 function elem=atM66(fname,varargin)
 %ATM66  Create an element applying an arbitrary 6x6 transfer matrix
 %
+%ATM66(FAMNAME, M66, M66RAD, PASSMETHOD)
+%
 %FAMNAME	family name
-%M66        transfer matrix, defaults to Identity(6)]
+%M66        transfer matrix, defaults to Identity(6)
+%M66RAD     transfer matrix when radiation is activated. Defaults to M66
 %PASSMETHOD	tracking function, defaults to 'Matrix66Pass'
 %
 %ATM66(FAMNAME,ATSTRUCT,PASSMETHOD)
@@ -10,14 +13,17 @@ function elem=atM66(fname,varargin)
 %
 %ATSTRUCT   AT structure
 
-[rsrc,m66,method] = decodeatargs({eye(6),'Matrix66Pass'},varargin);
+[rsrc,m66,m66rad,method] = decodeatargs({eye(6),[],'Matrix66Pass'},varargin);
 [method,rsrc]     = getoption(rsrc,'PassMethod',method);
 [cl,rsrc]         = getoption(rsrc,'Class','Matrix66');
 
 if isstruct(m66)
     m66=findm66(m66);
 end
+if isempty(m66rad)
+    m66rad=m66;
+end
 
-elem=atbaselem(fname,method,'Class',cl,'M66',m66,rsrc{:});
+elem=atbaselem(fname,method,'Class',cl,'M66',m66,'M66Rad',m66rad,rsrc{:});
 
 end

--- a/pyat/at/lattice/elements/basic_elements.py
+++ b/pyat/at/lattice/elements/basic_elements.py
@@ -443,25 +443,30 @@ class RFCavity(LongtMotion, LongElement):
         return super().set_longt_motion(enable, new_pass=new_pass, **kwargs)
 
 
-class M66(Element):
+class M66(Radiative, Element):
     """Linear (6, 6) transfer matrix."""
 
     _BUILD_ATTRIBUTES = [*Element._BUILD_ATTRIBUTES, "M66"]
     _conversions = dict(Element._conversions, M66=_array66)
     _file_classname = "Matrix66"
 
-    def __init__(self, family_name: str, m66=None, **kwargs):
+    def __init__(self, family_name: str, m66=None, m66rad=None, **kwargs):
         """
         Args:
             family_name:    Name of the element
             m66:            Transfer matrix. Default: Identity matrix.
+            m66rad:         Transfer matrix including radiation. Default: Identity matrix.
+
 
         Default PassMethod: ``Matrix66Pass``
         """
         if m66 is None:
             m66 = np.identity(6)
+        if m66rad is None:
+            m66rad = np.identity(6)       
         kwargs.setdefault("PassMethod", "Matrix66Pass")
         kwargs.setdefault("M66", m66)
+        kwargs.setdefault("M66Rad", m66rad)
         super().__init__(family_name, **kwargs)
 
 

--- a/pyat/at/lattice/elements/basic_elements.py
+++ b/pyat/at/lattice/elements/basic_elements.py
@@ -461,9 +461,9 @@ class M66(Radiative, Element):
         Default PassMethod: ``Matrix66Pass``
         """
         if m66 is None:
-            m66 = np.identity(6)
+            m66 = np.asfortranarray(np.identity(6))
         if m66rad is None:
-            m66rad = np.identity(6)       
+            m66rad = np.asfortranarray(np.identity(6))       
         kwargs.setdefault("PassMethod", "Matrix66Pass")
         kwargs.setdefault("M66", m66)
         kwargs.setdefault("M66Rad", m66rad)

--- a/pyat/at/lattice/elements/basic_elements.py
+++ b/pyat/at/lattice/elements/basic_elements.py
@@ -463,7 +463,7 @@ class M66(Radiative, Element):
         if m66 is None:
             m66 = np.asfortranarray(np.identity(6))
         if m66rad is None:
-            m66rad = np.asfortranarray(np.identity(6))       
+            m66rad = m66     
         kwargs.setdefault("PassMethod", "Matrix66Pass")
         kwargs.setdefault("M66", m66)
         kwargs.setdefault("M66Rad", m66rad)

--- a/pyat/at/lattice/lattice_object.py
+++ b/pyat/at/lattice/lattice_object.py
@@ -64,6 +64,7 @@ _DEFAULT_PASS = {
         ("energyloss_pass", elt.EnergyLoss, "auto"),
         ("simplequantdiff_pass", elt.SimpleQuantDiff, "auto"),
         ("simpleradiation_pass", elt.SimpleRadiation, "auto"),
+        ("m66_pass", elt.M66, "auto"),
     ),
     True: (
         ("cavity_pass", elt.RFCavity, "auto"),
@@ -78,6 +79,7 @@ _DEFAULT_PASS = {
         ("energyloss_pass", elt.EnergyLoss, "auto"),
         ("simplequantdiff_pass", elt.SimpleQuantDiff, "auto"),
         ("simpleradiation_pass", elt.SimpleRadiation, "auto"),
+        ("m66_pass", elt.M66, "auto"),
     ),
 }
 

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -109,10 +109,6 @@ def find_m66(ring: Lattice, refpts: Refpts = None,
     :py:func:`find_m66` finds the 6x6 transfer matrix of an accelerator
     lattice by differentiation of trajectories near the closed orbit.
 
-    :py:func:`find_m66` uses :py:func:`.find_orbit6` to search for the closed
-    orbit in 6-D. In order for this to work the ring **MUST** have a ``Cavity``
-    element
-
     Parameters:
         ring:           Lattice description
         refpts:         Observation points

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -206,9 +206,9 @@ def find_elem_m66(elem: Element, orbit: Orbit = None, **kwargs):
 
 
 def gen_m66_elem(ring: Lattice, 
-                 ringrad: Lattice = None,
                  o6b: Orbit = None,
                  o6e: Orbit = None,
+                 ringrad: Lattice = None,
                  o6brad: Orbit = None,
                  o6erad: Orbit = None,
                  **kwargs) -> M66:

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -205,32 +205,46 @@ def find_elem_m66(elem: Element, orbit: Orbit = None, **kwargs):
     return m66
 
 
-def gen_m66_elem(ring: Lattice,
-                 o4b: Orbit,
-                 o4e: Orbit) -> M66:
-    """Converts a ring to a linear 6x6 matrix
+def gen_m66_elem(ring: Lattice, 
+                 ringrad: Lattice = None,
+                 o6b: Orbit = None,
+                 o6e: Orbit = None,
+                 o6brad: Orbit = None,
+                 o6erad: Orbit = None,
+                 **kwargs) -> M66:
+    """Converts a ring to a linear 6x6 matrix. This element handles 2 passmethods
+    ``Matrix66Pass`` and ``Matrix66RadPass``, that can be activated within a lattice
+    using :py:func:`enable_6()` or :py:func:`disable_6d`.
+    This provides flexibility to turn ON and OFF the 6D motion or simply the radiation
+    damping, depending on the configuration of the rings provided as input.
 
     Parameters:
-        ring:       Lattice description
-        o4b:
-        o4e:
+        ring:       Lattice description. Is used by ``Matrix66Pass``
+        ringrad:    Optional lattice with radiations. Is used by ``Matrix66RadPass``
+        o6b:        entrace orbit without radiations, use by ``Matrix66Pass``
+        o6e:        exit orbit without radiations, use by ``Matrix66Pass``
+        o6b:        entrace orbit with radiations, use by ``Matrix66RadPass``
+        o6e:        exit orbit with radiations, use by ``Matrix66RadPass``
 
     Returns:
-        m66:        6x6 transfer matrix
+        m66:        :py:obj:`M66` object
     """
-
-    dipoles = ring[Dipole]
-    theta = numpy.array([elem.BendingAngle for elem in dipoles])
-    lendp = numpy.array([elem.Length for elem in dipoles])
-    s_pos = ring.get_s_pos()
-    s = numpy.diff(numpy.array([s_pos[0], s_pos[-1]]))[0]
-    i2 = numpy.sum(numpy.abs(theta * theta / lendp))
-    m66_mat, _ = find_m66(ring, [], orbit=o4b)
-    if ring.radiation is False:
-        m66_mat = symplectify(m66_mat)  # remove for damping
-    lin_elem = M66('Linear', m66_mat, T1=-o4b, T2=o4e, Length=s, I2=i2)
+    length = ring.circumference
+    kwargs.update({"Length": length})
+    m66_mat, _ = find_m66(ring, [], orbit=o6b)
+    m66_mat_rad, _ = find_m66(ringrad, [], orbit=o6brad)
+    kwargs.update({"M66Rad": m66_mat_rad})
+    if o6b is not None:
+        kwargs.update({"T1": -o6b})
+    if o6e is not None:
+        kwargs.update({"T2": o6e})
+    if o6brad is not None:
+        kwargs.update({"T1rad": -o6brad})
+    if o6erad is not None:
+        kwargs.update({"T2rad": o6erad})  
+    lin_elem = M66('Linear', m66_mat, **kwargs)
     return lin_elem
-
+       
 
 Lattice.find_m44 = find_m44
 Lattice.find_m66 = find_m66

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -229,7 +229,8 @@ def gen_m66_elem(ring: Lattice,
     Returns:
         m66:        :py:obj:`M66` object
     """
-    length = ring.circumference
+    s_pos = ring.get_s_pos()
+    length = numpy.diff(numpy.array([s_pos[0], s_pos[-1]]))[0]
     kwargs.update({"Length": length})
     m66_mat, _ = find_m66(ring, [], orbit=o6b)
     if ringrad is not None:

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -234,7 +234,7 @@ def gen_m66_elem(ring: Lattice,
     m66_mat, _ = find_m66(ring, [], orbit=o6b)
     if ringrad is not None:
         m66_mat_rad, _ = find_m66(ringrad, [], orbit=o6brad)
-    kwargs.update({"M66Rad": m66_mat_rad})
+        kwargs.update({"M66Rad": m66_mat_rad})
     if o6b is not None:
         kwargs.update({"T1": -o6b})
     if o6e is not None:

--- a/pyat/at/physics/matrix.py
+++ b/pyat/at/physics/matrix.py
@@ -232,7 +232,8 @@ def gen_m66_elem(ring: Lattice,
     length = ring.circumference
     kwargs.update({"Length": length})
     m66_mat, _ = find_m66(ring, [], orbit=o6b)
-    m66_mat_rad, _ = find_m66(ringrad, [], orbit=o6brad)
+    if ringrad is not None:
+        m66_mat_rad, _ = find_m66(ringrad, [], orbit=o6brad)
     kwargs.update({"M66Rad": m66_mat_rad})
     if o6b is not None:
         kwargs.update({"T1": -o6b})

--- a/pyat/test_matlab/test_cmp_physics.py
+++ b/pyat/test_matlab/test_cmp_physics.py
@@ -119,7 +119,6 @@ def test_fastring(engine, request, lattices):
     for r, rml in zip([ring, ringrad], [ring_ml, ringrad_ml]):
         assert_close(r[0].Frequency, rml[1]["Frequency"], rtol=1.0e-20)
         assert_close(r[0].Voltage, rml[1]["Voltage"], rtol=1.0e-20)
-        assert_close(r[1].I2, rml[2]["I2"], rtol=1.0e-20)
         assert_close(r[1].Length, rml[2]["Length"], rtol=1.0e-20)
         assert_close(r[1].M66, rml[2]["M66"], atol=1.0e-7)
         assert_close(r[1].T1, np.squeeze(rml[2]["T1"]), rtol=1.0e-8, atol=1.0e-11)


### PR DESCRIPTION
This PR adds a Matrix66RadPass passmethod to allow switching radition on or off for an M66 element using the standard enable_6d/disable_6d function.

This is the first step to a complete refurbishment of the fastring module.

This is for the comment a proposal, any comments or suggestions are more than welcome.