### PR TITLE
Add kz check in wiggler integrators

### DIFF
--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -137,6 +137,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         NVharm = atGetLong(ElemData, "NVharm"); check_error();
         By = atGetDoubleArray(ElemData, "By"); check_error();
         Bx = atGetDoubleArray(ElemData, "Bx"); check_error();
+        GWigCheckKz(NHharm, NVharm, By, Bx); check_error();
         /* Optional fields */
         Energy=atGetOptionalDouble(ElemData,"Energy",Param->energy); check_error();
         R1 = atGetOptionalDoubleArray(ElemData, "R1"); check_error();

--- a/atintegrators/GWigSymplecticPass.c
+++ b/atintegrators/GWigSymplecticPass.c
@@ -209,6 +209,7 @@ void mexFunction(       int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
         NVharm = atGetLong(ElemData, "NVharm"); check_error();
         By = atGetDoubleArray(ElemData, "By"); check_error();
         Bx = atGetDoubleArray(ElemData, "Bx"); check_error();
+        GWigCheckKz(NHharm, NVharm, By, Bx); check_error();
         /* Optional fields */
         Energy=atGetOptionalDouble(ElemData,"Energy",0.0); check_error();
         R1 = atGetOptionalDoubleArray(ElemData, "R1"); check_error();

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -263,6 +263,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
         NVharm = atGetLong(ElemData, "NVharm"); check_error();
         By = atGetDoubleArray(ElemData, "By"); check_error();
         Bx = atGetDoubleArray(ElemData, "Bx"); check_error();
+        GWigCheckKz(NHharm, NVharm, By, Bx); check_error();
         /* Optional fields */
         Energy = atGetOptionalDouble(ElemData, "Energy",Param->energy); check_error();
         R1 = atGetOptionalDoubleArray(ElemData, "R1"); check_error();

--- a/atintegrators/GWigSymplecticRadPass.c
+++ b/atintegrators/GWigSymplecticRadPass.c
@@ -334,6 +334,7 @@ void mexFunction(       int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
         NVharm = atGetLong(ElemData, "NVharm"); check_error();
         By = atGetDoubleArray(ElemData, "By"); check_error();
         Bx = atGetDoubleArray(ElemData, "Bx"); check_error();
+        GWigCheckKz(NHharm, NVharm, By, Bx); check_error();
         /* Optional fields */
         Energy = atGetOptionalDouble(ElemData, "Energy",0.0); check_error();
         R1 = atGetOptionalDoubleArray(ElemData, "R1"); check_error();

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -31,7 +31,28 @@
 #include <math.h>
 #include <stdio.h>
 
+static void GWigCheckKz(int NHharm, int NVharm, const double *By, const double *Bx)
+{
+    int i;
 
+    for (i = 0; i < NHharm; i++) {
+        double kz = By[6*i + 4];
+
+        if (fabs(kz) <= GWIG_EPS) {
+            atError("GWig error: By harmonic %d has kz=0; kz must be non-zero.", i);
+            return;
+        }
+    }
+
+    for (i = 0; i < NVharm; i++) {
+        double kz = Bx[6*i + 4];
+
+        if (fabs(kz) <= GWIG_EPS) {
+            atError("GWig error: Bx harmonic %d has kz=0; kz must be non-zero.", i);
+            return;
+        }
+    }
+}
 
 static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
             double Bmax, int Nstep, int Nmeth, int NHharm, int NVharm,

--- a/atintegrators/gwig.c
+++ b/atintegrators/gwig.c
@@ -74,10 +74,6 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Hky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Hkz[i] = (*tmppr) * kw;
-        if (fabs(Wig->Hkz[i] / kw) <= GWIG_EPS) {
-            atError("GWig error: By harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i);
-        }
         tmppr++;
         Wig->Htz[i] = *tmppr;
         tmppr++;
@@ -92,10 +88,6 @@ static void GWigInit2(struct gwig *Wig,double gamma, double Ltot, double Lw,
         Wig->Vky[i] = (*tmppr) * kw;
         tmppr++;
         Wig->Vkz[i] = (*tmppr) * kw;
-        if (fabs(Wig->Vkz[i] / kw) <= GWIG_EPS) {
-            atError("GWig error: Bx harmonic %d has kz=0 "
-            "; kz must be larger than 0.", i);
-        }
         tmppr++;
         Wig->Vtz[i] = *tmppr;
         tmppr++;


### PR DESCRIPTION
This PR is related to the discussion in: https://github.com/atcollab/at/issues/1075
And the PR: https://github.com/atcollab/at/pull/1085
I have now moved the kz checks inside `trackFunction` as requested by @lfarv 

I created a check function which I placed into gwig.c and called in GWigSymplecticPass.c and GWigSymplecticRadPass.c. Let me know if this is better now.