### PR TITLE
Fix get momentum acceptance

### DIFF
--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -76,7 +76,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hkz[i] = (*tmppr) * kw;
         if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
             atError("GWig error: By harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i); check_error();
+            "; kz must be larger than 0.", i);
         }
         tmppr++;
         Wig->Htz[i] = *tmppr;
@@ -94,7 +94,7 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vkz[i] = (*tmppr) * kw;
         if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
             atError("GWig error: Bx harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i); check_error();
+            "; kz must be larger than 0.", i);
         }
         tmppr++;
         Wig->Vtz[i] = *tmppr;

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -74,10 +74,6 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Hkz[i] = (*tmppr) * kw;
-        if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
-            atError("GWig error: By harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i);
-        }
         tmppr++;
         Wig->Htz[i] = *tmppr;
         tmppr++;
@@ -92,10 +88,6 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Vkz[i] = (*tmppr) * kw;
-        if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
-            atError("GWig error: Bx harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i);
-        }
         tmppr++;
         Wig->Vtz[i] = *tmppr;
         tmppr++;

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -74,6 +74,10 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Hkz[i] = (*tmppr) * kw;
+        if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
+            atError("GWig error: By harmonic %d has kz=0 "
+            "; kz must be larger than 0.", i); check_error();
+        }
         tmppr++;
         Wig->Htz[i] = *tmppr;
         tmppr++;
@@ -88,6 +92,10 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Vkz[i] = (*tmppr) * kw;
+        if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
+            atError("GWig error: Bx harmonic %d has kz=0 "
+            "; kz must be larger than 0.", i); check_error();
+        }
         tmppr++;
         Wig->Vtz[i] = *tmppr;
         tmppr++;

--- a/pyat/at/acceptance/acceptance.py
+++ b/pyat/at/acceptance/acceptance.py
@@ -515,7 +515,7 @@ def get_momentum_acceptance(
          do most of the work in a single function call and allows for
          full parallelization.
     """
-    return get_1d_acceptance(ring, "dp", resolution, amplitude, *args, **kwargs)
+    return get_1d_acceptance(ring, ["dp"], resolution, amplitude, *args, **kwargs)
 
 
 Lattice.get_acceptance = get_acceptance


### PR DESCRIPTION
I added some square brackets around 'dp' in `get_momentum_acceptance` to solve the bug reported in: https://github.com/atcollab/at/issues/1084
Now I can use `get_momentum_acceptance` and `get_lifetime` as before.