### PR TITLE
feat: off-momentum RDT

### DIFF
--- a/atmat/atphysics/NonLinearDynamics/computeRDTfluctuation.m
+++ b/atmat/atphysics/NonLinearDynamics/computeRDTfluctuation.m
@@ -25,17 +25,21 @@ function [RDT,buildup_fluctuation,natural_fluctuation] = computeRDTfluctuation(r
 %       absolute values of one-period RDTs observed at different
 %       longitudinal starting position.
 %       same as s_dependent_driving_terms in ELEGANT.
-%   
+%
+%  Bingfeng WEI, NSRL, USTC
+%
 %  REFERENCES
 %    [1] Johan Bengtsson, SLS Note 09/97, (1997)
 %    [2] S. C. Leemann, A. Streun, Phys. Rev. ST Accel. Beams 14, 030701 (2011)
 %    [3] A. Franchi, L. Farvacque, F. Ewald, G. Le Bec, and K. B. Scheidt, Phys. Rev. ST Accel. Beams 17, 074001 (2014)
 %    [4] B. Wei, Z. Bai, J. Tan, L. Wang, and G. Feng, Phys. Rev. Accel. Beams 26, 084001 (2023)
+%    [5] B. Wei, Z. Bai, G. Feng, A. Loulergue, L. S. Nadolski and R. Nagaoka, Phys. Rev. Accel. Beams 27, 104001 (2024)
 %
 
 % Validates the input arguements.
 [nslices,varargs]=getoption(varargin,'nslices',4);
 [nperiods,varargs]=getoption(varargs,'nperiods',1);
+[dpp,varargs]=getoption(varargs,'dpp',0.00);
 if ~ isempty(varargs)
     throw(MException('RDTFluctuation:parameterError', ...
         ['Unsupported parameter: ' varargs{1}]))
@@ -65,7 +69,7 @@ end
 % same as computeRDT().
 indDQSO=findcells(splitring,'Class','Bend','Quadrupole','Sextupole','Octupole','Multipole');
 
-[~,AVEBETA,AVEMU,AVEDISP,nu,~]=atavedata(splitring,0,1:length(splitring));
+[LINDATA,AVEBETA,AVEMU,AVEDISP,nu,~]=atavedata(splitring,dpp,1:length(splitring));
 
 s=[0,findspos(splitring,indDQSO)];
 betax=AVEBETA(indDQSO,1);
@@ -78,12 +82,28 @@ if any(a2L)
     throw(MException('RDTFluctuation:Unfinished', ...
         'The coupling case cannot be handled in the current version.'))
 end
-b2L=getcellstruct(splitring,'PolynomB',indDQSO,1,2).*getcellstruct(splitring,'Length',indDQSO);
-b2L(isnan(b2L))=0;
-b3L=getcellstruct(splitring,'PolynomB',indDQSO,1,3).*getcellstruct(splitring,'Length',indDQSO);
-b3L(isnan(b3L))=0;
 b4L=getcellstruct(splitring,'PolynomB',indDQSO,1,4).*getcellstruct(splitring,'Length',indDQSO);
 b4L(isnan(b4L))=0;
+b3L=getcellstruct(splitring,'PolynomB',indDQSO,1,3).*getcellstruct(splitring,'Length',indDQSO);
+b3L(isnan(b3L))=0;
+b2L=getcellstruct(splitring,'PolynomB',indDQSO,1,2).*getcellstruct(splitring,'Length',indDQSO);
+b2L(isnan(b2L))=0;
+
+if dpp ~= 0
+    closed_orbit = cat(2,LINDATA.ClosedOrbit);
+
+    if any(closed_orbit(3,:))
+        throw(MException('RDTFluctuation:Unfinished', ...
+            'The coupling case cannot be handled in the current version.'))
+    end
+
+    b2L = (b2L + b3L .* closed_orbit(1,indDQSO)' .* 2 + b4L .* closed_orbit(1,indDQSO)' .* closed_orbit(1,indDQSO)' .* 3);
+    b3L = (b3L + b4L .* closed_orbit(1,indDQSO)' .* 3);
+    b4L = b4L;
+
+end
+
+
 nData=length(indDQSO) + 1;
 
 % calculate the build-up fluctuation of RDTs.
@@ -234,6 +254,16 @@ else
             'h31000', buildup_fluctuation.h31000(end), 'h40000', buildup_fluctuation.h40000(end), 'h20110', buildup_fluctuation.h20110(end), 'h11200', buildup_fluctuation.h11200(end), ...
             'h20020', buildup_fluctuation.h20020(end), 'h20200', buildup_fluctuation.h20200(end), 'h00310', buildup_fluctuation.h00310(end), 'h00400', buildup_fluctuation.h00400(end),...
             'dnux_dJx', -4*real(buildup_fluctuation.h22000(end))/pi, 'dnux_dJy', -2*real(buildup_fluctuation.h11110(end))/pi, 'dnuy_dJy',-4*real(buildup_fluctuation.h00220(end))/pi);
+end
+
+if dpp ~= 0
+    % remove misleading information. 
+    % the off-momentum RDTs directly describe the nonlinear dynamics for
+    % the given dpp case. So we don't use the chromatic terms which
+    % describe the deviation from the on-momentum case.
+    natural_fluctuation = rmfield(natural_fluctuation, {'f20001', 'f00201', 'f10002'});
+    RDT = rmfield(RDT, {'h20001', 'h00201', 'h10002'});
+    buildup_fluctuation = rmfield(buildup_fluctuation, {'h20001', 'h00201', 'h10002'});
 end
 
     function newelems=splitelem(elem)

--- a/atmat/atphysics/NonLinearDynamics/computeRDTfluctuation.m
+++ b/atmat/atphysics/NonLinearDynamics/computeRDTfluctuation.m
@@ -39,7 +39,7 @@ function [RDT,buildup_fluctuation,natural_fluctuation] = computeRDTfluctuation(r
 % Validates the input arguements.
 [nslices,varargs]=getoption(varargin,'nslices',4);
 [nperiods,varargs]=getoption(varargs,'nperiods',1);
-[dpp,varargs]=getoption(varargs,'dpp',0.00);
+[dp,varargs]=getoption(varargs,'dp',0.00);
 if ~ isempty(varargs)
     throw(MException('RDTFluctuation:parameterError', ...
         ['Unsupported parameter: ' varargs{1}]))
@@ -69,7 +69,7 @@ end
 % same as computeRDT().
 indDQSO=findcells(splitring,'Class','Bend','Quadrupole','Sextupole','Octupole','Multipole');
 
-[LINDATA,AVEBETA,AVEMU,AVEDISP,nu,~]=atavedata(splitring,dpp,1:length(splitring));
+[LINDATA,AVEBETA,AVEMU,AVEDISP,nu,~]=atavedata(splitring,dp,1:length(splitring));
 
 s=[0,findspos(splitring,indDQSO)];
 betax=AVEBETA(indDQSO,1);
@@ -89,7 +89,7 @@ b3L(isnan(b3L))=0;
 b2L=getcellstruct(splitring,'PolynomB',indDQSO,1,2).*getcellstruct(splitring,'Length',indDQSO);
 b2L(isnan(b2L))=0;
 
-if dpp ~= 0
+if dp ~= 0
     closed_orbit = cat(2,LINDATA.ClosedOrbit);
 
     if any(closed_orbit(3,:))
@@ -256,10 +256,10 @@ else
             'dnux_dJx', -4*real(buildup_fluctuation.h22000(end))/pi, 'dnux_dJy', -2*real(buildup_fluctuation.h11110(end))/pi, 'dnuy_dJy',-4*real(buildup_fluctuation.h00220(end))/pi);
 end
 
-if dpp ~= 0
+if dp ~= 0
     % remove misleading information. 
     % the off-momentum RDTs directly describe the nonlinear dynamics for
-    % the given dpp case. So we don't use the chromatic terms which
+    % the given dp case. So we don't use the chromatic terms which
     % describe the deviation from the on-momentum case.
     natural_fluctuation = rmfield(natural_fluctuation, {'f20001', 'f00201', 'f10002'});
     RDT = rmfield(RDT, {'h20001', 'h00201', 'h10002'});


### PR DESCRIPTION
This PR implements off-momentum RDT calculation, which can be used to directly analyze the nonlinear dynamics for a given off-momentum case. 
Validation is performed by comparing ADTS and tracked tune shifts.
The following results are produced using the test script [test_off_momentum_tuneshifts.m](https://github.com/wei0852/ATRDTfluctuation/blob/main/test_off_momentum_tuneshifts.m)


<img width="1258" height="855" alt="off_momentum_ADTS" src="https://github.com/user-attachments/assets/fef3954b-10dd-45da-aa96-d94a2e34d7c3" />

>
>            ***************     dp/p = -6%         ***********************
>   tracked ADTS: dnux/dJx=291439.8309, dnuy/dJx=82225.2794, dnux/dJy=82355.4638, dnuy/dJy=-262227.5636
>   off-momentum ADTS: dnux/dJx=297021.2381,    dnux/dJy=84154.8008,       dnuy/dJy=-260910.2673
>                     ***************     dp/p = -5%         ***********************
>   tracked ADTS: dnux/dJx=238109.4868, dnuy/dJx=64495.3823, dnux/dJy=64601.9309, dnuy/dJy=-243325.1448
>   off-momentum ADTS: dnux/dJx=243346.8947,    dnux/dJy=66521.4485,       dnuy/dJy=-242008.7421
>                     ***************     dp/p = -4%         ***********************
>   tracked ADTS: dnux/dJx=185066.1173, dnuy/dJx=44059.0946, dnux/dJy=44150.0413, dnuy/dJy=-228730.4941
>   off-momentum ADTS: dnux/dJx=189876.3387,    dnux/dJy=46131.347,       dnuy/dJy=-227476.5268
>                     ***************     dp/p = -3%         ***********************
>   tracked ADTS: dnux/dJx=132290.3446, dnuy/dJx=21172.701, dnux/dJy=21218.0419, dnuy/dJy=-216553.2475
>   off-momentum ADTS: dnux/dJx=136804.773,    dnux/dJy=23227.315,       dnuy/dJy=-215398.231
>                     ***************     dp/p = -2%         ***********************
>   tracked ADTS: dnux/dJx=78966.7311, dnuy/dJx=-3364.7958, dnux/dJy=-3347.108, dnuy/dJy=-205516.98
>   off-momentum ADTS: dnux/dJx=83358.4706,    dnux/dJy=-1368.8922,       dnuy/dJy=-204466.1605
>                     ***************     dp/p = -1%         ***********************
>   tracked ADTS: dnux/dJx=23033.1612, dnuy/dJx=-28570.0934, dnux/dJy=-28574.3279, dnuy/dJy=-194911.0855
>   off-momentum ADTS: dnux/dJx=27456.5428,    dnux/dJy=-26671.7088,       dnuy/dJy=-193945.5812
>                     ***************     dp/p = 0%         ***********************
>   tracked ADTS: dnux/dJx=-39084.6511, dnuy/dJx=-53667.5615, dnux/dJy=-53706.2265, dnuy/dJy=-184499.9204
>   off-momentum ADTS: dnux/dJx=-34531.1666,    dnux/dJy=-51877.4417,       dnuy/dJy=-183575.8077
>                     ***************     dp/p = 1%         ***********************
>   tracked ADTS: dnux/dJx=-113177.2278, dnuy/dJx=-78359.7659, dnux/dJy=-78436.7779, dnuy/dJy=-174405.1507
>   off-momentum ADTS: dnux/dJx=-108423.074,    dnux/dJy=-76662.3053,       dnuy/dJy=-173433.9391
>                     ***************     dp/p = 2%         ***********************
>   tracked ADTS: dnux/dJx=-209611.566, dnuy/dJx=-103124.805, dnux/dJy=-103265.3033, dnuy/dJy=-164984.5582
>   off-momentum ADTS: dnux/dJx=-204512.1993,    dnux/dJy=-101528.1272,       dnuy/dJy=-163805.2629
>                     ***************     dp/p = 3%         ***********************
>   tracked ADTS: dnux/dJx=-350606.2737, dnuy/dJx=-130026.9447, dnux/dJy=-130281.0354, dnuy/dJy=-156753.6808
>   off-momentum ADTS: dnux/dJx=-344691.4587,    dnux/dJy=-128386.2957,       dnuy/dJy=-155097.7186
>                     ***************     dp/p = 4%         ***********************
>   tracked ADTS: dnux/dJx=-594677.099, dnuy/dJx=-164984.3599, dnux/dJy=-165268.9472, dnuy/dJy=-150407.3212
>   off-momentum ADTS: dnux/dJx=-585205.8096,    dnux/dJy=-162189.2792,       dnuy/dJy=-147924.2418