### PR TITLE
Require Mode and set ModeName in atvariablethinmultipole

### DIFF
--- a/atmat/lattice/at2str.m
+++ b/atmat/lattice/at2str.m
@@ -119,6 +119,12 @@ switch atclass
                             'xtable', ...
                             'ytable' ...
                             });
+    case 'VariableThinMultipole'
+        create=@atvariablethinmultipole;
+        [options,args]=doptions(elem,create,{'Mode'});
+        if isfield(options,'Energy')
+            options=rmfield(options,'Energy');
+        end
     otherwise %'Marker'
         create=@atmarker;
         [options,args]=doptions(elem,create);

--- a/atmat/lattice/at2str.m
+++ b/atmat/lattice/at2str.m
@@ -121,7 +121,7 @@ switch atclass
                             });
     case 'VariableThinMultipole'
         create=@atvariablethinmultipole;
-        [options,args]=doptions(elem,create,{'Mode'});
+        [options,args]=doptions(elem,create);
         if isfield(options,'Energy')
             options=rmfield(options,'Energy');
         end

--- a/atmat/lattice/atguessclass.m
+++ b/atmat/lattice/atguessclass.m
@@ -8,7 +8,7 @@ function atclass = atguessclass(elem, varargin)
 %
 %  NOTES
 %  1. atclass=atguessclass(atelem,'useclass')
-%  By default, ATGUESSCLASS will default "useless" elements (PolynopmB==0)
+%  By default, ATGUESSCLASS will default "useless" elements (PolynomB==0)
 %  to 'Drift' or 'Marker', depending on 'Length'. When specifying
 %  'UseClass', it it will preserve the 'Class' field for those elements.
 %
@@ -30,6 +30,8 @@ elseif isfield(elem,'Periodicity')
     atclass='RingParam';
 elseif isfield(elem,'Limits')
     atclass='Aperture';
+elseif isfield(elem,'Mode')
+    atclass='VariableThinMultipole';
 elseif isfield(elem,'PolynomB')
     if useclass && isfield(elem,'Class')
         atclass=elem.Class;

--- a/atmat/lattice/element_creation/Contents.m
+++ b/atmat/lattice/element_creation/Contents.m
@@ -29,7 +29,7 @@
 %   atskewquad               - Creates a skew quadrupole element with Class 'Multipole'
 %   atsolenoid               - Creates a new solenoid element with Class 'Solenoid'
 %   atthinmultipole          - Creates a thin multipole element
-%   atvariablemultipole      - Creates a variable thin multipole element
+%   atvariablethinmultipole  - Creates a variable thin multipole element
 %   atwiggler                - Creates a wiggler
 %   
 %   ELEMENT_CREATION/PRIVATE

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -18,7 +18,7 @@ function elem=atvariablethinmultipole(fname,modename,varargin)
 %    FREQUENCYB     Frequency of SINE excitation for PolynomB
 %    PHASEA         Phase of SINE excitation for PolynomA
 %    PHASEB         Phase of SINE excitation for PolynomB
-%	   MAXORDER       Order of the multipole for a scalar amplitude
+%    MAXORDER       Order of the multipole for a scalar amplitude
 %    SEED           Input seed for the random number generator
 %    FUNCA          ARBITRARY excitation turn-by-turn kick list for PolynomA
 %    FUNCB          ARBITRARY excitation turn-by-turn kick list for PolynomB

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -1,12 +1,12 @@
-function elem=atvariablethinmultipole(fname,mode,varargin)
+function elem=atvariablethinmultipole(fname,modename,varargin)
 %ATVARIABLETHINMULTIPOLE Creates a variable thin multipole element
 %
-%  ATVARIABLETHINMULTIPOLE(FAMNAME,MODE,[KEY,VALUE]...)
-%  ATVARIABLETHINMULTIPOLE(FAMNAME,MODE,PASSMETHOD,[KEY,VALUE]...)
+%  ATVARIABLETHINMULTIPOLE(FAMNAME,MODENAME,[KEY,VALUE]...)
+%  ATVARIABLETHINMULTIPOLE(FAMNAME,MODENAME,PASSMETHOD,[KEY,VALUE]...)
 %
 %  INPUTS
 %    FNAME          Family name 
-%    MODE           Excitation mode: 'SINE', 'WHITENOISE' or 'ARBITRARY'.
+%    MODENAME       'SINE', 'WHITENOISE' or 'ARBITRARY'.
 %
 %  OPTIONS (order does not matter)
 %    PASSMETHOD     Tracking function. Default: 'VariableThinMPolePass'
@@ -18,7 +18,7 @@ function elem=atvariablethinmultipole(fname,mode,varargin)
 %    FREQUENCYB     Frequency of SINE excitation for PolynomB
 %    PHASEA         Phase of SINE excitation for PolynomA
 %    PHASEB         Phase of SINE excitation for PolynomB
-%	 MAXORDER       Order of the multipole for a scalar amplitude
+%	   MAXORDER       Order of the multipole for a scalar amplitude
 %    SEED           Input seed for the random number generator
 %    FUNCA          ARBITRARY excitation turn-by-turn kick list for PolynomA
 %    FUNCB          ARBITRARY excitation turn-by-turn kick list for PolynomB
@@ -35,7 +35,7 @@ function elem=atvariablethinmultipole(fname,mode,varargin)
 %
 %  NOTES
 %    1. For all excitation modes at least one amplitude (A or B) is
-%    required. The default excitation is SINE
+%    required.
 %    2. For SINE excitation modes the FREQUENCY corresponding to the input
 %    AMPLITUDE is required
 %    3. For ARBITRARY excitation modes the FUNC corresponding to the input
@@ -50,11 +50,11 @@ function elem=atvariablethinmultipole(fname,mode,varargin)
 % >> atvariablethinmultipole('ACM','WHITENOISE','AmplitudeB',1.e-4);
 
 % Input parser for option
-if ~any(strcmpi(mode,{'SINE','WHITENOISE','ARBITRARY'}))
-  error("Mode should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
+if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
+  error("Mode name should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end
 [method,rsrc]   = getargs(varargin,'VariableThinMPolePass', ...
-                    'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
+                  'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
 [method,rsrc]   = getoption(rsrc,'PassMethod',method);
 [cl,rsrc]       = getoption(rsrc,'Class','VariableThinMultipole');
 [maxorder,rsrc] = getoption(rsrc,'MaxOrder',0);
@@ -64,15 +64,17 @@ rsrc.MaxOrder   = maxorder;
 if ~any(isfield(rsrc,{'AmplitudeA','AmplitudeB'}))
     error("Please provide at least one amplitude for A or B")
 end
-rsrc = setparams(rsrc,mode,'A');
-rsrc = setparams(rsrc,mode,'B');
+rsrc = setparams(rsrc,modename,'A');
+rsrc = setparams(rsrc,modename,'B');
 rsrc = setmaxorder(rsrc);
+
+m=struct('SINE',0,'WHITENOISE',1,'ARBITRARY',2);
 
 % Build the element
 % rsrc =namedargs2cell(rsrc);   % introduced in R2019b
 rsrc=reshape([fieldnames(rsrc) struct2cell(rsrc)]',1,[]);
-elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',mode,...
-               'PolynomA',[],'PolynomB',[],rsrc{:});
+elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
+               'ModeName',modename,'PolynomA',[],'PolynomB',[],rsrc{:});
 
 
     function setsine(rsrc, ab)

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -1,4 +1,4 @@
-function elem=atvariablethinmultipole(fname,varargin)
+function elem=atvariablethinmultipole(fname,mode,varargin)
 %ATVARIABLETHINMULTIPOLE Creates a variable thin multipole element
 %
 %  ATVARIABLETHINMULTIPOLE(FAMNAME,MODE,PASSMETHOD,[KEY,VALUE]...)
@@ -50,9 +50,10 @@ function elem=atvariablethinmultipole(fname,varargin)
 % >> atvariablethinmultipole('ACM','WHITENOISE','AmplitudeB',1.e-4);
 
 % Input parser for option
-[mode,rsrc]=getargs(varargin,'SINE','check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
+if ~any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'}))
+  error("Mode should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
+end
 [method,rsrc]=getargs(rsrc,'VariableThinMPolePass','check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
-[mode,rsrc]                       = getoption(rsrc,'Mode',mode);
 [method,rsrc]                     = getoption(rsrc,'PassMethod',method);
 [cl,rsrc]                         = getoption(rsrc,'Class','VariableThinMultipole');
 [maxorder,rsrc]                   = getoption(rsrc,'MaxOrder',0);

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -1,14 +1,16 @@
-function elem=atvariablethinmultipole(fname,modename,varargin)
+function elem=atvariablethinmultipole(fname,varargin)
 %ATVARIABLETHINMULTIPOLE Creates a variable thin multipole element
 %
+%  ATVARIABLETHINMULTIPOLE(FAMNAME,[KEY,VALUE]...)
 %  ATVARIABLETHINMULTIPOLE(FAMNAME,MODENAME,[KEY,VALUE]...)
 %  ATVARIABLETHINMULTIPOLE(FAMNAME,MODENAME,PASSMETHOD,[KEY,VALUE]...)
 %
 %  INPUTS
-%    FNAME          Family name 
-%    MODENAME       'SINE', 'WHITENOISE' or 'ARBITRARY'.
+%    FNAME          Family name
 %
 %  OPTIONS (order does not matter)
+%    MODENAME       'SINE', 'WHITENOISE' or 'ARBITRARY'.
+%                   Default: 'SINE'
 %    PASSMETHOD     Tracking function. Default: 'VariableThinMPolePass'
 %    AMPLITUDEA     Vector or scalar to define the excitation amplitude for
 %                   PolynomA
@@ -50,10 +52,14 @@ function elem=atvariablethinmultipole(fname,modename,varargin)
 % >> atvariablethinmultipole('ACM','WHITENOISE','AmplitudeB',1.e-4);
 
 % Input parser for option
+
+[modename, rsrc] = getargs(varargin,'SINE', ...
+                   'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
+[modename, rsrc] = getoption(rsrc,'ModeName',modename);
 if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
-  error("Mode name should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
+  error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end
-[method,rsrc]   = getargs(varargin,'VariableThinMPolePass', ...
+[method,rsrc]   = getargs(rsrc,'VariableThinMPolePass', ...
                   'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
 [method,rsrc]   = getoption(rsrc,'PassMethod',method);
 [cl,rsrc]       = getoption(rsrc,'Class','VariableThinMultipole');

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -1,15 +1,15 @@
 function elem=atvariablethinmultipole(fname,mode,varargin)
 %ATVARIABLETHINMULTIPOLE Creates a variable thin multipole element
 %
+%  ATVARIABLETHINMULTIPOLE(FAMNAME,MODE,[KEY,VALUE]...)
 %  ATVARIABLETHINMULTIPOLE(FAMNAME,MODE,PASSMETHOD,[KEY,VALUE]...)
-%	
+%
 %  INPUTS
 %    FNAME          Family name 
 %    MODE           Excitation mode: 'SINE', 'WHITENOISE' or 'ARBITRARY'.
-%                   Default: 'SINE'
-%    PASSMETHOD     Tracking function. Default: 'VariableThinMPolePass'
 %
 %  OPTIONS (order does not matter)
+%    PASSMETHOD     Tracking function. Default: 'VariableThinMPolePass'
 %    AMPLITUDEA     Vector or scalar to define the excitation amplitude for
 %                   PolynomA
 %    AMPLITUDEB     Vector or scalar to define the excitation amplitude for
@@ -50,17 +50,16 @@ function elem=atvariablethinmultipole(fname,mode,varargin)
 % >> atvariablethinmultipole('ACM','WHITENOISE','AmplitudeB',1.e-4);
 
 % Input parser for option
-if ~any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'}))
+if ~any(strcmpi(mode,{'SINE','WHITENOISE','ARBITRARY'}))
   error("Mode should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end
-[method,rsrc]=getargs(rsrc,'VariableThinMPolePass','check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
-[method,rsrc]                     = getoption(rsrc,'PassMethod',method);
-[cl,rsrc]                         = getoption(rsrc,'Class','VariableThinMultipole');
-[maxorder,rsrc]                   = getoption(rsrc,'MaxOrder',0);
-rsrc                              = struct(rsrc{:});
-rsrc.MaxOrder                     = maxorder;
-
-m=struct('SINE',0,'WHITENOISE',1,'ARBITRARY',2);
+[method,rsrc]   = getargs(varargin,'VariableThinMPolePass', ...
+                    'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
+[method,rsrc]   = getoption(rsrc,'PassMethod',method);
+[cl,rsrc]       = getoption(rsrc,'Class','VariableThinMultipole');
+[maxorder,rsrc] = getoption(rsrc,'MaxOrder',0);
+rsrc            = struct(rsrc{:});
+rsrc.MaxOrder   = maxorder;
 
 if ~any(isfield(rsrc,{'AmplitudeA','AmplitudeB'}))
     error("Please provide at least one amplitude for A or B")
@@ -72,7 +71,7 @@ rsrc = setmaxorder(rsrc);
 % Build the element
 % rsrc =namedargs2cell(rsrc);   % introduced in R2019b
 rsrc=reshape([fieldnames(rsrc) struct2cell(rsrc)]',1,[]);
-elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(upper(mode)),...
+elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',mode,...
                'PolynomA',[],'PolynomB',[],rsrc{:});
 
 

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -43,13 +43,13 @@ class VariableThinMultipole(Element):
     )
 
     def __init__(
-        self, family_name, mode, AmplitudeA=None, AmplitudeB=None, **kwargs
+        self, family_name, modename, AmplitudeA=None, AmplitudeB=None, **kwargs
     ):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection
         r"""
         Parameters:
             family_name(str):    Element name
-            mode:  one of the following:
+            modename:  one of the following:
 
               * :py:attr:`SINE`: sine function
               * :py:attr:`WHITENOISE`: gaussian white noise
@@ -93,21 +93,27 @@ class VariableThinMultipole(Element):
         .. note::
 
             * At least AmplitudeA or AmplitudeB has to be provided.
-            * For ``mode="SINE"`` the ``Frequency(A,B)`` corresponding to the
+            * For ``modename="SINE"`` the ``Frequency(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
-            * For ``mode="ARBITRARY"`` the ``Func(A,B)`` corresponding to the
+            * For ``modename="ARBITRARY"`` the ``Func(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
         """
         kwargs.setdefault("PassMethod", "VariableThinMPolePass")
         self.MaxOrder = kwargs.pop("MaxOrder", 0)
         self.Periodic = kwargs.pop("Periodic", True)
-        self.Mode = mode
+        self.Modename = modename
+        if modename == "SINE":
+            self.Mode = ACMode.SINE
+        if modename == "WHITENOISE":
+            self.Mode = ACMode.WHITENOISE
+        if modename == "ARBITRARY":
+            self.Mode = ACMode.ARBITRARY
         if AmplitudeA is None and AmplitudeB is None:
             raise AtError("Please provide at least one amplitude for A or B")
-        AmplitudeB = self._set_params(AmplitudeB, mode, "B", **kwargs)
-        AmplitudeA = self._set_params(AmplitudeA, mode, "A", **kwargs)
+        AmplitudeB = self._set_params(AmplitudeB, modename, "B", **kwargs)
+        AmplitudeA = self._set_params(AmplitudeA, modename, "A", **kwargs)
         self._setmaxorder(AmplitudeA, AmplitudeB)
-        if mode == "WHITENOISE":
+        if modename == "WHITENOISE":
             self.Seed = kwargs.pop("Seed", datetime.now().timestamp())
         self.PolynomA = np.zeros(self.MaxOrder + 1)
         self.PolynomB = np.zeros(self.MaxOrder + 1)
@@ -135,14 +141,14 @@ class VariableThinMultipole(Element):
                 ampb = np.pad(ampb, (0, delta))
             self.AmplitudeB = ampb
 
-    def _set_params(self, amplitude, mode, ab, **kwargs):
+    def _set_params(self, amplitude, modename, ab, **kwargs):
         if amplitude is not None:
             if np.isscalar(amplitude):
                 amp = np.zeros(self.MaxOrder)
                 amplitude = np.append(amp, amplitude)
-            if mode == "SINE":
+            if modename == "SINE":
                 self._set_sine(ab, **kwargs)
-            if mode == "ARBITRARY":
+            if modename == "ARBITRARY":
                 self._set_arb(ab, **kwargs)
         return amplitude
 

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -42,19 +42,17 @@ class VariableThinMultipole(Element):
         Periodic=bool,
     )
 
-    def __init__(
-        self, family_name, modename, AmplitudeA=None, AmplitudeB=None, **kwargs
-    ):
+    def __init__(self, family_name, mode, AmplitudeA=None, AmplitudeB=None, **kwargs):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection
         r"""Create a variable thin multipole.
 
         Parameters:
             family_name(str):    Element name
-            modename:  one of the following:
+            mode(ACMode):  one of the following:
 
-              * :py:attr:`SINE`: sine function
-              * :py:attr:`WHITENOISE`: gaussian white noise
-              * :py:attr:`ARBITRARY`: user defined turn-by-turn kick list
+              * :py:attr:`.ACMode.SINE`: sine function
+              * :py:attr:`.ACMode.WHITENOISE`: gaussian white noise
+              * :py:attr:`.GridMode.ARBITRARY`: user defined turn-by-turn kick list
 
         Keyword Arguments:
             AmplitudeA(list,float): Amplitude of the excitation for PolynomA.
@@ -84,38 +82,33 @@ class VariableThinMultipole(Element):
         Examples:
 
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", "SINE", AmplitudeB=amp, FrequencyB=frequency
+            ...     "ACMPOLE", ACMode.SINE, AmplitudeB=amp, FrequencyB=frequency
             ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", "WHITENOISE", AmplitudeB=amp, ... )
+            ...     "ACMPOLE", ACMode.WHITENOISE, AmplitudeB=amp, ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", "ARBITRARY", AmplitudeB=amp, FuncB=fun, ... )
+            ...     "ACMPOLE", ACMode.ARBITRARY, AmplitudeB=amp, FuncB=fun, ... )
 
         .. note::
 
             * At least AmplitudeA or AmplitudeB has to be provided.
-            * For ``modename="SINE"`` the ``Frequency(A,B)`` corresponding to the
+            * For ``mode=ACMode.SINE`` the ``Frequency(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
-            * For ``modename="ARBITRARY"`` the ``Func(A,B)`` corresponding to the
+            * For ``mode=ACMode.ARBITRARY`` the ``Func(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
         """
+        self.Mode = mode.value
+        self.ModeName = mode.name
         kwargs.setdefault("PassMethod", "VariableThinMPolePass")
         self.MaxOrder = kwargs.pop("MaxOrder", 0)
         self.Periodic = kwargs.pop("Periodic", True)
-        self.ModeName = modename
-        if modename == "SINE":
-            self.Mode = ACMode.SINE
-        if modename == "WHITENOISE":
-            self.Mode = ACMode.WHITENOISE
-        if modename == "ARBITRARY":
-            self.Mode = ACMode.ARBITRARY
         if AmplitudeA is None and AmplitudeB is None:
             msg = "Please provide at least one amplitude for A or B"
             raise AtError(msg)
-        AmplitudeB = self._set_params(AmplitudeB, modename, "B", **kwargs)
-        AmplitudeA = self._set_params(AmplitudeA, modename, "A", **kwargs)
+        AmplitudeB = self._set_params(AmplitudeB, "B", **kwargs)
+        AmplitudeA = self._set_params(AmplitudeA, "A", **kwargs)
         self._setmaxorder(AmplitudeA, AmplitudeB)
-        if modename == "WHITENOISE":
+        if self.Mode == ACMode.WHITENOISE:
             self.Seed = kwargs.pop("Seed", datetime.now().timestamp())
         self.PolynomA = np.zeros(self.MaxOrder + 1)
         self.PolynomB = np.zeros(self.MaxOrder + 1)
@@ -143,14 +136,14 @@ class VariableThinMultipole(Element):
                 ampb = np.pad(ampb, (0, delta))
             self.AmplitudeB = ampb
 
-    def _set_params(self, amplitude, modename, ab, **kwargs):
+    def _set_params(self, amplitude, ab, **kwargs):
         if amplitude is not None:
             if np.isscalar(amplitude):
                 amp = np.zeros(self.MaxOrder)
                 amplitude = np.append(amp, amplitude)
-            if modename == "SINE":
+            if self.Mode == ACMode.SINE:
                 self._set_sine(ab, **kwargs)
-            if modename == "ARBITRARY":
+            if self.Mode == ACMode.ARBITRARY:
                 self._set_arb(ab, **kwargs)
         return amplitude
 

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -1,4 +1,4 @@
-"""Time-dependent Multipole"""
+"""Time-dependent thin multipole."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ class ACMode(IntEnum):
 class VariableThinMultipole(Element):
     """Class to generate an AT variable thin multipole element"""
 
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["Mode"]
     _conversions = dict(
         Element._conversions,
         Mode=int,
@@ -43,23 +43,24 @@ class VariableThinMultipole(Element):
     )
 
     def __init__(
-        self, family_name, AmplitudeA=None, AmplitudeB=None, mode=ACMode.SINE, **kwargs
+        self, family_name, mode, AmplitudeA=None, AmplitudeB=None, **kwargs
     ):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection
         r"""
         Parameters:
             family_name(str):    Element name
+            mode(ACMode):  one of the following:
+
+              * :py:attr:`.ACMode.SINE`: sine function
+              * :py:attr:`.ACMode.WHITENOISE`: gaussian white noise
+              * :py:attr:`.GridMode.ARBITRARY`: user defined turn-by-turn kick list
 
         Keyword Arguments:
             AmplitudeA(list,float): Amplitude of the excitation for PolynomA.
               Default None
             AmplitudeB(list,float): Amplitude of the excitation for PolynomB.
               Default None
-            mode(ACMode): defines the evaluation grid. Default ACMode.SINE
 
-              * :py:attr:`.ACMode.SINE`: sine function
-              * :py:attr:`.ACMode.WHITENOISE`: gaussian white noise
-              * :py:attr:`.GridMode.ARBITRARY`: user defined turn-by-turn kick list
             FrequencyA(float): Frequency of the sine excitation for PolynomA
             FrequencyB(float): Frequency of the sine excitation for PolynomB
             PhaseA(float): Phase of the sine excitation for PolynomA. Default 0

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -23,7 +23,7 @@ class ACMode(IntEnum):
 class VariableThinMultipole(Element):
     """Class to generate an AT variable thin multipole element."""
 
-    _BUILD_ATTRIBUTES = [Element._BUILD_ATTRIBUTES]
+    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES
     _conversions = dict(
         Element._conversions,
         Mode=int,

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -23,7 +23,7 @@ class ACMode(IntEnum):
 class VariableThinMultipole(Element):
     """Class to generate an AT variable thin multipole element."""
 
-    _BUILD_ATTRIBUTES = [Element._BUILD_ATTRIBUTES, "Mode"]
+    _BUILD_ATTRIBUTES = [Element._BUILD_ATTRIBUTES]
     _conversions = dict(
         Element._conversions,
         Mode=int,
@@ -43,17 +43,19 @@ class VariableThinMultipole(Element):
         Periodic=bool,
     )
 
-    def __init__(self, family_name, mode, AmplitudeA=None, AmplitudeB=None, **kwargs):
+    def __init__(
+        self, family_name, mode=ACMode.SINE, AmplitudeA=None, AmplitudeB=None, **kwargs
+    ):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection
         r"""Create a variable thin multipole.
 
         Parameters:
             family_name(str):    Element name
-            mode(ACMode):  one of the following:
+            mode(ACMode):  one of the following at.ACMode. Default at.ACMode.SINE.
 
-              * :py:attr:`.ACMode.SINE`: sine function
-              * :py:attr:`.ACMode.WHITENOISE`: gaussian white noise
-              * :py:attr:`.GridMode.ARBITRARY`: user defined turn-by-turn kick list
+              * :py:attr:`at.ACMode.SINE`: sine function
+              * :py:attr:`at.ACMode.WHITENOISE`: gaussian white noise
+              * :py:attr:`at.ACMode.ARBITRARY`: user defined turn-by-turn kick list
 
         Keyword Arguments:
             AmplitudeA(list,float): Amplitude of the excitation for PolynomA.
@@ -83,19 +85,19 @@ class VariableThinMultipole(Element):
         Examples:
 
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", ACMode.SINE, AmplitudeB=amp, FrequencyB=frequency
+            ...     "ACMPOLE", at.ACMode.SINE, AmplitudeB=amp, FrequencyB=frequency
             ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", ACMode.WHITENOISE, AmplitudeB=amp, ... )
+            ...     "ACMPOLE", at.ACMode.WHITENOISE, AmplitudeB=amp, ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", ACMode.ARBITRARY, AmplitudeB=amp, FuncB=fun, ... )
+            ...     "ACMPOLE", at.ACMode.ARBITRARY, AmplitudeB=amp, FuncB=fun, ... )
 
         .. note::
 
             * At least AmplitudeA or AmplitudeB has to be provided.
-            * For ``mode=ACMode.SINE`` the ``Frequency(A,B)`` corresponding to the
+            * For ``mode=at.ACMode.SINE`` the ``Frequency(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
-            * For ``mode=ACMode.ARBITRARY`` the ``Func(A,B)`` corresponding to the
+            * For ``mode=at.ACMode.ARBITRARY`` the ``Func(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
         """
         self.Mode = mode.value

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -101,7 +101,7 @@ class VariableThinMultipole(Element):
         kwargs.setdefault("PassMethod", "VariableThinMPolePass")
         self.MaxOrder = kwargs.pop("MaxOrder", 0)
         self.Periodic = kwargs.pop("Periodic", True)
-        self.Modename = modename
+        self.ModeName = modename
         if modename == "SINE":
             self.Mode = ACMode.SINE
         if modename == "WHITENOISE":

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -26,7 +26,7 @@ class VariableThinMultipole(Element):
     _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["Mode"]
     _conversions = dict(
         Element._conversions,
-        Mode=int,
+        Mode=str,
         AmplitudeA=_array,
         AmplitudeB=_array,
         FrequencyA=float,
@@ -49,11 +49,11 @@ class VariableThinMultipole(Element):
         r"""
         Parameters:
             family_name(str):    Element name
-            mode(ACMode):  one of the following:
+            mode:  one of the following:
 
-              * :py:attr:`.ACMode.SINE`: sine function
-              * :py:attr:`.ACMode.WHITENOISE`: gaussian white noise
-              * :py:attr:`.GridMode.ARBITRARY`: user defined turn-by-turn kick list
+              * :py:attr:`SINE`: sine function
+              * :py:attr:`WHITENOISE`: gaussian white noise
+              * :py:attr:`ARBITRARY`: user defined turn-by-turn kick list
 
         Keyword Arguments:
             AmplitudeA(list,float): Amplitude of the excitation for PolynomA.
@@ -83,34 +83,31 @@ class VariableThinMultipole(Element):
         Examples:
 
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", AmplitudeB=amp, FrequencyB=frequency
+            ...     "ACMPOLE", "SINE", AmplitudeB=amp, FrequencyB=frequency
             ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", AmplitudeB=amp, mode=at.ACMode.WHITENOISE
-            ... )
+            ...     "ACMPOLE", "WHITENOISE", AmplitudeB=amp, ... )
             >>> acmpole = at.VariableThinMultipole(
-            ...     "ACMPOLE", AmplitudeB=amp, FuncB=fun, mode=at.ACMode.ARBITRARY
-            ... )
+            ...     "ACMPOLE", "ARBITRARY", AmplitudeB=amp, FuncB=fun, ... )
 
         .. note::
 
-            * For all excitation modes at least one amplitude has to be provided.
-              The default excitation is ``ACMode.SINE``
-            * For ``mode=ACMode.SINE`` the ``Frequency(A,B)`` corresponding to the
+            * At least AmplitudeA or AmplitudeB has to be provided.
+            * For ``mode="SINE"`` the ``Frequency(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
-            * For ``mode=ACMode.ARBITRARY`` the ``Func(A,B)`` corresponding to the
+            * For ``mode="ARBITRARY"`` the ``Func(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
         """
         kwargs.setdefault("PassMethod", "VariableThinMPolePass")
         self.MaxOrder = kwargs.pop("MaxOrder", 0)
         self.Periodic = kwargs.pop("Periodic", True)
-        self.Mode = int(mode)
+        self.Mode = mode
         if AmplitudeA is None and AmplitudeB is None:
             raise AtError("Please provide at least one amplitude for A or B")
         AmplitudeB = self._set_params(AmplitudeB, mode, "B", **kwargs)
         AmplitudeA = self._set_params(AmplitudeA, mode, "A", **kwargs)
         self._setmaxorder(AmplitudeA, AmplitudeB)
-        if mode == ACMode.WHITENOISE:
+        if mode == "WHITENOISE":
             self.Seed = kwargs.pop("Seed", datetime.now().timestamp())
         self.PolynomA = np.zeros(self.MaxOrder + 1)
         self.PolynomB = np.zeros(self.MaxOrder + 1)
@@ -143,9 +140,9 @@ class VariableThinMultipole(Element):
             if np.isscalar(amplitude):
                 amp = np.zeros(self.MaxOrder)
                 amplitude = np.append(amp, amplitude)
-            if mode == ACMode.SINE:
+            if mode == "SINE":
                 self._set_sine(ab, **kwargs)
-            if mode == ACMode.ARBITRARY:
+            if mode == "ARBITRARY":
                 self._set_arb(ab, **kwargs)
         return amplitude
 

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -26,7 +26,8 @@ class VariableThinMultipole(Element):
     _BUILD_ATTRIBUTES = [Element._BUILD_ATTRIBUTES, "Mode"]
     _conversions = dict(
         Element._conversions,
-        Mode=str,
+        Mode=int,
+        ModeName=str,
         AmplitudeA=_array,
         AmplitudeB=_array,
         FrequencyA=float,

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -7,13 +7,13 @@ from enum import IntEnum
 
 import numpy as np
 
+from ..exceptions import AtError
 from .conversions import _array
 from .element_object import Element
-from ..exceptions import AtError
 
 
 class ACMode(IntEnum):
-    """Class to define the excitation types"""
+    """Class to define the excitation types."""
 
     SINE = 0
     WHITENOISE = 1
@@ -21,9 +21,9 @@ class ACMode(IntEnum):
 
 
 class VariableThinMultipole(Element):
-    """Class to generate an AT variable thin multipole element"""
+    """Class to generate an AT variable thin multipole element."""
 
-    _BUILD_ATTRIBUTES = Element._BUILD_ATTRIBUTES + ["Mode"]
+    _BUILD_ATTRIBUTES = [Element._BUILD_ATTRIBUTES, "Mode"]
     _conversions = dict(
         Element._conversions,
         Mode=str,
@@ -46,7 +46,8 @@ class VariableThinMultipole(Element):
         self, family_name, modename, AmplitudeA=None, AmplitudeB=None, **kwargs
     ):
         # noinspection PyUnresolvedReferences,SpellCheckingInspection
-        r"""
+        r"""Create a variable thin multipole.
+
         Parameters:
             family_name(str):    Element name
             modename:  one of the following:
@@ -109,7 +110,8 @@ class VariableThinMultipole(Element):
         if modename == "ARBITRARY":
             self.Mode = ACMode.ARBITRARY
         if AmplitudeA is None and AmplitudeB is None:
-            raise AtError("Please provide at least one amplitude for A or B")
+            msg = "Please provide at least one amplitude for A or B"
+            raise AtError(msg)
         AmplitudeB = self._set_params(AmplitudeB, modename, "B", **kwargs)
         AmplitudeA = self._set_params(AmplitudeA, modename, "A", **kwargs)
         self._setmaxorder(AmplitudeA, AmplitudeB)


### PR DESCRIPTION
This PR  proposes to resolve the class determination at AT matlab and pyat by requiring Mode to be always defined for the atvariablethinmultipole. See issue #1098 .