### PR TITLE
Add atoctupole to Matlab version

### DIFF
--- a/atmat/lattice/element_creation/atoctupole.m
+++ b/atmat/lattice/element_creation/atoctupole.m
@@ -1,44 +1,43 @@
 function elem=atoctupole(fname,varargin)
-%ATOCTUPOLE Creates an octupole element with class 'Octupole'
+%ATOCTUPOLE Creates an octupole element
 %
-%  ATOCTUPOLE(FAMNAME,LENGTH,S,PASSMETHOD)
+%  ATOCTUPOLE(FAMNAME,LENGTH,POLYNOMA,POLYNOMB,PASSMETHOD)
 %	
 %  INPUTS
-%	 1. FNAME        	family name 
-%    2. LENGTH			length [m]
-%    3. O				strength [m-3]
-%    4. PASSMETHOD     tracking function, defaults to 'StrMPoleSymplectic4Pass'
+%  1. FNAME      - Family name 
+%  2. LENGTH     - Length[m]
+%  3. POLYNOMA   - Skew [dipole quad sext oct];	 
+%  4. POLYNOMB   - Normal [dipole quad sext oct]; 
+%  5. PASSMETHOD - Tracking function. Defaults to 'StrMPoleSymplectic4Pass'
 %
 %  OPTIONS (order does not matter)
-%    R1				6 x 6 rotation matrix at the entrance
-%	 R2        		6 x 6 rotation matrix at the entrance
-%	 T1				6 x 1 translation at entrance 
-%	 T2				6 x 1 translation at exit
-%	 NumIntSteps    Number of integration steps
-%	 MaxOrder       Max Order for multipole (1 up to quadrupole)
+%    R1			 -	6 x 6 rotation matrix at the entrance
+%	 R2        	 -	6 x 6 rotation matrix at the entrance
+%	 T1			 - 	6 x 1 translation at entrance 
+%	 T2			 -	6 x 1 translation at exit
+%	 NumIntSteps -   Number of integration steps
+%	 MaxOrder    -    Max Order for multipole (1 up to quadrupole)
 %
 %  OUTPUTS
-%      1. ELEM - Structure with the AT element
+%  1. ELEM - Structure with the AT element
 %
 %  EXAMPLES
-%    ATOCTUPOLE(FAMNAME,LENGTH,O,PASSMETHOD,'FIELDNAME1',VALUE1,...)
-%    Each pair {'FIELDNAME',VALUE} is added to the element
+%    1. atoctupole(famname,length,polynoma,polynomb,passmethod,'fieldname1',value1,...)
+%   each pair {'fieldname',value} is added to the element
 %
-%  See also: atdrift, atquadrupole, atsecxtupole, atmultipole, atsbend,
-%            atrbend,atskewquad, atmultipole, atthinmultipole, atmarker, 
-%            atcorrector
+%  See also atdrift, atquadrupole, atsextupole, atsbend, atrbend, atskewquad,
+%          atthinmultipole, atmarker, atcorrector
 
 % Input parser for option
-[rsrc,L,O,method] = decodeatargs({0,[],'StrMPoleSymplectic4Pass'},varargin);
-[L,rsrc]          = getoption(rsrc,'Length',L);
-[method,rsrc]     = getoption(rsrc,'PassMethod',method);
-[PolynomB,rsrc]   = getoption(rsrc,'PolynomB',[0 0 0 0]);
-[cl,rsrc]         = getoption(rsrc,'Class','Octupole');
+[rsrc,L,PolynomA,PolynomB,method] = decodeatargs({0,0,0,'StrMPoleSymplectic4Pass'},varargin);
+[L,rsrc]                          = getoption(rsrc,'Length',L);
+[PolynomA,rsrc]                   = getoption(rsrc,'PolynomA',PolynomA);
+[PolynomB,rsrc]                   = getoption(rsrc,'PolynomB',PolynomB);
+[method,rsrc]                     = getoption(rsrc,'PassMethod',method);
+[cl,rsrc]                         = getoption(rsrc,'Class','Octupole');
 
-% Octupole setting if not specified explicitly
-if ~isempty(O), PolynomB(4)=O; end
 
 % Build the element
 elem=atbaselem(fname,method,'Class',cl,'Length',L,...
-    'PolynomB','DefaultMaxOrder',3,PolynomB,rsrc{:});
+    'PolynomA',PolynomA,'PolynomB',PolynomB,'DefaultMaxOrder',3,rsrc{:});
 end

--- a/atmat/lattice/element_creation/atoctupole.m
+++ b/atmat/lattice/element_creation/atoctupole.m
@@ -1,0 +1,44 @@
+function elem=atoctupole(fname,varargin)
+%ATOCTUPOLE Creates an octupole element with class 'Octupole'
+%
+%  ATOCTUPOLE(FAMNAME,LENGTH,S,PASSMETHOD)
+%	
+%  INPUTS
+%	 1. FNAME        	family name 
+%    2. LENGTH			length [m]
+%    3. O				strength [m-3]
+%    4. PASSMETHOD     tracking function, defaults to 'StrMPoleSymplectic4Pass'
+%
+%  OPTIONS (order does not matter)
+%    R1				6 x 6 rotation matrix at the entrance
+%	 R2        		6 x 6 rotation matrix at the entrance
+%	 T1				6 x 1 translation at entrance 
+%	 T2				6 x 1 translation at exit
+%	 NumIntSteps    Number of integration steps
+%	 MaxOrder       Max Order for multipole (1 up to quadrupole)
+%
+%  OUTPUTS
+%      1. ELEM - Structure with the AT element
+%
+%  EXAMPLES
+%    ATOCTUPOLE(FAMNAME,LENGTH,O,PASSMETHOD,'FIELDNAME1',VALUE1,...)
+%    Each pair {'FIELDNAME',VALUE} is added to the element
+%
+%  See also: atdrift, atquadrupole, atsecxtupole, atmultipole, atsbend,
+%            atrbend,atskewquad, atmultipole, atthinmultipole, atmarker, 
+%            atcorrector
+
+% Input parser for option
+[rsrc,L,O,method] = decodeatargs({0,[],'StrMPoleSymplectic4Pass'},varargin);
+[L,rsrc]          = getoption(rsrc,'Length',L);
+[method,rsrc]     = getoption(rsrc,'PassMethod',method);
+[PolynomB,rsrc]   = getoption(rsrc,'PolynomB',[0 0 0 0]);
+[cl,rsrc]         = getoption(rsrc,'Class','Octupole');
+
+% Octupole setting if not specified explicitly
+if ~isempty(O), PolynomB(4)=O; end
+
+% Build the element
+elem=atbaselem(fname,method,'Class',cl,'Length',L,...
+    'PolynomB','DefaultMaxOrder',3,PolynomB,rsrc{:});
+end


### PR DESCRIPTION
When saving a pyAT lattice to a m-file using `at.save_m` it can currently not be loaded in the Matlab version if the lattice contains octupoles since there is no atoctupole element in the Matlab version.

This is the output of `at.save_m`:

```
atoctupole('OMK1RP', 0.1, [0. 0. 0. 0.], [ 0.   0.   0. -50.]);
```

I have added an atoctupole element to the Matlab version based on the same syntax as atmultipole.