### PR TITLE
pyat ID table text file read H and V fix

### DIFF
--- a/pyat/at/lattice/elements/idtable_element.py
+++ b/pyat/at/lattice/elements/idtable_element.py
@@ -339,8 +339,8 @@ class InsertionDeviceKickMap(Element):
                     if block_lines > v_points:
                         block_lines = 0
                         kick_block_list.append(np.copy(kick_block))
-                        kick_haxes_list.append(haxis)
-                        kick_vaxes_list.append(vaxis)
+                        kick_haxes_list.append(np.copy(haxis))
+                        kick_vaxes_list.append(np.copy(vaxis))
                     block_lines += 1
         # checking how many kick blocks were added
         lenkick_block_list = len(kick_block_list)

--- a/pyat/at/lattice/elements/idtable_element.py
+++ b/pyat/at/lattice/elements/idtable_element.py
@@ -1,6 +1,5 @@
 """ID table :py:class:`.Element`."""
 
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -339,7 +338,7 @@ class InsertionDeviceKickMap(Element):
                         kick_block[block_lines - 2][:] = sline[1:]
                     if block_lines > v_points:
                         block_lines = 0
-                        kick_block_list.append(kick_block)
+                        kick_block_list.append(np.copy(kick_block))
                         kick_haxes_list.append(haxis)
                         kick_vaxes_list.append(vaxis)
                     block_lines += 1


### PR DESCRIPTION
This PR solves issue #1102 where the horizontal and vertical kickmap had the same values.

This bug was introduced when extending from 2 to 4 blocks the functionality of the idtable read from text file  in the pull request #963 on August 25, 2025. I hope this has not created too much damage. 

The solution is to make a copy of the block before inserting it into a list, i.e. there was a missing np.copy call.