### PR TITLE
fix(xsuite): remove duplicate keyword args in Corrector.from_at

### DIFF
--- a/pyat/at/load/xsuite.py
+++ b/pyat/at/load/xsuite.py
@@ -848,6 +848,13 @@ class Corrector(_XsFactory):
         if (length := atparams["Length"]) != 0.0:
             pola /= length
             polb /= length
+
+      ####################################
+        atparams.pop("PolynomA", None)
+        atparams.pop("PolynomB", None)
+        atparams.pop("MaxOrder", None)
+      #####################################
+      
         return Multipole.from_at(PolynomA=pola, PolynomB=polb, MaxOrder=0, **atparams)
 
 


### PR DESCRIPTION
atelem.to_file() serializes all element attributes including PolynomA, PolynomB and MaxOrder into atparams. These were then passed twice to Multipole.from_at() — once explicitly and once via **atparams — causing a TypeError.

Fix by popping PolynomA, PolynomB and MaxOrder from atparams before the call, so only the values recomputed from KickAngle are used.