### PR TITLE
Variablethinmultipole WHITENOISE buffer

### DIFF
--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -16,6 +16,7 @@ struct elemab {
     double Sinmin, Sinmax;
     int NSamples;
     double* Func;
+    double* Buffer;
 };
 
 struct elem {
@@ -35,9 +36,7 @@ struct elem {
     double *T2;
     double *EApertures;
     double *RApertures;
-    double *Buffer;
-    double BufferSize;
-    double BufferOffset;
+    int BufferSize, BufferOffset;
 };
 
 double get_amp(double amp, double* ramps, double t)
@@ -59,7 +58,7 @@ double get_amp(double amp, double* ramps, double t)
     return ampt;
 }
 
-double get_pol(struct elemab* elem, double* ramps, int mode,
+double get_pol(struct elem* El, struct elemab* elem, double* ramps, int mode,
     double t, int turn, int order, int periodic)
 {
     int idx;
@@ -81,8 +80,9 @@ double get_pol(struct elemab* elem, double* ramps, int mode,
         return ampt;
     case 1:
         val = atrandn(0.0, 1.0); // uses pcg32_global
-        idx = turn - elem->BufferOffset;
-        if (idx >= 0 && idx < elem->BufferSize) elem->Buffer[idx] = val;
+        idx = turn - El->BufferOffset;
+        printf("idx %d\n", idx);
+        if (idx >= 0 && idx < El->BufferSize) elem->Buffer[idx] = val;
         ampt *= val;
         return ampt;
     case 2:
@@ -115,7 +115,6 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
     struct elemab* ElemB = Elem->ElemB;
     double* ramps = Elem->Ramps;
 
-
     // offsets at input and output
     double *T1 = Elem->T1;
     double *T2 = Elem->T2;
@@ -128,8 +127,8 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
 
     if (mode != 0) {
         for (i = 0; i < maxorder + 1; i++) {
-            pola[i] = get_pol(ElemA, ramps, mode, t, turn, i, periodic, rng);
-            polb[i] = get_pol(ElemB, ramps, mode, t, turn, i, periodic, rng);
+            pola[i] = get_pol(Elem, ElemA, ramps, mode, t, turn, i, periodic);
+            polb[i] = get_pol(Elem, ElemB, ramps, mode, t, turn, i, periodic);
         };
     };
 
@@ -139,8 +138,8 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
             if (mode == 0) {
                 double tpart = t + r6[5] / C0;
                 for (i = 0; i < maxorder + 1; i++) {
-                    pola[i] = get_pol(ElemA, ramps, mode, tpart, turn, i, periodic);
-                    polb[i] = get_pol(ElemB, ramps, mode, tpart, turn, i, periodic);
+                    pola[i] = get_pol(Elem, ElemA, ramps, mode, tpart, turn, i, periodic);
+                    polb[i] = get_pol(Elem, ElemB, ramps, mode, tpart, turn, i, periodic);
                 };
             };
             /*  misalignment at entrance  */
@@ -224,6 +223,8 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         Elem->Mode = Mode;
         Elem->MaxOrder = MaxOrder;
         Elem->Periodic = Periodic;
+        Elem->BufferSize = BufferSize;
+        Elem->BufferOffset= BufferOffset;
         ElemA->Amplitude = AmplitudeA;
         ElemB->Amplitude = AmplitudeB;
         ElemA->Frequency = FrequencyA;
@@ -236,10 +237,6 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         ElemB->Sinmax = Sinmax;
         ElemA->Buffer = BufferA;
         ElemB->Buffer = BufferB;
-        ElemA->BufferSize = BufferSize;
-        ElemB->BufferSize = BufferSize;
-        ElemA->BufferOffset= BufferOffset;
-        ElemB->BufferOffset = BufferOffset;
         ElemA->NSamples = NSamplesA;
         ElemB->NSamples = NSamplesB;
         ElemA->Func = FuncA;
@@ -319,8 +316,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         Elem->T2 = T2;
         Elem->EApertures = EApertures;
         Elem->RApertures = RApertures;
-        ElemA->Amplitude = AmplitudeA;
-        ElemB->Amplitude = AmplitudeB;
+        Elem->BufferSize = BufferSize;
+        Elem->BufferOffset= BufferOffset;
+        Elem->Amplitude = AmplitudeA;
+        Elem->Amplitude = AmplitudeB;
         ElemA->Frequency = FrequencyA;
         ElemB->Frequency = FrequencyB;
         ElemA->Phase = PhaseA;
@@ -331,10 +330,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         ElemB->Sinmax = Sinmax;
         ElemA->Buffer = BufferA;
         ElemB->Buffer = BufferB;
-        ElemA->BufferSize = BufferSize;
-        ElemB->BufferSize = BufferSize;
-        ElemA->BufferOffset= BufferOffset;
-        ElemB->BufferOffset = BufferOffset;
         ElemA->NSamples = NSamplesA;
         ElemB->NSamples = NSamplesB;
         ElemA->Func = FuncA;

--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -197,8 +197,8 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         Sinmax=atGetOptionalDouble(ElemData,"Sinmax", 1.1); check_error();
         BufferA=atGetOptionalDoubleArray(ElemData,"BufferA"); check_error();
         BufferB=atGetOptionalDoubleArray(ElemData,"BufferB"); check_error();
-        BufferSize=atGetOptionalLong(ElemData, "Buffersize", 0); check_error();
-        BufferOffset=atGetOptionalLong(ElemData, "Bufferoffset", 0); check_error();
+        BufferSize=atGetOptionalLong(ElemData, "BufferSize", 0); check_error();
+        BufferOffset=atGetOptionalLong(ElemData, "BufferOffset", 0); check_error();
         Ramps=atGetOptionalDoubleArray(ElemData, "Ramps"); check_error();
         NSamplesA=atGetOptionalLong(ElemData, "NSamplesA", 1); check_error();
         NSamplesB=atGetOptionalLong(ElemData, "NSamplesB", 1); check_error();
@@ -354,7 +354,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         mxSetCell(plhs[0], 3, mxCreateString("PolynomB"));
         if (nlhs > 1) {
             /* list of optional fields */
-            plhs[1] = mxCreateCellMatrix(22, 1);
+            plhs[1] = mxCreateCellMatrix(24, 1);
             mxSetCell(plhs[1], 0, mxCreateString("AmplitudeA"));
             mxSetCell(plhs[1], 1, mxCreateString("AmplitudeB"));
             mxSetCell(plhs[1], 2, mxCreateString("FrequencyA"));
@@ -375,8 +375,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
             mxSetCell(plhs[1], 17, mxCreateString("EApertures"));
             mxSetCell(plhs[1], 18, mxCreateString("Sinmin"));
             mxSetCell(plhs[1], 19, mxCreateString("Sinmax"));
-            mxSetCell(plhs[1], 20, mxCreateString("Buffer"));
-            mxSetCell(plhs[1], 21, mxCreateString("Buffersize"));
+            mxSetCell(plhs[1], 20, mxCreateString("BufferA"));
+            mxSetCell(plhs[1], 21, mxCreateString("BufferB"));
+            mxSetCell(plhs[1], 22, mxCreateString("BufferSize"));
+            mxSetCell(plhs[1], 23, mxCreateString("BufferOffset"));
         }
     } else {
         mexErrMsgIdAndTxt("AT:WrongArg", "Needs 0 or 2 arguments");

--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -36,6 +36,9 @@ struct elem {
     double *T2;
     double *EApertures;
     double *RApertures;
+    double *Buffer;
+    double BufferSize;
+    double BufferOffset;
 };
 
 double get_amp(double amp, double* ramps, double t)
@@ -57,11 +60,19 @@ double get_amp(double amp, double* ramps, double t)
     return ampt;
 }
 
-double get_pol(struct elemab* elem, double* ramps, int mode,
-    double t, int turn, int seed, int order, int periodic)
+double get_pol(
+      struct elemab* elem,
+      double* ramps, int mode,
+      double t,
+      int turn,
+      int seed,
+      int order,
+      int periodic,
+      pcg32_random_t* rng
+      )
 {
     int idx;
-    double ampt, freq, ph, sinval, val;
+    double ampt, freq, ph, val;
     double* func;
     double* amp = elem->Amplitude;
     if (!amp) {
@@ -72,13 +83,15 @@ double get_pol(struct elemab* elem, double* ramps, int mode,
     case 0:
         freq = elem->Frequency;
         ph = elem->Phase;
-        sinval = sin(TWOPI * freq * t + ph);
-        if (sinval < elem->Sinmin) sinval = elem->Sinmin;
-        if (sinval > elem->Sinmax) sinval = elem->Sinmax;
-        ampt *= sinval;
+        val = sin(TWOPI * freq * t + ph);
+        if (val < elem->Sinmin) val = elem->Sinmin;
+        if (val > elem->Sinmax) val = elem->Sinmax;
+        ampt *= val;
         return ampt;
     case 1:
-        val = atrandn(0.0, 1.0);
+        val = atrandn_r(rng, 0, 1);
+        idx = turn - elem->BufferOffset;
+        if (idx >= 0 && idx < elem->BufferSize) elem->Buffer[idx] = val;
         ampt *= val;
         return ampt;
     case 2:
@@ -95,7 +108,13 @@ double get_pol(struct elemab* elem, double* ramps, int mode,
     }
 }
 
-void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, int num_particles)
+void VariableThinMPolePass(
+      double* r,
+      struct elem* Elem,
+      double t0,
+      int turn, int num_particles,
+      pcg32_random_t* rng // pcg32 random stream
+    )
 {
 
     int i, c;
@@ -125,8 +144,8 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
 
     if (mode != 0) {
         for (i = 0; i < maxorder + 1; i++) {
-            pola[i] = get_pol(ElemA, ramps, mode, t, turn, seed, i, periodic);
-            polb[i] = get_pol(ElemB, ramps, mode, t, turn, seed, i, periodic);
+            pola[i] = get_pol(ElemA, ramps, mode, t, turn, seed, i, periodic, rng);
+            polb[i] = get_pol(ElemB, ramps, mode, t, turn, seed, i, periodic, rng);
         };
     };
 
@@ -237,7 +256,7 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
     }
     double t0 = Param->T0;
     int turn = Param->nturn;
-    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles);
+    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles, Param->thread_rng);
     return Elem;
 }
 
@@ -323,7 +342,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles);
+        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles, &pcg32_global);
     } else if (nrhs == 0) {
         /* list of required fields */
         plhs[0] = mxCreateCellMatrix(4, 1);

--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -59,7 +59,7 @@ double get_amp(double amp, double* ramps, double t)
 }
 
 double get_pol(struct elem* El, struct elemab* elem, double* ramps, int mode,
-    double t, int turn, int order, int periodic)
+    double t, int turn, int order, int periodic, pcg32_random_t* rng)
 {
     int idx;
     double ampt, freq, ph, val;
@@ -79,9 +79,8 @@ double get_pol(struct elem* El, struct elemab* elem, double* ramps, int mode,
         ampt *= val;
         return ampt;
     case 1:
-        val = atrandn(0.0, 1.0); // uses pcg32_global
+        val = atrandn_r(rng, 0, 1);
         idx = turn - El->BufferOffset;
-        printf("idx %d\n", idx);
         if (idx >= 0 && idx < El->BufferSize) elem->Buffer[idx] = val;
         ampt *= val;
         return ampt;
@@ -99,7 +98,8 @@ double get_pol(struct elem* El, struct elemab* elem, double* ramps, int mode,
     }
 }
 
-void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, int num_particles)
+void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, int num_particles,
+    pcg32_random_t* rng)
 {
 
     int i, c;
@@ -127,8 +127,8 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
 
     if (mode != 0) {
         for (i = 0; i < maxorder + 1; i++) {
-            pola[i] = get_pol(Elem, ElemA, ramps, mode, t, turn, i, periodic);
-            polb[i] = get_pol(Elem, ElemB, ramps, mode, t, turn, i, periodic);
+            pola[i] = get_pol(Elem, ElemA, ramps, mode, t, turn, i, periodic, rng);
+            polb[i] = get_pol(Elem, ElemB, ramps, mode, t, turn, i, periodic, rng);
         };
     };
 
@@ -138,8 +138,8 @@ void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, in
             if (mode == 0) {
                 double tpart = t + r6[5] / C0;
                 for (i = 0; i < maxorder + 1; i++) {
-                    pola[i] = get_pol(Elem, ElemA, ramps, mode, tpart, turn, i, periodic);
-                    polb[i] = get_pol(Elem, ElemB, ramps, mode, tpart, turn, i, periodic);
+                    pola[i] = get_pol(Elem, ElemA, ramps, mode, tpart, turn, i, periodic, rng);
+                    polb[i] = get_pol(Elem, ElemB, ramps, mode, tpart, turn, i, periodic, rng);
                 };
             };
             /*  misalignment at entrance  */
@@ -246,7 +246,7 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
     }
     double t0 = Param->T0;
     int turn = Param->nturn;
-    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles);
+    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles, Param->thread_rng);
     return Elem;
 }
 
@@ -318,8 +318,8 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         Elem->RApertures = RApertures;
         Elem->BufferSize = BufferSize;
         Elem->BufferOffset= BufferOffset;
-        Elem->Amplitude = AmplitudeA;
-        Elem->Amplitude = AmplitudeB;
+        ElemA->Amplitude = AmplitudeA;
+        ElemB->Amplitude = AmplitudeB;
         ElemA->Frequency = FrequencyA;
         ElemB->Frequency = FrequencyB;
         ElemA->Phase = PhaseA;
@@ -339,7 +339,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles);
+        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles, &pcg32_global);
     } else if (nrhs == 0) {
         /* list of required fields */
         plhs[0] = mxCreateCellMatrix(4, 1);

--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -59,16 +59,8 @@ double get_amp(double amp, double* ramps, double t)
     return ampt;
 }
 
-double get_pol(
-      struct elemab* elem,
-      double* ramps, int mode,
-      double t,
-      int turn,
-      int seed,
-      int order,
-      int periodic,
-      pcg32_random_t* rng
-      )
+double get_pol(struct elemab* elem, double* ramps, int mode,
+    double t, int turn, int order, int periodic)
 {
     int idx;
     double ampt, freq, ph, val;
@@ -88,7 +80,7 @@ double get_pol(
         ampt *= val;
         return ampt;
     case 1:
-        val = atrandn_r(rng, 0, 1);
+        val = atrandn(0.0, 1.0); // uses pcg32_global
         idx = turn - elem->BufferOffset;
         if (idx >= 0 && idx < elem->BufferSize) elem->Buffer[idx] = val;
         ampt *= val;
@@ -107,13 +99,7 @@ double get_pol(
     }
 }
 
-void VariableThinMPolePass(
-      double* r,
-      struct elem* Elem,
-      double t0,
-      int turn, int num_particles,
-      pcg32_random_t* rng // pcg32 random stream
-    )
+void VariableThinMPolePass(double* r, struct elem* Elem, double t0, int turn, int num_particles)
 {
 
     int i, c;
@@ -142,8 +128,8 @@ void VariableThinMPolePass(
 
     if (mode != 0) {
         for (i = 0; i < maxorder + 1; i++) {
-            pola[i] = get_pol(ElemA, ramps, mode, t, turn, seed, i, periodic, rng);
-            polb[i] = get_pol(ElemB, ramps, mode, t, turn, seed, i, periodic, rng);
+            pola[i] = get_pol(ElemA, ramps, mode, t, turn, i, periodic, rng);
+            polb[i] = get_pol(ElemB, ramps, mode, t, turn, i, periodic, rng);
         };
     };
 
@@ -153,8 +139,8 @@ void VariableThinMPolePass(
             if (mode == 0) {
                 double tpart = t + r6[5] / C0;
                 for (i = 0; i < maxorder + 1; i++) {
-                    pola[i] = get_pol(ElemA, ramps, mode, tpart, turn, seed, i, periodic);
-                    polb[i] = get_pol(ElemB, ramps, mode, tpart, turn, seed, i, periodic);
+                    pola[i] = get_pol(ElemA, ramps, mode, tpart, turn, i, periodic);
+                    polb[i] = get_pol(ElemB, ramps, mode, tpart, turn, i, periodic);
                 };
             };
             /*  misalignment at entrance  */
@@ -183,9 +169,10 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
 {
     if (!Elem) {
         int MaxOrder, Mode, NSamplesA, NSamplesB, Periodic;
+        int BufferSize, BufferOffset;
         double *R1, *R2, *T1, *T2, *EApertures, *RApertures;
         double *PolynomA, *PolynomB, *AmplitudeA, *AmplitudeB;
-        double *Ramps, *FuncA, *FuncB;
+        double *Ramps, *FuncA, *FuncB, *BufferA, *BufferB;
         double FrequencyA, FrequencyB;
         double PhaseA, PhaseB;
         double Sinmin, Sinmax;
@@ -208,15 +195,15 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         PhaseB=atGetOptionalDouble(ElemData,"PhaseB", 0); check_error();
         Sinmin=atGetOptionalDouble(ElemData,"Sinmin", -1.1); check_error();
         Sinmax=atGetOptionalDouble(ElemData,"Sinmax", 1.1); check_error();
+        BufferA=atGetOptionalDoubleArray(ElemData,"BufferA"); check_error();
+        BufferB=atGetOptionalDoubleArray(ElemData,"BufferB"); check_error();
+        BufferSize=atGetOptionalLong(ElemData, "Buffersize", 0); check_error();
+        BufferOffset=atGetOptionalLong(ElemData, "Bufferoffset", 0); check_error();
         Ramps=atGetOptionalDoubleArray(ElemData, "Ramps"); check_error();
         NSamplesA=atGetOptionalLong(ElemData, "NSamplesA", 1); check_error();
         NSamplesB=atGetOptionalLong(ElemData, "NSamplesB", 1); check_error();
         FuncA=atGetOptionalDoubleArray(ElemData,"FuncA"); check_error();
         FuncB=atGetOptionalDoubleArray(ElemData,"FuncB"); check_error();
-        BufferA=atGetOptionalDoubleArray(ElemData,"BufferA"); check_error();
-        BufferB=atGetOptionalDoubleArray(ElemData,"BufferB"); check_error();
-        BufferSizeA=atGetOptionalLong(ElemData, "BufferSizeA", 0); check_error();
-        BufferSizeB=atGetOptionalLong(ElemData, "BufferSizeB", 0); check_error();
         Periodic=atGetOptionalLong(ElemData,"Periodic", 1); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         ElemA = (struct elemab*)atMalloc(sizeof(struct elemab));
@@ -247,6 +234,12 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         ElemB->Sinmin = Sinmin;
         ElemA->Sinmax = Sinmax;
         ElemB->Sinmax = Sinmax;
+        ElemA->Buffer = BufferA;
+        ElemB->Buffer = BufferB;
+        ElemA->BufferSize = BufferSize;
+        ElemB->BufferSize = BufferSize;
+        ElemA->BufferOffset= BufferOffset;
+        ElemB->BufferOffset = BufferOffset;
         ElemA->NSamples = NSamplesA;
         ElemB->NSamples = NSamplesB;
         ElemA->Func = FuncA;
@@ -256,7 +249,7 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
     }
     double t0 = Param->T0;
     int turn = Param->nturn;
-    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles, Param->thread_rng);
+    VariableThinMPolePass(r_in, Elem, t0, turn, num_particles);
     return Elem;
 }
 
@@ -272,9 +265,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         const mxArray* ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
         int MaxOrder, Mode, NSamplesA, NSamplesB, Periodic;
+        int BufferSize, BufferOffset;
         double *R1, *R2, *T1, *T2, *EApertures, *RApertures;
         double *PolynomA, *PolynomB, *AmplitudeA, *AmplitudeB;
-        double *Ramps, *FuncA, *FuncB;
+        double *Ramps, *FuncA, *FuncB, *BufferA, *BufferB;
         double FrequencyA, FrequencyB;
         double PhaseA, PhaseB;
         double Sinmin, Sinmax;
@@ -304,6 +298,10 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         NSamplesB=atGetOptionalLong(ElemData, "NSamplesB", 0); check_error();
         FuncA=atGetOptionalDoubleArray(ElemData,"FuncA"); check_error();
         FuncB=atGetOptionalDoubleArray(ElemData,"FuncB"); check_error();
+        BufferA=atGetOptionalDoubleArray(ElemData,"BufferA"); check_error();
+        BufferB=atGetOptionalDoubleArray(ElemData,"BufferB"); check_error();
+        BufferSize=atGetOptionalLong(ElemData, "BufferSize", 0); check_error();
+        BufferOffset=atGetOptionalLong(ElemData, "BufferOffset", 0); check_error();
         Periodic=atGetOptionalLong(ElemData,"Periodic", 1); check_error();
         Elem->PolynomA = PolynomA;
         Elem->PolynomB = PolynomB;
@@ -331,6 +329,12 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         ElemB->Sinmin = Sinmin;
         ElemA->Sinmax = Sinmax;
         ElemB->Sinmax = Sinmax;
+        ElemA->Buffer = BufferA;
+        ElemB->Buffer = BufferB;
+        ElemA->BufferSize = BufferSize;
+        ElemB->BufferSize = BufferSize;
+        ElemA->BufferOffset= BufferOffset;
+        ElemB->BufferOffset = BufferOffset;
         ElemA->NSamples = NSamplesA;
         ElemB->NSamples = NSamplesB;
         ElemA->Func = FuncA;
@@ -340,7 +344,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         /* ALLOCATE memory for the output array of the same size as the input  */
         plhs[0] = mxDuplicateArray(prhs[1]);
         r_in = mxGetDoubles(plhs[0]);
-        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles, &pcg32_global);
+        VariableThinMPolePass(r_in, Elem, 0, 0, num_particles);
     } else if (nrhs == 0) {
         /* list of required fields */
         plhs[0] = mxCreateCellMatrix(4, 1);

--- a/atintegrators/VariableThinMPolePass.c
+++ b/atintegrators/VariableThinMPolePass.c
@@ -25,7 +25,6 @@ struct elem {
     double* PolynomBstart;
     struct elemab* ElemA;
     struct elemab* ElemB;
-    int Seed;
     int Mode;
     int MaxOrder;
     double* Ramps;
@@ -125,7 +124,6 @@ void VariableThinMPolePass(
     int periodic = Elem->Periodic;
     double* pola = Elem->PolynomA;
     double* polb = Elem->PolynomB;
-    int seed = Elem->Seed;
     int mode = Elem->Mode;
     struct elemab* ElemA = Elem->ElemA;
     struct elemab* ElemB = Elem->ElemB;
@@ -184,7 +182,7 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
     double* r_in, int num_particles, struct parameters* Param)
 {
     if (!Elem) {
-        int MaxOrder, Mode, Seed, NSamplesA, NSamplesB, Periodic;
+        int MaxOrder, Mode, NSamplesA, NSamplesB, Periodic;
         double *R1, *R2, *T1, *T2, *EApertures, *RApertures;
         double *PolynomA, *PolynomB, *AmplitudeA, *AmplitudeB;
         double *Ramps, *FuncA, *FuncB;
@@ -211,11 +209,14 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         Sinmin=atGetOptionalDouble(ElemData,"Sinmin", -1.1); check_error();
         Sinmax=atGetOptionalDouble(ElemData,"Sinmax", 1.1); check_error();
         Ramps=atGetOptionalDoubleArray(ElemData, "Ramps"); check_error();
-        Seed=atGetOptionalLong(ElemData, "Seed", 0); check_error();
         NSamplesA=atGetOptionalLong(ElemData, "NSamplesA", 1); check_error();
         NSamplesB=atGetOptionalLong(ElemData, "NSamplesB", 1); check_error();
         FuncA=atGetOptionalDoubleArray(ElemData,"FuncA"); check_error();
         FuncB=atGetOptionalDoubleArray(ElemData,"FuncB"); check_error();
+        BufferA=atGetOptionalDoubleArray(ElemData,"BufferA"); check_error();
+        BufferB=atGetOptionalDoubleArray(ElemData,"BufferB"); check_error();
+        BufferSizeA=atGetOptionalLong(ElemData, "BufferSizeA", 0); check_error();
+        BufferSizeB=atGetOptionalLong(ElemData, "BufferSizeB", 0); check_error();
         Periodic=atGetOptionalLong(ElemData,"Periodic", 1); check_error();
         Elem = (struct elem*)atMalloc(sizeof(struct elem));
         ElemA = (struct elemab*)atMalloc(sizeof(struct elemab));
@@ -233,7 +234,6 @@ ExportMode struct elem* trackFunction(const atElem* ElemData, struct elem* Elem,
         memcpy(Elem->PolynomAstart, Elem->PolynomA, (MaxOrder+1)*sizeof(double));
         memcpy(Elem->PolynomBstart, Elem->PolynomB, (MaxOrder+1)*sizeof(double));
         Elem->Ramps = Ramps;
-        Elem->Seed = Seed;
         Elem->Mode = Mode;
         Elem->MaxOrder = MaxOrder;
         Elem->Periodic = Periodic;
@@ -271,7 +271,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         double* r_in;
         const mxArray* ElemData = prhs[0];
         int num_particles = mxGetN(prhs[1]);
-        int MaxOrder, Mode, Seed, NSamplesA, NSamplesB, Periodic;
+        int MaxOrder, Mode, NSamplesA, NSamplesB, Periodic;
         double *R1, *R2, *T1, *T2, *EApertures, *RApertures;
         double *PolynomA, *PolynomB, *AmplitudeA, *AmplitudeB;
         double *Ramps, *FuncA, *FuncB;
@@ -300,7 +300,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         Sinmin=atGetOptionalDouble(ElemData,"Sinmin", -1.1); check_error();
         Sinmax=atGetOptionalDouble(ElemData,"Sinmax", 1.1); check_error();
         Ramps=atGetOptionalDoubleArray(ElemData, "Ramps"); check_error();
-        Seed=atGetOptionalLong(ElemData, "Seed", 0); check_error();
         NSamplesA=atGetOptionalLong(ElemData, "NSamplesA", 0); check_error();
         NSamplesB=atGetOptionalLong(ElemData, "NSamplesB", 0); check_error();
         FuncA=atGetOptionalDoubleArray(ElemData,"FuncA"); check_error();
@@ -313,7 +312,6 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         memcpy(Elem->PolynomAstart, Elem->PolynomA, (MaxOrder+1)*sizeof(double));
         memcpy(Elem->PolynomBstart, Elem->PolynomB, (MaxOrder+1)*sizeof(double));
         Elem->Ramps = Ramps;
-        Elem->Seed = Seed;
         Elem->Mode = Mode;
         Elem->MaxOrder = MaxOrder;
         Elem->Periodic = Periodic;
@@ -352,7 +350,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
         mxSetCell(plhs[0], 3, mxCreateString("PolynomB"));
         if (nlhs > 1) {
             /* list of optional fields */
-            plhs[1] = mxCreateCellMatrix(21, 1);
+            plhs[1] = mxCreateCellMatrix(22, 1);
             mxSetCell(plhs[1], 0, mxCreateString("AmplitudeA"));
             mxSetCell(plhs[1], 1, mxCreateString("AmplitudeB"));
             mxSetCell(plhs[1], 2, mxCreateString("FrequencyA"));
@@ -360,20 +358,21 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
             mxSetCell(plhs[1], 4, mxCreateString("PhaseA"));
             mxSetCell(plhs[1], 5, mxCreateString("PhaseB"));
             mxSetCell(plhs[1], 6, mxCreateString("Ramps"));
-            mxSetCell(plhs[1], 7, mxCreateString("Seed"));
-            mxSetCell(plhs[1], 8, mxCreateString("FuncA"));
-            mxSetCell(plhs[1], 9, mxCreateString("FuncB"));
-            mxSetCell(plhs[1], 10, mxCreateString("NSamplesA"));
-            mxSetCell(plhs[1], 11, mxCreateString("NSamplesB"));
-            mxSetCell(plhs[1], 12, mxCreateString("Periodic"));
-            mxSetCell(plhs[1], 13, mxCreateString("T1"));
-            mxSetCell(plhs[1], 14, mxCreateString("T2"));
-            mxSetCell(plhs[1], 15, mxCreateString("R1"));
-            mxSetCell(plhs[1], 16, mxCreateString("R2"));
-            mxSetCell(plhs[1], 17, mxCreateString("RApertures"));
-            mxSetCell(plhs[1], 18, mxCreateString("EApertures"));
-            mxSetCell(plhs[1], 19, mxCreateString("Sinmin"));
-            mxSetCell(plhs[1], 20, mxCreateString("Sinmax"));
+            mxSetCell(plhs[1], 7, mxCreateString("FuncA"));
+            mxSetCell(plhs[1], 8, mxCreateString("FuncB"));
+            mxSetCell(plhs[1], 9, mxCreateString("NSamplesA"));
+            mxSetCell(plhs[1], 10, mxCreateString("NSamplesB"));
+            mxSetCell(plhs[1], 11, mxCreateString("Periodic"));
+            mxSetCell(plhs[1], 12, mxCreateString("T1"));
+            mxSetCell(plhs[1], 13, mxCreateString("T2"));
+            mxSetCell(plhs[1], 14, mxCreateString("R1"));
+            mxSetCell(plhs[1], 15, mxCreateString("R2"));
+            mxSetCell(plhs[1], 16, mxCreateString("RApertures"));
+            mxSetCell(plhs[1], 17, mxCreateString("EApertures"));
+            mxSetCell(plhs[1], 18, mxCreateString("Sinmin"));
+            mxSetCell(plhs[1], 19, mxCreateString("Sinmax"));
+            mxSetCell(plhs[1], 20, mxCreateString("Buffer"));
+            mxSetCell(plhs[1], 21, mxCreateString("Buffersize"));
         }
     } else {
         mexErrMsgIdAndTxt("AT:WrongArg", "Needs 0 or 2 arguments");

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -47,7 +47,7 @@ function elem=atvariablethinmultipole(fname,varargin)
 %    3. For ARBITRARY excitation modes the FUNC corresponding to the input
 %    AMPLITUDE is required
 %    4. In ARBITRARY mode the seed is fixed by the tracking function, and
-%    it is common to all threads. See at.track.
+%    it is common to all threads. See ringpass, linepass and elempass.
 %
 %  EXAMPLES
 %

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -70,7 +70,7 @@ function elem=atvariablethinmultipole(fname,varargin)
 
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
-[modename, rsrc] = getoption(rsrc,'ModeName',modename);
+[modename, rsrc] = getoption(rsrc,'ModeName',convertStringsToChars(modename));
 if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
   error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -22,8 +22,10 @@ function elem=atvariablethinmultipole(fname,varargin)
 %    PHASEB         Phase of SINE excitation for PolynomB
 %    SINMIN         Sine function min limit. Default -1.1
 %    SINMAX         Sine function max limit. Default +1.1
+%    BUFFERSIZE     Set the buffer length in WHITENOISE mode.
+%    BUFFEROFFSET   Offset in turns for the first element of the buffer
+%                         in WHITENOISE mode.
 %    MAXORDER       Order of the multipole for a scalar amplitude
-%    SEED           Input seed for the random number generator
 %    FUNCA          ARBITRARY excitation turn-by-turn kick list for PolynomA
 %    FUNCB          ARBITRARY excitation turn-by-turn kick list for PolynomB
 %    PERIODIC       If true (default) the user input kick list is repeated
@@ -44,6 +46,8 @@ function elem=atvariablethinmultipole(fname,varargin)
 %    AMPLITUDE is required
 %    3. For ARBITRARY excitation modes the FUNC corresponding to the input
 %    AMPLITUDE is required
+%    4. In ARBITRARY mode the seed is fixed by the tracking function, and
+%    it is common to all threads. See at.track.
 %
 %  EXAMPLES
 %
@@ -58,6 +62,9 @@ function elem=atvariablethinmultipole(fname,varargin)
 %
 % % Create a sine saturation
 % >> atvariablethimultipole('HSINE','SINE','AmplitudeB',1e-3,'FrequencyB',100,'Sinmax',0.9)
+%
+% % Create whitenoise and store the random values starting from third turn for 10 turns.
+% >> atvariablethinmultipole('v',"WHITENOISE",'AmplitudeB',1e-3,'BufferSize',10,'BufferOffset',2);
 
 % Input parser for option
 
@@ -112,8 +119,20 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
 
     end
 
-    function rsrc = setwhitenoise(rsrc, ~)
-    % it will later implement a buffer
+    function rsrc = setwhitenoise(rsrc, ab)
+      funcarg = 'BufferSize';
+      if ~isfield(rsrc,funcarg)
+          rsrc.(funcarg) = 0;
+      end
+      funcarg = 'BufferOffset';
+      if ~isfield(rsrc,funcarg)
+          rsrc.(funcarg) = 0;
+      end
+      funcarg = strcat('Buffer',ab);
+      if ~isfield(rsrc,funcarg)
+          bfsize = rsrc.('BufferSize');
+          rsrc.(funcarg) = zeros(1,bfsize);
+      end
     end
 
     function rsrc = setarb(rsrc, ab)

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -147,10 +147,8 @@ class VariableThinMultipole(Element):
             # after the definition of MaxOrder we can create Amplitudes
             self._set_amplitudes(AmplitudeA, AmplitudeB)
             self.Periodic = kwargs.pop("Periodic", True)
-            if AmplitudeB:
-                self._set_params(AmplitudeB, "B", **kwargs)
-            if AmplitudeA:
-                self._set_params(AmplitudeA, "A", **kwargs)
+            self._set_params(AmplitudeB, "B", **kwargs)
+            self._set_params(AmplitudeA, "A", **kwargs)
             self.PolynomA = np.zeros(self.MaxOrder + 1)
             self.PolynomB = np.zeros(self.MaxOrder + 1)
             ramps = kwargs.pop("Ramps", None)
@@ -172,12 +170,13 @@ class VariableThinMultipole(Element):
             self.AmplitudeB = ampb
 
     def _set_params(self, amplitude, ab, **kwargs):
-        if self.Mode == ACMode.SINE:
-            self._set_sine(ab, **kwargs)
-        if self.Mode == ACMode.WHITENOISE:
-            self._set_white_noise(ab, **kwargs)
-        if self.Mode == ACMode.ARBITRARY:
-            self._set_arb(ab, **kwargs)
+        if amplitude is not None:
+            if self.Mode == ACMode.SINE:
+                self._set_sine(ab, **kwargs)
+            if self.Mode == ACMode.WHITENOISE:
+                self._set_white_noise(ab, **kwargs)
+            if self.Mode == ACMode.ARBITRARY:
+                self._set_arb(ab, **kwargs)
 
     def _set_sine(self, ab, **kwargs):
         frequency = kwargs.pop("Frequency" + ab, 0)

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -135,25 +135,23 @@ class VariableThinMultipole(Element):
 
         self.Mode = mode.value
         self.ModeName = mode.name
-        kwargs.setdefault("PassMethod", "VariableThinMPolePass")
-
-        AmplitudeA, AmplitudeB = _default_amplitudes(AmplitudeA, AmplitudeB)
-
-        # MaxOrder is set finally by the user if given
-        max_order_ampab = _getmaxorder(AmplitudeA, AmplitudeB)
-        self.MaxOrder = kwargs.get("MaxOrder", max_order_ampab)
-        # after the definition of MaxOrder we can create Amplitudes
-        self._set_amplitudes(AmplitudeA, AmplitudeB)
-
-        self.Periodic = kwargs.pop("Periodic", True)
-        AmplitudeB = self._set_params(AmplitudeB, "B", **kwargs)
-        AmplitudeA = self._set_params(AmplitudeA, "A", **kwargs)
-        self.PolynomA = np.zeros(self.MaxOrder + 1)
-        self.PolynomB = np.zeros(self.MaxOrder + 1)
-        ramps = kwargs.pop("Ramps", None)
-        if ramps is not None:
-            assert len(ramps) == 4, "Ramps has to be a vector with 4 elements"
-            self.Ramps = ramps
+        if len(kwargs) == 0:
+            kwargs.setdefault("PassMethod", "VariableThinMPolePass")
+            AmplitudeA, AmplitudeB = _default_amplitudes(AmplitudeA, AmplitudeB)
+            # MaxOrder is set finally by the user if given
+            max_order_ampab = _getmaxorder(AmplitudeA, AmplitudeB)
+            self.MaxOrder = kwargs.get("MaxOrder", max_order_ampab)
+            # after the definition of MaxOrder we can create Amplitudes
+            self._set_amplitudes(AmplitudeA, AmplitudeB)
+            self.Periodic = kwargs.pop("Periodic", True)
+            AmplitudeB = self._set_params(AmplitudeB, "B", **kwargs)
+            AmplitudeA = self._set_params(AmplitudeA, "A", **kwargs)
+            self.PolynomA = np.zeros(self.MaxOrder + 1)
+            self.PolynomB = np.zeros(self.MaxOrder + 1)
+            ramps = kwargs.pop("Ramps", None)
+            if ramps is not None:
+                assert len(ramps) == 4, "Ramps has to be a vector with 4 elements"
+                self.Ramps = ramps
         super().__init__(family_name, **kwargs)
 
     def _set_amplitudes(self, ampa, ampb):

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -104,6 +104,8 @@ class VariableThinMultipole(Element):
             ...     "ACMPOLE", at.ACMode.WHITENOISE, AmplitudeB=amp, ... )
             >>> acmpole = at.VariableThinMultipole(
             ...     "ACMPOLE", at.ACMode.ARBITRARY, AmplitudeB=amp, FuncB=fun, ... )
+            >>> elewhitenoise = at.VariableThinMultipole('v',at.ACMode.WHITENOISE,
+            ...     AmplitudeA=0.001,BufferSize=10,BufferOffset=2)
 
         .. note::
 
@@ -133,10 +135,11 @@ class VariableThinMultipole(Element):
                 mxb = np.max(np.append(np.nonzero(ampb), 0))
             return max(mxa, mxb)
 
-        self.Mode = mode.value
-        self.ModeName = mode.name
-        if len(kwargs) == 0:
-            kwargs.setdefault("PassMethod", "VariableThinMPolePass")
+        kwargs.setdefault("Mode", mode.value)
+        kwargs.setdefault("ModeName", mode.name)
+        kwargs.setdefault("PassMethod", "VariableThinMPolePass")
+        if len(kwargs) > 3:
+            self.Mode = kwargs["Mode"]
             AmplitudeA, AmplitudeB = _default_amplitudes(AmplitudeA, AmplitudeB)
             # MaxOrder is set finally by the user if given
             max_order_ampab = _getmaxorder(AmplitudeA, AmplitudeB)
@@ -167,16 +170,12 @@ class VariableThinMultipole(Element):
             self.AmplitudeB = ampb
 
     def _set_params(self, amplitude, ab, **kwargs):
-        if amplitude is not None:
-            if np.isscalar(amplitude):
-                amp = np.zeros(self.MaxOrder)
-                amplitude = np.append(amp, amplitude)
-            if self.Mode == ACMode.SINE:
-                self._set_sine(ab, **kwargs)
-            if self.Mode == ACMode.WHITENOISE:
-                self._set_white_noise(ab, **kwargs)
-            if self.Mode == ACMode.ARBITRARY:
-                self._set_arb(ab, **kwargs)
+        if self.Mode == ACMode.SINE:
+            self._set_sine(ab, **kwargs)
+        if self.Mode == ACMode.WHITENOISE:
+            self._set_white_noise(ab, **kwargs)
+        if self.Mode == ACMode.ARBITRARY:
+            self._set_arb(ab, **kwargs)
         return amplitude
 
     def _set_sine(self, ab, **kwargs):

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -35,7 +35,10 @@ class VariableThinMultipole(Element):
         PhaseB=float,
         Sinmin=float,
         Sinmax=float,
-        Seed=int,
+        BufferA=_anyarray,
+        BufferB=_anyarray,
+        BufferSize=int,
+        BufferOffset=int,
         NSamplesA=int,
         NSamplesB=int,
         FuncA=_array,
@@ -70,9 +73,10 @@ class VariableThinMultipole(Element):
             PhaseB(float): Phase of the sine excitation for PolynomB. Default 0
             Sinmin(float): Sine function min limit. Default -1.1
             Sinmax(float): Sine function max limit. Default +1.1
+            BufferSize(int): Sets the buffer size in WHITENOISE mode.
+            BufferOffset(int): Offset in turns for the first element of the buffer
+                         in WHITENOISE mode.
             MaxOrder(int): Order of the multipole for scalar amplitude. Default 0
-            Seed(int): Seed of the random number generator for white
-                       noise excitation. Default datetime.now()
             FuncA(list): User defined tbt kick list for PolynomA
             FuncB(list): User defined tbt kick list for PolynomB
             Periodic(bool): If True (default) the user defined kick is repeated
@@ -108,6 +112,8 @@ class VariableThinMultipole(Element):
               ``Amplitude(A,B)`` has to be provided
             * For ``mode=at.ACMode.ARBITRARY`` the ``Func(A,B)`` corresponding to the
               ``Amplitude(A,B)`` has to be provided
+            * In ``at.ACMode.ARBITRARY`` the seed is fixed by the tracking function, and
+              it is common to all threads. See at.track.
         """
 
         def _default_amplitudes(ampa, ampb):
@@ -142,8 +148,6 @@ class VariableThinMultipole(Element):
         self.Periodic = kwargs.pop("Periodic", True)
         AmplitudeB = self._set_params(AmplitudeB, "B", **kwargs)
         AmplitudeA = self._set_params(AmplitudeA, "A", **kwargs)
-        if self.Mode == ACMode.WHITENOISE:
-            self.Seed = kwargs.pop("Seed", datetime.now().timestamp())
         self.PolynomA = np.zeros(self.MaxOrder + 1)
         self.PolynomB = np.zeros(self.MaxOrder + 1)
         ramps = kwargs.pop("Ramps", None)
@@ -171,6 +175,8 @@ class VariableThinMultipole(Element):
                 amplitude = np.append(amp, amplitude)
             if self.Mode == ACMode.SINE:
                 self._set_sine(ab, **kwargs)
+            if self.Mode == ACMode.WHITENOISE:
+                self._set_white_noise(ab, **kwargs)
             if self.Mode == ACMode.ARBITRARY:
                 self._set_arb(ab, **kwargs)
         return amplitude
@@ -184,6 +190,16 @@ class VariableThinMultipole(Element):
         setattr(self, "Phase" + ab, phase)
         setattr(self, "Sinmin", sinmin)
         setattr(self, "Sinmax", sinmax)
+
+    def _set_white_noise(ab, **kwargs):
+        bfsize = int(kwargs.setdefault("BufferSize", 0))
+        bfoffset = int(kwargs.setdefault("BufferOffset", 0))
+        if not hasattr(self, "BufferSize"):
+            setattr(self, "BufferSize", bfsize)
+        if not hasattr(self, "BufferOffset"):
+            setattr(self, "BufferOffset", bfoffset)
+        if not hasattr(self, "Buffer" + ab):
+            setattr(self, "Buffer" + ab, np.zeros((self,bfsize)))
 
     def _set_arb(self, ab, **kwargs):
         func = kwargs.pop("Func" + ab, None)

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from enum import IntEnum
 
 import numpy as np

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -147,8 +147,10 @@ class VariableThinMultipole(Element):
             # after the definition of MaxOrder we can create Amplitudes
             self._set_amplitudes(AmplitudeA, AmplitudeB)
             self.Periodic = kwargs.pop("Periodic", True)
-            AmplitudeB = self._set_params(AmplitudeB, "B", **kwargs)
-            AmplitudeA = self._set_params(AmplitudeA, "A", **kwargs)
+            if AmplitudeB:
+                self._set_params(AmplitudeB, "B", **kwargs)
+            if AmplitudeA:
+                self._set_params(AmplitudeA, "A", **kwargs)
             self.PolynomA = np.zeros(self.MaxOrder + 1)
             self.PolynomB = np.zeros(self.MaxOrder + 1)
             ramps = kwargs.pop("Ramps", None)
@@ -176,7 +178,6 @@ class VariableThinMultipole(Element):
             self._set_white_noise(ab, **kwargs)
         if self.Mode == ACMode.ARBITRARY:
             self._set_arb(ab, **kwargs)
-        return amplitude
 
     def _set_sine(self, ab, **kwargs):
         frequency = kwargs.pop("Frequency" + ab, 0)

--- a/pyat/at/lattice/elements/variable_elements.py
+++ b/pyat/at/lattice/elements/variable_elements.py
@@ -35,8 +35,8 @@ class VariableThinMultipole(Element):
         PhaseB=float,
         Sinmin=float,
         Sinmax=float,
-        BufferA=_anyarray,
-        BufferB=_anyarray,
+        BufferA=_array,
+        BufferB=_array,
         BufferSize=int,
         BufferOffset=int,
         NSamplesA=int,
@@ -191,7 +191,7 @@ class VariableThinMultipole(Element):
         setattr(self, "Sinmin", sinmin)
         setattr(self, "Sinmax", sinmax)
 
-    def _set_white_noise(ab, **kwargs):
+    def _set_white_noise(self, ab, **kwargs):
         bfsize = int(kwargs.setdefault("BufferSize", 0))
         bfoffset = int(kwargs.setdefault("BufferOffset", 0))
         if not hasattr(self, "BufferSize"):
@@ -199,7 +199,7 @@ class VariableThinMultipole(Element):
         if not hasattr(self, "BufferOffset"):
             setattr(self, "BufferOffset", bfoffset)
         if not hasattr(self, "Buffer" + ab):
-            setattr(self, "Buffer" + ab, np.zeros((self,bfsize)))
+            setattr(self, "Buffer" + ab, np.zeros((bfsize)))
 
     def _set_arb(self, ab, **kwargs):
         func = kwargs.pop("Func" + ab, None)


### PR DESCRIPTION
The PR adds the possibility to have a buffer for the WHITENOISE mode of the VariableThinMultipole.

Two new parameters are added: `BufferSize` and `BufferOffset`. The buffer size sets the lenght of the buffer and allows to store in an array the random value used in every turn, while the buffer offset sets the first turn to be stored in the array.

The parameter seed is removed because it had no use in this pass method. Instead, the seed for the random number generator should be set through the tracking functio, and it is mentioned in the help message of the element.
