### PR TITLE
allow double quotes in mode name for atvariablethinmultipole

### DIFF
--- a/atmat/lattice/element_creation/atbaselem.m
+++ b/atmat/lattice/element_creation/atbaselem.m
@@ -15,7 +15,7 @@ DefaultNumIntSteps = 10;
 [method,rsrc]  = getoption(rsrc,'PassMethod',method);
 [lg,rsrc]      = getoption(rsrc,'Length',0);
 [defmax,rsrc]  = getoption(rsrc,'DefaultMaxOrder',0);
-elem           = struct('FamName',famname,'PassMethod',method,'Length',lg,rsrc{:});
+elem           = struct('FamName',char(famname),'PassMethod',char(method),'Length',lg,rsrc{:});
 
 % Making PolynomA of same length with zero padding when necesssary
 ab = isfield(elem,{'PolynomA','PolynomB'});

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -63,7 +63,7 @@ function elem=atvariablethinmultipole(fname,varargin)
 
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
-[modename, rsrc] = getoption(rsrc,'ModeName',modename);
+[modename, rsrc] = getoption(rsrc,'ModeName',convertStringsToChars(modename));
 if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
   error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -62,7 +62,8 @@ function elem=atvariablethinmultipole(fname,varargin)
 
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
-[modename, rsrc] = getoption(rsrc,'ModeName',char(modename));
+[modename, rsrc] = getoption(rsrc,'ModeName',modename);
+modename = char(modename);
 [~, rsrc] = getoption(rsrc,'Mode',2); % remove Mode, the element is set by ModeName
 [method,rsrc]   = getargs(rsrc,'VariableThinMPolePass', ...
                   'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -125,11 +125,11 @@ elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
         amplarg=strcat('Amplitude',ab);
         if isfield(rsrc,amplarg)
             switch modename
-                case "SINE"
+                case 'SINE'
                     rsrc = setsine(rsrc,ab);
-                case "ARBITRARY"
+                case 'ARBITRARY'
                     rsrc = setarb(rsrc,ab);
-                case "WHITENOISE"
+                case 'WHITENOISE'
                     rsrc = setwhitenoise(rsrc,ab);
             end
         end

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -62,7 +62,7 @@ function elem=atvariablethinmultipole(fname,varargin)
 
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
-[modename, rsrc] = getoption(rsrc,'ModeName',convertStringsToChars(modename));
+[modename, rsrc] = char(getoption(rsrc,'ModeName',modename));
 [~, rsrc] = getoption(rsrc,'Mode',2); % remove Mode, the element is set by ModeName
 if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
   error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");

--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -62,11 +62,8 @@ function elem=atvariablethinmultipole(fname,varargin)
 
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
-[modename, rsrc] = char(getoption(rsrc,'ModeName',modename));
+[modename, rsrc] = getoption(rsrc,'ModeName',char(modename));
 [~, rsrc] = getoption(rsrc,'Mode',2); % remove Mode, the element is set by ModeName
-if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
-  error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
-end
 [method,rsrc]   = getargs(rsrc,'VariableThinMPolePass', ...
                   'check',@(arg) (ischar(arg) || isstring(arg)) && endsWith(arg,'Pass'));
 [method,rsrc]   = getoption(rsrc,'PassMethod',method);


### PR DESCRIPTION
This PR solves issue #1139 , where a mode name double quoted created a .mat file incompatible with pyat.

The string is converted to characters to make it readable in pyat.