### PR TITLE
fix MaxOrd and Amplitude for atvariablethinmultipole

### DIFF
--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -84,7 +84,7 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
                'ModeName',modename,'PolynomA',[],'PolynomB',[],rsrc{:});
 
 
-    function setsine(rsrc, ab)
+    function rsrc = setsine(rsrc, ab)
         funcarg = strcat('Frequency',ab);
         if ~isfield(rsrc,funcarg)
             rsrc.(funcarg) = 0;
@@ -106,38 +106,36 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
     function rsrc = setparams(rsrc,mode,ab)
         amplarg=strcat('Amplitude',ab);
         if isfield(rsrc,amplarg)
-            amp=rsrc.(amplarg);
-            if isscalar(amp)
-                rsrc.(amplarg)=[zeros(1,rsrc.MaxOrder) amp];
+            switch mode
+                case "SINE"
+                    rsrc = setsine(rsrc,ab);
+                case "ARBITRARY"
+                    rsrc = setarb(rsrc,ab);
+                case "WHITENOISE"
+                    rsrc = setwhitenoise(rsrc,ab);
             end
-            if strcmpi(mode,'SINE')
-                setsine(rsrc,ab);
-            end
-            if strcmpi(mode,'ARBITRARY')
-                rsrc = setarb(rsrc,ab);
-            end        
         end
     end
 
     function rsrc = setmaxorder(rsrc)
-        if isfield(rsrc,'AmplitudeA')
-            mxa=find(abs(rsrc.AmplitudeA)>0,1,'last');
-        else
-            mxa=0;
+        mxab = [0 0];
+        thefields = {'AmplitudeA','AmplitudeB'};
+        for i = 1:2
+          ampab = thefields{i};
+          tmp = 0;
+          if isfield(rsrc,ampab)
+              tmp=find(abs(rsrc.(ampab))>0,1,'last');
+              if isempty(tmp), tmp=1; end
+          end
+          mxab(i) = tmp;
         end
-        if isfield(rsrc,'AmplitudeB')
-            mxb=find(abs(rsrc.AmplitudeB)>0,1,'last');
-        else
-            mxb=0;
+        maxamp=max([mxab,rsrc.MaxOrder-1]);
+        rsrc.MaxOrder=maxamp-1;
+        for i = 1:2
+          ampab = thefields{i};
+          if isfield(rsrc,ampab)
+            rsrc.(ampab)(mxab(i)+1:maxamp)=0;
+          end
         end
-        mxab=max([mxa,mxb,rsrc.MaxOrder-1]);
-        rsrc.MaxOrder=mxab-1;
-        if isfield(rsrc,'AmplitudeA')
-            rsrc.AmplitudeA(mxa+1:mxab)=0;
-        end
-        if isfield(rsrc,'AmplitudeB')
-            rsrc.AmplitudeB(mxb+1:mxab)=0;
-        end               
     end
-    
 end

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -129,7 +129,7 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
           end
           mxab(i) = tmp;
         end
-        maxamp=max([mxab,rsrc.MaxOrder-1]);
+        maxamp=max([mxab,rsrc.MaxOrder+1]);
         rsrc.MaxOrder=maxamp-1;
         for i = 1:2
           ampab = thefields{i};

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -103,10 +103,10 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
         rsrc.(strcat('NSamples',ab))=length(rsrc.(funcarg));
     end
 
-    function rsrc = setparams(rsrc,mode,ab)
+    function rsrc = setparams(rsrc,modename,ab)
         amplarg=strcat('Amplitude',ab);
         if isfield(rsrc,amplarg)
-            switch mode
+            switch modename
                 case "SINE"
                     rsrc = setsine(rsrc,ab);
                 case "ARBITRARY"


### PR DESCRIPTION
Dear all,
this is a possible solution to issue #1113 where  the PolynomA, PolynomB and MaxOrder are wrongly initialized if the initial amplitude is zero.

The function setparam is simplified, and the function setmaxorder has been modified to initialize correctly the polynoms and MaxOrder fields.

For example,
<img width="509" height="310" alt="image" src="https://github.com/user-attachments/assets/58c22b4a-0970-41d0-a72d-653df434223d" />
