### PR TITLE
Add atError when kz=0 in gwig.c

### DIFF
--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -76,7 +76,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hkz[i] = (*tmppr) * kw;
         if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
             atError("GWig error: By harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i); check_error();
+            "; kz must be larger than 0.", i);
         }
         tmppr++;
         Wig->Htz[i] = *tmppr;
@@ -94,7 +94,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vkz[i] = (*tmppr) * kw;
         if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
             atError("GWig error: Bx harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i); check_error();
+            "; kz must be larger than 0.", i);
         }
         tmppr++;
         Wig->Vtz[i] = *tmppr;

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -74,6 +74,10 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Hkz[i] = (*tmppr) * kw;
+        if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
+            atError("GWig error: By harmonic %d has kz=0 "
+            "; kz must be larger than 0.", i); check_error();
+        }
         tmppr++;
         Wig->Htz[i] = *tmppr;
         tmppr++;
@@ -88,6 +92,10 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Vkz[i] = (*tmppr) * kw;
+        if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
+            atError("GWig error: Bx harmonic %d has kz=0 "
+            "; kz must be larger than 0.", i); check_error();
+        }
         tmppr++;
         Wig->Vtz[i] = *tmppr;
         tmppr++;


### PR DESCRIPTION
I added some safeguards in the gwig.c integrator following the discussion in: https://github.com/atcollab/at/issues/1075
It raises an atError whenever a wiggler with kz=0 (in By or Bx) is called.

I am not sure whether I should call check_error() after atError(). What would you recommend?