### PR TITLE
Update for CUDA13

### DIFF
--- a/atgpu/CudaGPU.cpp
+++ b/atgpu/CudaGPU.cpp
@@ -21,7 +21,13 @@ CudaContext::CudaContext(CUDA_GPU_INFO* gpu) {
   info = gpu->info;
   arch = gpu->arch;
 
+#if CUDA_VERSION >= 13000
+  CUctxCreateParams ctxCreateParams = {};
+  cudaCall(cuCtxCreate, &context, &ctxCreateParams, CU_CTX_SCHED_BLOCKING_SYNC, cuDevice);
+#else
   cudaCall(cuCtxCreate,&context,  CU_CTX_SCHED_BLOCKING_SYNC, cuDevice);
+#endif
+
   cudaCall(cuCtxSetSharedMemConfig, CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE);
   cudaCall(cuCtxSetCacheConfig , CU_FUNC_CACHE_PREFER_L1);
 

--- a/docs/p/howto/multiprocessing.rst
+++ b/docs/p/howto/multiprocessing.rst
@@ -114,7 +114,7 @@ to a `MPI <https://www.mpi-forum.org/docs/>`_ one or vice-versa, remove the
 `GPU Tracking`_
 ---------------
 PyAT can be installed with GPU support, either `OpenCL <https://github.com/KhronosGroup/OpenCL-Guide/tree/main>`_ or
-`CUDA <https://developer.nvidia.com/cuda-toolkit>`_, compatibility. GPU are especially interesting for tracking large
+`CUDA <https://developer.nvidia.com/cuda-toolkit>`_, compatibility. CUDA is supported up to version 13. GPU are especially interesting for tracking large
 number of particle. The performance of the tracking is mainly related to the GPU double precision arithmetic performance.
 
 OpenCL Installation


### PR DESCRIPTION
This PR fix method signature change in CUDA13.

```
      atgpu/CudaGPU.cpp:24:35: error: cannot convert ‘CUctx_flags_enum’ to ‘CUctxCreateParams*’ {aka ‘CUctxCreateParams_st*’}
         24 |   cudaCall(cuCtxCreate,&context,  CU_CTX_SCHED_BLOCKING_SYNC, cuDevice);
            |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
            |                                   |
            |                                   CUctx_flags_enum
```