### PR TITLE
Fix Transient Beam Loading Computation + Energy Loss Bug

### DIFF
--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -71,7 +71,7 @@ void BeamLoadingCavityPass(double *r_in, int num_particles, int nbunch,
     double normfact = Elem->normfact;  
     double le = Elem->Length;
     double rffreq = Elem->Frequency;
-    double harmn = Elem->HarmNumber;
+    int harmn = rffreq * circumference / C0 ;    // cavity harmonic number    
     int ring_harmn = harmonic_number;
     double tlag = Elem->TimeLag;
     double qfactor = Elem->Qfactor;
@@ -121,7 +121,7 @@ void BeamLoadingCavityPass(double *r_in, int num_particles, int nbunch,
     /*Track RF cavity is always done. */
     trackRFCavity(r_in, le, vgen/energy, rffreq, harmn, tlag, -gen_phase - tot_lag_phase, nturn, circumference/C0, num_particles);
     /*Only allocate memory if current is > 0*/
-    if(tot_current>0){
+    if(tot_current>0 && rshunt>0){
         void *buffer = atMalloc(sz);
         
         double *dptr = (double *) buffer;
@@ -152,7 +152,7 @@ void BeamLoadingCavityPass(double *r_in, int num_particles, int nbunch,
         if(buffersize>0){
             write_buffer(vbeam, vbeam_buffer, 2, buffersize);
             write_buffer(vgen_arr, vgen_buffer, 4, buffersize);
-            write_buffer(vbunch, vbunch_buffer, 2*nbunch, buffersize);
+            write_buffer(vbunch, vbunch_buffer, 2*ring_harmn, buffersize);
         }   
 
         update_vbeam_set(fbmode, vbeam_set, ave_vbeam, vbeam_buffer,
@@ -238,7 +238,7 @@ ExportMode struct elem *trackFunction(const atElem *ElemData,struct elem *Elem,
 
         int dimsth[] = {Param->nbunch*nslice*nturns, 4};
         atCheckArrayDims(ElemData,"_turnhistory", 2, dimsth); check_error();
-        int dimsvb[] = {Param->nbunch, 2};
+        int dimsvb[] = {Param->harmonic_number, 2};
         atCheckArrayDims(ElemData,"_vbunch", 2, dimsvb); check_error();
        
         Elem = (struct elem*)atMalloc(sizeof(struct elem));

--- a/atintegrators/BeamLoadingCavityPass.c
+++ b/atintegrators/BeamLoadingCavityPass.c
@@ -71,7 +71,8 @@ void BeamLoadingCavityPass(double *r_in, int num_particles, int nbunch,
     double normfact = Elem->normfact;  
     double le = Elem->Length;
     double rffreq = Elem->Frequency;
-    int harmn = rffreq * circumference / C0 ;    // cavity harmonic number    
+    int harmn = rffreq * circumference / C0 ;    // cavity harmonic number 
+       
     int ring_harmn = harmonic_number;
     double tlag = Elem->TimeLag;
     double qfactor = Elem->Qfactor;
@@ -138,7 +139,7 @@ void BeamLoadingCavityPass(double *r_in, int num_particles, int nbunch,
                              freqres, qfactor, rshunt, vbeam_phasor, circumference, energy,
                              beta, ave_vbeam, vbunch, bunch_spos, ring_harmn, fillpattern, ts);                        
 
-                
+
         /*apply kicks*/
         for (c=0; c<num_particles; c++) {
             double *r6 = r_in+c*6;

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -308,10 +308,10 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
                           double *fillpattern, double ts_central_z){ 
                           
     #ifndef _MSC_VER  
-    int i,ib;
+    int i=0;
     double wi;
     double selfkick;
-    double dt =0.0;
+    double dt=0.0;
     double *turnhistoryZ = turnhistory+nslice*nbunch*nturns*2;
     double *turnhistoryW = turnhistory+nslice*nbunch*nturns*3;
     double omr = TWOPI*resfreq;
@@ -320,7 +320,9 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double bc = beta*C0;
     double *vbr = vbunch;
     double *vbi = vbunch+ring_harmn;
-    int ibunch, islice, total_slice_counter;
+    int ibucket = 0;
+    int total_slice_counter = 0;
+    int islice = 0;
     int bunch_counter = 0;
     double is_filled = 0.0;
     double main_bucket = circumference / (double) ring_harmn;
@@ -332,18 +334,17 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
         vbeam_kicks[i] = 0.0;
     }
 
-    for (ibunch=0;ibunch<ring_harmn;ibunch++){
-        vbr[ibunch] = 0.0;
-        vbi[ibunch] = 0.0;
-    
+    for (ibucket=0;ibucket<ring_harmn;ibucket++){
+        vbr[ibucket] = 0.0;
+        vbi[ibucket] = 0.0;
     }
 
     /* The vbeam_complex will always be sent to the center of the next bucket */
 
     double bucket_z_center = 0.0;
-    for(ibunch=0; ibunch<ring_harmn; ibunch++){
-        is_filled = fillpattern[ibunch]; 
-        bucket_z_center = ibunch*main_bucket;
+    for(ibucket=0; ibucket<ring_harmn; ibucket++){
+        is_filled = fillpattern[ibucket]; 
+        bucket_z_center = ibucket*main_bucket;
         if(is_filled!=0.0){
             for(islice=0; islice<nslice; islice++){
                 total_slice_counter = islice + nslice*bunch_counter; 
@@ -373,8 +374,8 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
         dt = -ts_central_z/bc;
         vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
 
-        vbr[ibunch] = cabs(vbeam_complex);
-        vbi[ibunch] = carg(vbeam_complex);
+        vbr[ibucket] = cabs(vbeam_complex);
+        vbi[ibucket] = carg(vbeam_complex);
             
         ave_vbeam_ri[0] += creal(vbeam_complex)/ring_harmn;
         ave_vbeam_ri[1] += cimag(vbeam_complex)/ring_harmn;

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -319,36 +319,42 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double kloss = rshunt*omr/(2*qfactor);
     double bc = beta*C0;
     double *vbr = vbunch;
-    double *vbi = vbunch+nbunch;
+    double *vbi = vbunch+ring_harmn;
     int ibunch, islice, total_slice_counter;
     int bunch_counter = 0;
-    double bucket_curr = 0.0;
+    double is_filled = 0.0;
     double main_bucket = circumference / (double) ring_harmn;
     double ave_vbeam_ri[] = {0.0, 0.0};
     
     
     
     for (i=0;i<nslice*nbunch;i++) {
-        ibunch = (int)(i/nslice);
         vbeam_kicks[i] = 0.0;
-        vbr[ibunch] = 0.0;
-        vbi[ibunch] = 0.0;
     }
 
+    for (ibunch=0;ibunch<ring_harmn;ibunch++){
+        vbr[ibunch] = 0.0;
+        vbi[ibunch] = 0.0;
     
+    }
+
     /* The vbeam_complex will always be sent to the center of the next bucket */
-    
+
+    double bucket_z_center = 0.0;
     for(ibunch=0; ibunch<ring_harmn; ibunch++){
-        bucket_curr = fillpattern[ibunch];
-        if(bucket_curr!=0.0){
+        is_filled = fillpattern[ibunch]; 
+
+        bucket_z_center = ibunch*main_bucket;
+        
+        if(is_filled!=0.0){
             for(islice=0; islice<nslice; islice++){
                 total_slice_counter = islice + nslice*bunch_counter; 
                 wi = turnhistoryW[total_slice_counter];
                 selfkick = normfact*wi*kloss*energy; /*normfact*energy is -t0 . This number comes out to be negative, which is correct*/       
                 if(islice==0){
-                    /* TurnhistoryZ goes from -bucket991 to bucket0 */
-                    dt = (turnhistoryZ[total_slice_counter] + bunch_spos[nbunch-1-bunch_counter] - bunch_spos[0])/bc;
-                    
+                    // TurnhistoryZ goes from -bucket991 to bucket0 
+                    // so the bucket center in the turnhistory reference is one bucket shifted,
+                    dt = (turnhistoryZ[total_slice_counter] + circumference - bucket_z_center - main_bucket)/bc; 
                 }else{
                     /* This is dt between each slice*/
                     dt = (turnhistoryZ[total_slice_counter]-turnhistoryZ[total_slice_counter-1])/bc;
@@ -357,28 +363,24 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
                 /* track the dt */
                 vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
                 vbeam_kicks[total_slice_counter] = creal((vbeam_complex + selfkick)/energy);
-                
                 vbeam_complex += 2*selfkick;    
                
             }
             /* back to the center of the bucket */
-            dt = -(turnhistoryZ[total_slice_counter] + bunch_spos[nbunch - 1 - bunch_counter] - bunch_spos[0])/bc;
-            vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
+            dt = -(turnhistoryZ[total_slice_counter] + circumference - bucket_z_center - main_bucket)/bc;
             
-            /* move to ts_central time */
-            dt = -ts_central_z/bc;
             vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
-            
-            vbr[bunch_counter] = cabs(vbeam_complex);
-            vbi[bunch_counter] = carg(vbeam_complex);
-                        
             bunch_counter += 1;
-        }else{
-            /* move to ts_central time */
-            dt = -ts_central_z/bc;
-            vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);     
         }
+        
+        /* move to ts_central time */
+        dt = -ts_central_z/bc;
+        vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
+                       
 
+        vbr[ibunch] = cabs(vbeam_complex);
+        vbi[ibunch] = carg(vbeam_complex);
+            
         ave_vbeam_ri[0] += creal(vbeam_complex)/ring_harmn;
         ave_vbeam_ri[1] += cimag(vbeam_complex)/ring_harmn;
 
@@ -390,7 +392,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
        
         dt = main_bucket/bc;
         vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
-        
+
     }
     /* store the phasor for the next turn */
     vbeam_phasor[0] = cabs(vbeam_complex);
@@ -401,7 +403,6 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
 
     #endif    
 };
-
 
 static void update_vgen(double *vbeam,double *vcav,double *vgen, double voltgain,double phasegain,double detune_angle){
 

--- a/atintegrators/atimplib.c
+++ b/atintegrators/atimplib.c
@@ -343,9 +343,7 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
     double bucket_z_center = 0.0;
     for(ibunch=0; ibunch<ring_harmn; ibunch++){
         is_filled = fillpattern[ibunch]; 
-
         bucket_z_center = ibunch*main_bucket;
-        
         if(is_filled!=0.0){
             for(islice=0; islice<nslice; islice++){
                 total_slice_counter = islice + nslice*bunch_counter; 
@@ -359,7 +357,6 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
                     /* This is dt between each slice*/
                     dt = (turnhistoryZ[total_slice_counter]-turnhistoryZ[total_slice_counter-1])/bc;
                 }
-                
                 /* track the dt */
                 vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
                 vbeam_kicks[total_slice_counter] = creal((vbeam_complex + selfkick)/energy);
@@ -368,7 +365,6 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
             }
             /* back to the center of the bucket */
             dt = -(turnhistoryZ[total_slice_counter] + circumference - bucket_z_center - main_bucket)/bc;
-            
             vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
             bunch_counter += 1;
         }
@@ -376,7 +372,6 @@ static void compute_kicks_phasor(int nslice, int nbunch, int nturns, double *tur
         /* move to ts_central time */
         dt = -ts_central_z/bc;
         vbeam_complex *= cexp((_Complex_I*omr-omr/(2*qfactor))*dt);
-                       
 
         vbr[ibunch] = cabs(vbeam_complex);
         vbi[ibunch] = carg(vbeam_complex);

--- a/pyat/at/collective/beam_loading.py
+++ b/pyat/at/collective/beam_loading.py
@@ -266,6 +266,7 @@ class BeamLoadingElement(RFCavity, Collective):
 
         self.circumference = ring.circumference
         self.bunch_spos = ring.bunch_spos
+        self.ring_harmonic_number = ring.harmonic_number #ring harmonic number (nbuckets) 
         energy = ring.energy
         harmonic_number = self.system_harmonic * ring.harmonic_number
         self.feedback_angle_offset = kwargs.pop("feedback_angle_offset", 0)
@@ -352,10 +353,8 @@ class BeamLoadingElement(RFCavity, Collective):
 
     def clear_history(self, ring=None):
         if ring is not None:
-            self._nbunch = ring.nbunch
             current = ring.beam_current
-            nbunch = ring.nbunch
-            self._vbunch = np.zeros((nbunch, 2), order="F")
+            self._vbunch = np.zeros((self.ring_harmonic_number, 2), order="F")
             self._init_bl_params(current)
         tl = self._nturns * self._nslice * self._nbunch
         self._turnhistory = np.zeros((tl, 4), order="F")
@@ -363,7 +362,7 @@ class BeamLoadingElement(RFCavity, Collective):
             self._vgen_buffer = np.zeros((4, self._buffersize), order="F")
             self._vbeam_buffer = np.zeros((2, self._buffersize), order="F")
             self._vbunch_buffer = np.zeros(
-                (self._nbunch, 2, self._buffersize), order="F"
+                (self.ring_harmonic_number, 2, self._buffersize), order="F"
             )
 
     def _init_bl_params(self, current):

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -41,6 +41,7 @@ def get_energy_loss(
         ring:           Lattice description
         method:         Method for energy loss computation.
           See :py:class:`ELossMethod`.
+        orbit6:         6d orbit to use as initial condition for tracking
 
     Returns:
         eloss (float):  Energy loss per turn [eV]
@@ -66,6 +67,9 @@ def get_energy_loss(
 
         def eloss_i2(eloss: EnergyLoss):
             return eloss.EnergyLoss / coef
+        
+        def simplerad_i2(simplerad: SimpleRadiation):
+            return simplerad.U0 / ring.energy
 
         i2 = 0.0
         coef = Cgamma / 2.0 / np.pi * ring.energy**4
@@ -76,6 +80,8 @@ def get_energy_loss(
                 i2 += wiggler_i2(el)
             elif isinstance(el, EnergyLoss) and el.PassMethod != "IdentityPass":
                 i2 += eloss_i2(el)
+            elif isinstance(el, SimpleRadiation):
+                i2 += simplerad_i2(el)
         e_loss = coef * i2
         return e_loss
 
@@ -87,34 +93,33 @@ def get_energy_loss(
         particle = ring.particle
         delta = 0.0
         
-        try:
-            if len(ring[SimpleRadiation]) > 0:
-                raise AtError("Simple Ring has no 6D orbit")
-            ring = ring.disable_6d(*_EXCLUDED, copy=True)
-            for e in ring[VariableThinMultipole]:
-                e.disable()
-            if orbit6 is None:
-                o6, *_ = ring.find_orbit(method=ELossMethod.INTEGRAL)
-            else:
-                o6 = orbit6
-            o6l, *_ = ring.disable_6d(RFCavity, copy=True).track(o6)
-            for e in ring[VariableThinMultipole]:
-                e.enable()
-            delta = np.squeeze(o6l)[4] - o6[4]
-        except:
-            msg = (
-                "Closed orbit not found, falling back to energy loss "
-                "calculation excluding orbit effects"
-            )
-            warn(AtWarning(msg))
-        
-            for e in ring:
-                if e.PassMethod == "SimpleRadiationRadPass":
-                    delta -= e.U0 / energy  # Needed to prevent mixing with rad. damping
-                elif e.PassMethod.endswith("RadPass"):
-                    ot = e.track(np.zeros(6), energy=energy, particle=particle)
-                    delta += ot[4]
-        return -delta * energy
+        if len(ring[SimpleRadiation]) > 0:
+            return ring[SimpleRadiation][0].U0
+        else:
+            try:
+                ring = ring.disable_6d(*_EXCLUDED, copy=True)
+                for e in ring[VariableThinMultipole]:
+                    e.disable()
+                if orbit6 is None:
+                    o6, *_ = ring.find_orbit(method=ELossMethod.INTEGRAL)
+                else:
+                    o6 = orbit6
+                o6l, *_ = ring.disable_6d(RFCavity, copy=True).track(o6)
+                for e in ring[VariableThinMultipole]:
+                    e.enable()
+                delta = np.squeeze(o6l)[4] - o6[4]
+            except:
+                delta = 0.0
+                msg = (
+                    "Closed orbit not found, falling back to energy loss "
+                    "calculation excluding orbit effects"
+                )
+                warn(AtWarning(msg))
+                for e in ring:
+                    if e.PassMethod.endswith("RadPass"):
+                        ot = e.track(np.zeros(6), energy=energy, particle=particle)
+                        delta += ot[4]
+            return -delta * energy
 
     if isinstance(method, str):
         method = ELossMethod[method.upper()]

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -85,7 +85,10 @@ def get_energy_loss(
         energy = ring.energy
         particle = ring.particle
         delta = 0.0
+        
         try:
+            if len(ring[at.SimpleRadiation]) > 0:
+                raise AtError("Simple Ring has no 6D orbit")
             ring = ring.disable_6d(*_EXCLUDED, copy=True)
             for e in ring[VariableThinMultipole]:
                 e.disable()
@@ -103,6 +106,7 @@ def get_energy_loss(
                 "calculation excluding orbit effects"
             )
             warn(AtWarning(msg))
+        
             for e in ring:
                 if e.PassMethod == "SimpleRadiationRadPass":
                     delta -= e.U0 / energy  # Needed to prevent mixing with rad. damping

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["get_energy_loss", "set_cavity_phase", "ELossMethod", "get_timelag_fromU0"]
+__all__ = ["ELossMethod", "get_energy_loss", "get_timelag_fromU0", "set_cavity_phase"]
 
 from enum import Enum
 from warnings import warn
@@ -11,8 +11,8 @@ from scipy.optimize import least_squares
 
 from at.constants import clight, Cgamma
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts, EnergyLoss
-from at.lattice import Collective, SimpleQuantDiff, QuantumDiffusion, VariableThinMultipole
-from at.lattice import SimpleRadiation
+from at.lattice import Collective, SimpleQuantDiff, QuantumDiffusion
+from at.lattice import SimpleRadiation, VariableThinMultipole
 from at.lattice import check_radiation, AtError, AtWarning
 from at.lattice import get_bool_index, set_value_refpts
 from at.lattice import DConstant
@@ -21,7 +21,7 @@ _EXCLUDED = [Collective, SimpleQuantDiff, QuantumDiffusion]
 
 
 class ELossMethod(Enum):
-    """methods for the computation of energy losses"""
+    """methods for the computation of energy losses."""
 
     #: The losses are obtained from
     #: :math:`E_{loss}=C_\gamma/2\pi . E^4 . I_2`.
@@ -35,7 +35,7 @@ class ELossMethod(Enum):
 def get_energy_loss(
     ring: Lattice, method: ELossMethod | None = ELossMethod.INTEGRAL, orbit6=None
 ) -> float:
-    """Computes the energy loss per turn
+    """Computes the energy loss per turn.
 
     Parameters:
         ring:           Lattice description
@@ -49,7 +49,7 @@ def get_energy_loss(
 
     # noinspection PyShadowingNames
     def integral(ring):
-        """Losses = Cgamma / 2pi * EGeV^4 * i2"""
+        """Losses = Cgamma / 2pi * EGeV^4 * i2."""
 
         def wiggler_i2(wiggler: Wiggler):
             rhoinv = wiggler.Bmax / ring.BRho
@@ -67,7 +67,7 @@ def get_energy_loss(
 
         def eloss_i2(eloss: EnergyLoss):
             return eloss.EnergyLoss / coef
-        
+
         def simplerad_i2(simplerad: SimpleRadiation):
             return simplerad.U0 / coef
 
@@ -88,11 +88,11 @@ def get_energy_loss(
     # noinspection PyShadowingNames
     @check_radiation(True)
     def tracking(ring, orbit6):
-        """Losses from tracking"""
+        """Losses from tracking."""
         energy = ring.energy
         particle = ring.particle
         delta = 0.0
-        
+
         if len(ring[SimpleRadiation]) > 0:
             return ring[SimpleRadiation][0].U0
         else:
@@ -108,13 +108,13 @@ def get_energy_loss(
                 for e in ring[VariableThinMultipole]:
                     e.enable()
                 delta = np.squeeze(o6l)[4] - o6[4]
-            except:
+            except AtError:
                 delta = 0.0
                 msg = (
                     "Closed orbit not found, falling back to energy loss "
                     "calculation excluding orbit effects"
                 )
-                warn(AtWarning(msg))
+                warn(AtWarning(msg), stacklevel=2)
                 for e in ring:
                     if e.PassMethod.endswith("RadPass"):
                         ot = e.track(np.zeros(6), energy=energy, particle=particle)
@@ -129,7 +129,8 @@ def get_energy_loss(
     elif method == ELossMethod.TRACKING:
         return ring.periodicity * tracking(ring, orbit6)
     else:
-        raise AtError(f"Invalid method: {method}")
+        err_string = f"Invalid method: {method}"
+        raise AtError(err_string)
 
 
 # noinspection PyPep8Naming
@@ -144,7 +145,7 @@ def get_timelag_fromU0(
     """
     Get the TimeLag attribute of RF cavities based on frequency,
     voltage and energy loss per turn, so that the synchronous phase is zero.
-    Used in set_cavity_phase()
+    Used in set_cavity_phase().
 
     Parameters:
         ring:               Lattice description
@@ -165,7 +166,8 @@ def get_timelag_fromU0(
     def singlev(values):
         vals = np.unique(values)
         if len(vals) > 1:
-            raise AtError("values not equal for all cavities")
+            err_string = "values not equal for all cavities"
+            raise AtError(err_string)
         return vals[0]
 
     def eq(x, freq, rfv, tl0, u0):
@@ -213,7 +215,8 @@ def get_timelag_fromU0(
         ok = res < ts_tol
         vals = np.array([abs(ri.x[0]).round(decimals=6) for ri in r])
         if not np.any(ok):
-            raise AtError("No solution found for Phis: check RF settings") from None
+            err_string = "No solution found for Phis: check RF settings"
+            raise AtError(err_string) from None
         if len(np.unique(vals[ok])) > 1:
             warn(
                 AtWarning("More than one solution found for Phis: check RF settings"),
@@ -226,10 +229,12 @@ def get_timelag_fromU0(
         if u0 > vrf:
             v1 = ring.periodicity * vrf
             v2 = ring.periodicity * u0
-            raise AtError(
+            err_string = (
                 f"The RF voltage ({v1:.3e} eV) is lower than "
                 f"the radiation losses ({v2:.3e} eV)."
             )
+            raise AtError(err_string)
+
         timelag = clight / (2 * np.pi * frf) * np.arcsin(u0 / vrf)
         ts = timelag - tml
         timelag *= np.ones(ring.refcount(cavpts))

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -69,7 +69,7 @@ def get_energy_loss(
             return eloss.EnergyLoss / coef
         
         def simplerad_i2(simplerad: SimpleRadiation):
-            return simplerad.U0 / ring.energy
+            return simplerad.U0 / coef
 
         i2 = 0.0
         coef = Cgamma / 2.0 / np.pi * ring.energy**4

--- a/pyat/at/physics/energy_loss.py
+++ b/pyat/at/physics/energy_loss.py
@@ -12,6 +12,7 @@ from scipy.optimize import least_squares
 from at.constants import clight, Cgamma
 from at.lattice import Lattice, Dipole, Wiggler, RFCavity, Refpts, EnergyLoss
 from at.lattice import Collective, SimpleQuantDiff, QuantumDiffusion, VariableThinMultipole
+from at.lattice import SimpleRadiation
 from at.lattice import check_radiation, AtError, AtWarning
 from at.lattice import get_bool_index, set_value_refpts
 from at.lattice import DConstant
@@ -87,7 +88,7 @@ def get_energy_loss(
         delta = 0.0
         
         try:
-            if len(ring[at.SimpleRadiation]) > 0:
+            if len(ring[SimpleRadiation]) > 0:
                 raise AtError("Simple Ring has no 6D orbit")
             ring = ring.disable_6d(*_EXCLUDED, copy=True)
             for e in ring[VariableThinMultipole]:

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -143,6 +143,10 @@ def test_buffers(hmba_lattice):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         ring.harmonic_number = 32
+        
+    ring.set_fillpattern(nbunch)
+    ring.beam_current = 0.2
+
     nturns = 11
     nbunch = 4
     nslice = 51
@@ -150,8 +154,6 @@ def test_buffers(hmba_lattice):
     ls = ns*ring.circumference/ring.periodicity
     add_beamloading(ring, 44e3, 400, Nturns=nturns, Nslice=nslice,
                     buffersize=nturns)
-    ring.set_fillpattern(nbunch)
-    ring.beam_current = 0.2
     rin = numpy.zeros((6, nbunch)) + 1.0e-6
     bl_elem = ring.get_elements('*_BL')[0]
     th = numpy.zeros((nturns, ) + bl_elem.TurnHistory.shape)

--- a/pyat/test/test_collective.py
+++ b/pyat/test/test_collective.py
@@ -143,15 +143,15 @@ def test_buffers(hmba_lattice):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         ring.harmonic_number = 32
-        
-    ring.set_fillpattern(nbunch)
-    ring.beam_current = 0.2
-
     nturns = 11
     nbunch = 4
     nslice = 51
     ns = nbunch*nslice
     ls = ns*ring.circumference/ring.periodicity
+
+    ring.set_fillpattern(nbunch)
+    ring.beam_current = 0.2
+
     add_beamloading(ring, 44e3, 400, Nturns=nturns, Nslice=nslice,
                     buffersize=nturns)
     rin = numpy.zeros((6, nbunch)) + 1.0e-6


### PR DESCRIPTION
There was a problem with the computation of the beam induced voltage when gaps were present in the ring. This bug has been present since January #1025 . Basically, the cavity phasor was adjusted by one bucket whether a bunch was present or not, but then when the next bunch arrived, the full previous gap was applied again (incorrectly).

This is now fixed.

This PR also uncovers a problem with `get_energy_loss ` since the recent fast ring upgrade. `get_timelag_fromU0` does not return the same number for `ts`  for each cavity. There is a temporary fix in place until @swhite2401 can provide a cleaner fix.

Below is an example script for BessyII (my TBL benchmark case).

```
import numpy as np
import matplotlib.pyplot as plt
from at.constants import clight
import at
from at.collective import Wake, WakeElement, WakeType, WakeComponent
from scipy.interpolate import interp1d

def gen_fill_pattern(h):
    gap = 100
    fill_pattern = np.zeros(h)
    fill_pattern[0:int((h-gap)/2)] = 1
    fill_pattern[int((h+gap)/2):h] = 1

    fill_pattern[3] = 3
    fill_pattern[9] = 3
    fill_pattern[15] = 3

    #fill_pattern[200] = 4
    fill_pattern[201] = 4
    fill_pattern[243] = 3
    fill_pattern[379] = 3
    fill_pattern[385] = 3
    fill_pattern[391] = 3
    fill_pattern[397] = 3

    return fill_pattern/np.sum(fill_pattern)
    
ring_dict = {
            'circumference': 240,
            'harmonic_number': 400,
            'ac': 7.3e-4,
            'energy': 1.7e9,
            'sigma_e': 0.000695451,
            'U0': 2.3e5,
            # from lattice file
            #U0 = 1.749192e+05 

            # from python script
            #U0 = 2.3e5
            }


beta_main = 2.2
Q0_main = 29600
QL_main = Q0_main / (1+beta_main)
Nmain = 4
Rsl_main = 114*QL_main*Nmain # R/Q * QL * Nmain

# 3rd harmonic passive harmonic cavities (there is one cavity that is different)
n = 3
RoQ_3h = 63

Q0_3h_1 = 13750
N_3h_1 = 3
Rs_3h_1 = RoQ_3h * Q0_3h_1 * N_3h_1
detune_3h_1 = 0.38e6

Q0_3h_2 = 9250
N_3h_2 = 1
Rs_3h_2 = RoQ_3h * Q0_3h_2 * N_3h_2
detune_3h_2 = 0.46e6



Vmain = 1.4e6

fillp = gen_fill_pattern(ring_dict['harmonic_number'])


t0 = ring_dict['circumference'] / clight
tauz = 0.00775692 / t0

simple_ring = at.simple_ring(ring_dict['energy'], ring_dict['circumference'], ring_dict['harmonic_number'], 0.1, 0.1, Vmain, ring_dict['ac'], U0=ring_dict['U0'], tauz=tauz/100, espread=ring_dict['sigma_e'])
simple_ring.pop(-1) #remove pointless nonlinear element
simple_ring.pop(-2) #remove quantdiff for single particle model

simple_ring.enable_6d()
simple_ring.set_cavity_phase()

# set fill pattern, and beam current
I0 = 0.3
simple_ring.set_fillpattern(fillp)
simple_ring.set_beam_current(I0)
Nbunches = simple_ring.bunch_list.shape[0]

# some simulation parameters
Nslice = 1 #only 1 slice as only one macroparticle per bunch!
Nturns = 30000

Nparts = Nbunches


# for pyat you must first add all rf cavities as elements, then you add beamloading later.
# here I just make two RF cavities with 0 voltage and 0 length, but with frequency=3*rf_frequency
harm_cavity_1 = at.RFCavity('HC1', 0.0, 0.0, n*simple_ring.rf_frequency, n*simple_ring.harmonic_number, simple_ring.energy)
harm_cavity_2 = at.RFCavity('HC2', 0.0, 0.0, n*simple_ring.rf_frequency, n*simple_ring.harmonic_number, simple_ring.energy)

simple_ring.insert(1, harm_cavity_2) #puts them in order, main ->HC1 -> HC2
simple_ring.insert(1, harm_cavity_1)

# main beamloading
at.add_beamloading(simple_ring, QL_main, Rsl_main, cavpts=[0], Nslice=Nslice, VoltGain=1e-3, PhaseGain=1e-3, cavitymode=at.CavityMode.ACTIVE, fbmode=at.FeedbackMode.ONETURN, buffersize=1)#, buffersize=1000, windowlength=200)

# passive cavity for HC type 1
at.add_beamloading(simple_ring, Q0_3h_1, Rs_3h_1, detune=detune_3h_1, cavpts=[1], Nslice=Nslice, cavitymode=at.CavityMode.PASSIVE, system_harmonic=n)
   
# passive cavity for HC type 2
at.add_beamloading(simple_ring, Q0_3h_2, Rs_3h_2, detune=detune_3h_2, cavpts=[2], Nslice=Nslice, cavitymode=at.CavityMode.PASSIVE, system_harmonic=n)




# add wake element with Nslice=1 to model the losses to the machine wake
kq = 1.25e13 #in V/C
sr = np.arange(-0.1,0.1,1e-3)
wake_z = np.heaviside(sr,0.5)*kq

wa = Wake(sr)
wa.add(WakeType.TABLE, WakeComponent.Z, sr, wake_z)

welem = WakeElement('waa', simple_ring, wa, Nslice=1)
simple_ring.insert(3,welem)


parts = np.zeros((6, Nparts))

all_z = np.zeros((Nturns, Nparts))
all_Vg_main = np.zeros((Nturns,3))
all_Vb_harm_1 = np.zeros((Nturns,2))
all_Vb_harm_2 = np.zeros((Nturns,2))

msk = fillp!=0
for i in np.arange(Nturns):
        
    simple_ring.track(parts, nturns=1, in_place=True, refpts=None, keep_counter=True)
    
    
    all_z[i,:] = parts[5,:]
    all_Vg_main[i,:] = simple_ring[0].Vgen[:3]    
    all_Vb_harm_1[i,:] = simple_ring[1].Vbeam
    all_Vb_harm_2[i,:] = simple_ring[2].Vbeam

last_turn_z = all_z[-1,:]
main_phase_transient = last_turn_z*2*np.pi*simple_ring[0].ResFrequency/clight

ifun = interp1d(simple_ring.bunch_list, main_phase_transient, fill_value=0, bounds_error=False)
# now some plotting

fig, (ax1,ax2) = plt.subplots(2,1,figsize=(12,6))
ax1.plot(simple_ring.bunch_list, 1e12*(all_z[-1,:] - np.mean(all_z[-1,:]))/clight, color='r', marker='.', linestyle='None')
ax2.plot(simple_ring.bunch_list, 1e3*simple_ring.bunch_currents, color='r', marker='.', linestyle='None')
ax1.grid(color='k', linestyle='dashed', alpha=0.4)

ax1.set_ylabel('Arrival Time (centered) [ps]')
ax1.xaxis.set_visible(False)
ax2.set_ylabel(r'$I_{b}$ [mA]')
ax2.set_xlabel('Bunch #')
ax2.set_ylim(0, np.amax(1e3*simple_ring.bunch_currents)*1.1)

plt.show()

```
