### PR TITLE
change variable multipole class name in energy loss

### DIFF
--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -11,7 +11,7 @@ from scipy.optimize import least_squares
 
 from at.constants import clight, Cgamma
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts, EnergyLoss
-from at.lattice import Collective, SimpleQuantDiff, QuantumDiffusion, VariableMultipole
+from at.lattice import Collective, SimpleQuantDiff, QuantumDiffusion, VariableThinMultipole
 from at.lattice import check_radiation, AtError, AtWarning
 from at.lattice import get_bool_index, set_value_refpts
 from at.lattice import DConstant
@@ -87,7 +87,7 @@ def get_energy_loss(
         delta = 0.0
         try:
             ring = ring.disable_6d(*_EXCLUDED, copy=True)
-            for e in ring[VariableMultipole]:
+            for e in ring[VariableThinMultipole]:
                 e.PassMethod = "IdentityPass"
             if orbit6 is None:
                 o6, *_ = ring.find_orbit(method=ELossMethod.INTEGRAL)


### PR DESCRIPTION
PR #1118 change the variable multipole class name but this was not integrated in PR #1082 (master was not pulled before merge).
This fixes this issue.