### PR TITLE
set atvariablethinmultipole element by ModeName in MATLAB

### DIFF
--- a/atmat/lattice/element_creation/atvariablethinmultipole.m
+++ b/atmat/lattice/element_creation/atvariablethinmultipole.m
@@ -64,6 +64,7 @@ function elem=atvariablethinmultipole(fname,varargin)
 [modename, rsrc] = getargs(varargin,'SINE', ...
                    'check',@(arg) any(strcmpi(arg,{'SINE','WHITENOISE','ARBITRARY'})));
 [modename, rsrc] = getoption(rsrc,'ModeName',modename);
+[~, rsrc] = getoption(rsrc,'Mode',2); % remove Mode, the element is set by ModeName
 if ~any(strcmpi(modename,{'SINE','WHITENOISE','ARBITRARY'}))
   error("ModeName should be 'SINE', 'WHITENOISE' or 'ARBITRARY'");
 end


### PR DESCRIPTION
This PR solves issue #1148 where saving a ring with a VariableThinMultipole in pyat and reading it in matlab created an error in the creation of the element.

The problem was that both Mode and ModeName were used to define the element. The ModeName tries to create a second time the Mode as 'Mode' from 'm.(modename)' even if it exists
```matlab
elem=atbaselem(fname,method,'Class',cl,'Length',0,'Mode',m.(modename),...
               'ModeName',modename,'PolynomA',[],'PolynomB',[],rsrc{:});
```

The proposed solution is to remove the Mode if it exists. It will be always created from ModeName which is the normal usage in matlab, e.g. 'atvariablethinmultipole('v','SINE', ...)'.

```python
>>> v = at.VariableThinMultipole('v')
>>> ring = at.Lattice([v],energy=1e9)
>>> at.save_m(ring,'ring.m')
```

and in matlab
<img width="175" height="179" alt="image" src="https://github.com/user-attachments/assets/6ce8aa05-3307-4444-a32e-617899c475a1" />
