### PR TITLE
function to enable/disable elements

### DIFF
--- a/pyat/at/lattice/elements/element_object.py
+++ b/pyat/at/lattice/elements/element_object.py
@@ -256,7 +256,6 @@ class Element:
             if not np.array_equal(v, getattr(defelem, k, None))
             and k not in self._drop_attr
         }
-        print(keywords)
         return self.__class__.__name__, arguments, keywords
 
     def items(self) -> Generator[tuple[str, Any], None, None]:

--- a/pyat/at/lattice/elements/element_object.py
+++ b/pyat/at/lattice/elements/element_object.py
@@ -120,7 +120,8 @@ class Element:
     def __str__(self):
         return "\n".join(
             [self.__class__.__name__ + ":"]
-            + [f"{k:>14}: {v!s}" for k, v in self.items()]
+            + [f"{k:>14}: {v!s}" for k, v in self.items()
+               if k not in self._drop_attr]
         )
 
     def __repr__(self):
@@ -253,7 +254,9 @@ class Element:
             k: v
             for k, v in attrs.items()
             if not np.array_equal(v, getattr(defelem, k, None))
+            and k not in self._drop_attr
         }
+        print(keywords)
         return self.__class__.__name__, arguments, keywords
 
     def items(self) -> Generator[tuple[str, Any], None, None]:

--- a/pyat/at/lattice/elements/element_object.py
+++ b/pyat/at/lattice/elements/element_object.py
@@ -66,9 +66,12 @@ class Element:
     _entrance_fields: ClassVar[list[str]] = ["T1", "R1"]
     _exit_fields: ClassVar[list[str]] = ["T2", "R2"]
     _no_swap = _entrance_fields + _exit_fields
-    # For the moment keep empty for Matlab compatibility
+    # For the moment keep T1, T2, R1, R2 for Matlab compatibility
     # _drop_attr = ["T1", "T2", "R1", "R2"]
-    _drop_attr: ClassVar[list[str]] = []
+    _drop_attr: ClassVar[list[str]] = [
+        "_enable_passmethod",
+        "_disable_passmethod",
+    ]
     _convert_attr: ClassVar[dict] = {
         "_dx": "dx",
         "_dy": "dy",
@@ -91,6 +94,11 @@ class Element:
         self.FamName = family_name
         self.Length = kwargs.pop("Length", 0.0)
         self.PassMethod = kwargs.pop("PassMethod", "IdentityPass")
+        self._enable_passmethod = self.PassMethod
+        if self.Length==0.0:
+            self._disable_passmethod = "IdentityPass"
+        else:
+            self._disable_passmethod = "DriftPass"
         self.update(kwargs)
 
     def __setattr__(self, attrname: str, value: Any) -> None:
@@ -140,7 +148,23 @@ class Element:
         for subclass in cls.__subclasses__():
             yield from subclass.subclasses()
         yield cls
-
+        
+    def enable(self):
+        """Function to enable an element in the lattice.
+        Convert DriftPass / IdentityPass to the standard
+        or user defined element pass method
+        """          
+        self.PassMethod = self._enable_passmethod
+        
+    def disable(self):
+        """Function to disable an element in the lattice.
+        Convert the element passmethod to either a DrifPass
+        is the length is not zero or IdentityPass otherwise
+        """ 
+        if self.PassMethod != self._disable_passmethod:
+            self._enable_passmethod = self.PassMethod
+            self.PassMethod = self._disable_passmethod   
+        
     def to_dict(self):
         return vars(self).copy()
 


### PR DESCRIPTION
This PR allows to disable / enable elements in a lattice, converting its pass method to IdentityPass or DriftPass, with a function call.
When call the enable function the pass method is restored to the value before `disable()` was called.
This value is generally set at initialization, but could be changed by the user.