### PR TITLE
remove orbitin from dispersive orbit calculation atlinopt4

### DIFF
--- a/atmat/atphysics/LinearOptics/atlinopt4.m
+++ b/atmat/atphysics/LinearOptics/atlinopt4.m
@@ -124,11 +124,13 @@ if isempty(twiss_in)        % Circular machine
     [orbit,orbitin] = findorbit4(ring,dp,refpts, ...
                                 'orbit',orbitin, dpargs{:}, ...
                                 'XYStep', XYStep,'strict', -1);
+    % to calculate the dispersion we need to recalculate the orbit,
+    % therefore, orbitin is not used.
     dp=orbitin(5);
     [orbitP,o1P] = findorbit4(ring,dp+0.5*DPStep,refpts, ...
-                              'orbit',orbitin,'XYStep',XYStep,'strict',-1);
+                              'XYStep',XYStep,'strict',-1);
     [orbitM,o1M] = findorbit4(ring,dp-0.5*DPStep,refpts, ...
-                              'orbit',orbitin,'XYStep',XYStep,'strict',-1);
+                              'XYStep',XYStep,'strict',-1);
 else                        % Transfer line
     if isempty(orbitin)
         orbitin = zeros(6,1);


### PR DESCRIPTION
This pull request is possible solution to issue #1107 where it is reported that dispersion is wrong in atlinopt4.

I remove the `orbitin` from the input parameters to `findorbit4` when the energy is changed by some small DPStep. This forces the calculation of the dispersive orbit.